### PR TITLE
feat: add smooth page transition animations using Framer Motion

### DIFF
--- a/app/layout.js
+++ b/app/layout.js
@@ -7,6 +7,7 @@ import "./globals.css";
 import { AuthProvider } from "@/contexts/AuthContext";
 import LearnovaChatbot from "@/components/ChatBot";
 import ClientLayout from "@/components/ClientLayout";
+import PageTransition from "@/components/PageTransition";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -231,12 +232,12 @@ export default function RootLayout({ children }) {
       >
         <AuthProvider>
           <Suspense fallback={null}>
-            {children}
+            <PageTransition>{children}</PageTransition>
             {/* Chatbot injected globally */}
             <div className="z-50">
               <LearnovaChatbot />
             </div>
-            <ClientLayout/>
+            <ClientLayout />
             <Toaster
               position="top-right" // default; see below for options
               toastOptions={{

--- a/components/PageTransition.js
+++ b/components/PageTransition.js
@@ -1,0 +1,21 @@
+"use client";
+import { motion, AnimatePresence } from "framer-motion";
+import { usePathname } from "next/navigation";
+
+export default function PageTransition({ children }) {
+    const pathname = usePathname();
+
+    return (
+        <AnimatePresence mode="wait">
+            <motion.div
+                key={pathname}
+                initial={{ opacity: 0, y: 12 }}
+                animate={{ opacity: 1, y: 0 }}
+                exit={{ opacity: 0, y: -8 }}
+                transition={{ duration: 0.3, ease: "easeInOut" }}
+            >
+                {children}
+            </motion.div>
+        </AnimatePresence>
+    );
+}


### PR DESCRIPTION
- Create PageTransition component with AnimatePresence
- Wrap children in layout.js with PageTransition
- Fade + slide up on enter (y: 12), fade + slide up on exit (y: -8)
- Duration 0.3s easeInOut for zero-friction premium feel

## What type of PR is this?
- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 📚 Documentation
- [x] 🎨 UI/UX improvement
- [ ] ⚡ Performance improvement
- [ ] 🔒 Security fix

## Description
Page navigation felt abrupt despite Framer Motion being installed. 
Added AnimatePresence in layout.js via a dedicated PageTransition 
component to create smooth fade+slide transitions on every route change.

## Related Issues
Closes #35

## Changes Made
- Create `components/PageTransition.js` with AnimatePresence + motion.div
- Wrap `{children}` in `app/layout.js` with PageTransition component
- Fade + slide up on enter (y: 12), fade + slide up on exit (y: -8)
- Duration 0.3s easeInOut — smooth, zero-friction feel

## Testing
- [x] Tested locally
- [ ] Tested on mobile
- [ ] Tested different user roles
- [ ] All roles tested

## Screenshots (if applicable)
N/A — animation, no visual diff. Test by navigating between pages.

## Checklist
- [x] No hardcoded secrets or credentials
- [x] `.env.local` is not committed
- [x] Code follows project style
- [x] Changes are documented
- [ ] Build passes locally (`npm run build`)
- [x] No console errors/warnings
