### PR TITLE
Refresh 404 page styling

### DIFF
--- a/app/not-found.js
+++ b/app/not-found.js
@@ -1,37 +1,124 @@
 "use client";
 
 import Link from "next/link";
-import { Home, Search, Sparkles } from "lucide-react";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { ArrowRight, Home } from "lucide-react";
+import DarkVeil from "@/components/ui-block/DarkVeil";
+
+const PARTICLES_DATA = [
+  { id: 1, left: 16, top: 22, delay: 0, duration: 10 },
+  { id: 2, left: 64, top: 78, delay: 1.5, duration: 12 },
+  { id: 3, left: 82, top: 18, delay: 3, duration: 14 },
+  { id: 4, left: 34, top: 66, delay: 4.5, duration: 11 },
+  { id: 5, left: 90, top: 48, delay: 6, duration: 13 },
+];
 
 export default function NotFound() {
+  const [mousePosition, setMousePosition] = useState({ x: 0, y: 0 });
+
+  const handleMouseMove = useCallback((event) => {
+    setMousePosition({ x: event.clientX, y: event.clientY });
+  }, []);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    setMousePosition({
+      x: window.innerWidth / 2,
+      y: window.innerHeight / 2,
+    });
+
+    let mouseTimeout;
+    const throttledMouseMove = (event) => {
+      if (!mouseTimeout) {
+        mouseTimeout = setTimeout(() => {
+          handleMouseMove(event);
+          mouseTimeout = null;
+        }, 32);
+      }
+    };
+
+    window.addEventListener("mousemove", throttledMouseMove, {
+      passive: true,
+    });
+
+    return () => {
+      window.removeEventListener("mousemove", throttledMouseMove);
+      if (mouseTimeout) clearTimeout(mouseTimeout);
+    };
+  }, [handleMouseMove]);
+
+  const mouseOrbStyle = useMemo(
+    () => ({
+      left: mousePosition.x - 192,
+      top: mousePosition.y - 192,
+      transition: "all 1.2s ease-out",
+    }),
+    [mousePosition.x, mousePosition.y]
+  );
+
   return (
-    <div className="min-h-screen flex flex-col items-center justify-center bg-gradient-to-br from-gray-900 via-blue-900 to-purple-900 text-center px-6">
-      {/* Glowing Icon */}
-      <div className="w-24 h-24 bg-gradient-to-r from-blue-500 to-purple-500 rounded-full flex items-center justify-center shadow-2xl animate-pulse mb-6">
-        <Sparkles className="w-12 h-12 text-white" />
+    <>
+      <div className="fixed inset-0 -z-10">
+        <DarkVeil />
+
+        <div
+          className="absolute h-96 w-96 rounded-full bg-gradient-to-r from-purple-500/10 to-pink-500/10 blur-3xl"
+          style={mouseOrbStyle}
+        />
+
+        <div className="absolute inset-0 overflow-hidden">
+          {PARTICLES_DATA.map((particle) => (
+            <div
+              key={particle.id}
+              className="absolute h-1 w-1 rounded-full bg-accent/20 animate-float"
+              style={{
+                left: `${particle.left}%`,
+                top: `${particle.top}%`,
+                animationDelay: `${particle.delay}s`,
+                animationDuration: `${particle.duration}s`,
+              }}
+            />
+          ))}
+        </div>
       </div>
 
-      {/* Headline */}
-      <h1 className="text-5xl font-bold text-white tracking-tight mb-4">
-        404 - Page Not Found
-      </h1>
+      <main className="relative z-10 flex min-h-screen items-center justify-center px-6 py-24 text-center text-white">
+        <div className="w-full max-w-2xl space-y-6">
+          <h1 className="text-6xl sm:text-7xl md:text-8xl font-bold tracking-tight text-white">
+            404
+          </h1>
+          <p className="text-lg sm:text-xl text-slate-300">
+            The page you're looking for doesn't exist or may have moved. Check
+            the URL or head back to the homepage.
+          </p>
+          <div className="flex items-center justify-center">
+            <Link
+              href="/"
+              className="inline-flex items-center justify-center gap-2 rounded-full bg-gradient-to-r from-accent to-purple-500 px-8 py-4 text-sm font-semibold text-white shadow-xl shadow-accent/25 transition-all duration-500 hover:scale-[1.02]"
+            >
+              <Home className="h-4 w-4" />
+              Go back home
+            </Link>
+          </div>
+        </div>
+      </main>
 
-      {/* Subtitle */}
-      <p className="text-gray-300 text-lg max-w-xl mb-8">
-        Oops! The page you are looking for doesn’t exist or has been moved.
-        Let’s get you back on track.
-      </p>
-
-      {/* Action Buttons */}
-      <div className="flex flex-wrap gap-4 justify-center">
-        <Link
-          href="/"
-          className="bg-gradient-to-r from-green-600 to-emerald-600 text-white px-6 py-3 rounded-xl shadow-lg hover:scale-105 hover:brightness-110 transition-all duration-300 ease-in-out flex items-center"
-        >
-          <Home className="w-5 h-5 mr-2" />
-          Go Home
-        </Link>
-      </div>
-    </div>
+      <style jsx>{`
+        @keyframes float {
+          0%,
+          100% {
+            transform: translateY(0px) rotate(0deg);
+            opacity: 0.3;
+          }
+          50% {
+            transform: translateY(-15px) rotate(90deg);
+            opacity: 0.8;
+          }
+        }
+        .animate-float {
+          animation: float ease-in-out infinite;
+        }
+      `}</style>
+    </>
   );
 }


### PR DESCRIPTION
## What type of PR is this?

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 📚 Documentation
- [x] 🎨 UI/UX improvement
- [ ] ⚡ Performance improvement
- [ ] 🔒 Security fix

## Description

redesigned the 404 page to match the homepage’s dark theme and background effects, added a prominent 404 heading and the requested message, and simplified the CTA to a single “Go back home” button styled to match the primary home button.

## Related Issues

Fixes #19 

## Changes Made

- Updated the 404 layout to use the home page visual treatment (DarkVeil, particles, gradient orb)
- Added the required 404 copy and headline
- Aligned CTA styling with the homepage primary button and removed extra CTA text

## Testing

How did you test these changes?
- [x] Tested locally
- [x] Tested on mobile
- [x] Tested different user roles
- [x] All roles tested

## Screenshots (if applicable)

<img width="1917" height="857" alt="image" src="https://github.com/user-attachments/assets/25ef53c5-a71d-4e70-8b53-1df28cbf9576" />


## Checklist

- [ ] No hardcoded secrets or credentials
- [ ] `.env.local` is not committed
- [x] Code follows project style
- [ ] Changes are documented
- [x] Build passes locally (`npm run build`)
- [x] No console errors/warnings