### PR TITLE
fix: add keyboard navigation to RoleSelection component

### DIFF
--- a/components/RoleSelection.js
+++ b/components/RoleSelection.js
@@ -3,6 +3,14 @@ import { Sparkles, Shield, Zap } from "lucide-react";
 import { ROLE_CONFIG } from "@/constants/userRoles";
 
 export default function RoleSelection({ onRoleSelect }) {
+  // Keyboard handler — Enter ya Space press hone pe role select hoga
+  const handleKeyDown = (e, role) => {
+    if (e.key === "Enter" || e.key === " ") {
+      e.preventDefault(); // Page scroll rokne ke liye Space key pe
+      onRoleSelect(role);
+    }
+  };
+
   return (
     <div className="max-w-4xl mx-auto text-center">
       <div className="mb-10">
@@ -23,7 +31,8 @@ export default function RoleSelection({ onRoleSelect }) {
             <button
               key={role}
               onClick={() => onRoleSelect(role)}
-              className="group p-4 bg-gray-800/70 backdrop-blur-sm rounded-2xl border border-gray-700/50 hover:border-indigo-500/50 transition-all duration-300 transform hover:scale-105 hover:shadow-2xl text-center"
+              onKeyDown={(e) => handleKeyDown(e, role)} // ✅ NEW — keyboard support
+              className="group p-4 bg-gray-800/70 backdrop-blur-sm rounded-2xl border border-gray-700/50 hover:border-indigo-500/50 transition-all duration-300 transform hover:scale-105 hover:shadow-2xl text-center focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 focus:ring-offset-gray-900" // ✅ NEW — focus ring
             >
               <div
                 className={`w-16 h-16 mx-auto mb-6 rounded-full bg-gradient-to-r ${config.color} p-4 group-hover:shadow-lg transition-all duration-300`}


### PR DESCRIPTION
## What type of PR is this?
- [x] 🐛 Bug fix

## Description
This PR improves the keyboard accessibility of the `RoleSelection` component by adding proper keyboard navigation support. Previously, users who rely on keyboard navigation (Tab / Enter / Space) had no reliable way to select a role without a mouse. The focus ring was browser-default and unstyled, making it inconsistent across browsers and mismatched with the project's design system.

This fix ensures the component meets **WCAG accessibility guidelines** and provides a polished, consistent experience for all users.

## Related Issues
Closes #21

## Changes Made
- Added `onKeyDown` handler to trigger role selection on `Enter` and `Space` key press
- Added `e.preventDefault()` on `Space` key to prevent unintended page scroll
- Added `focus:outline-none` to remove inconsistent browser-default outline
- Added `focus:ring-2 focus:ring-indigo-500` to apply a consistent indigo focus ring matching the project's design system
- Added `focus:ring-offset-2 focus:ring-offset-gray-900` for clear visibility on the dark background
- All changes are confined to `components/RoleSelection.js` — no functionality altered

## Testing
- [x] Manually reviewed code for correctness
- [x] Verified Tab key moves focus across all 4 role cards in order
- [x] Verified indigo focus ring is visible on each focused card
- [x] Verified Enter and Space key triggers role selection correctly
- [x] Verified mouse click interaction is unchanged
- [x] Tested on localhost (npm run dev)

## Screenshots
**Before** — Browser default unstyled outline (inconsistent across browsers):
_(live site: learnova-web.vercel.app)_

**After** — Indigo focus ring consistent with project design system:
_(localhost — Tab key focused on Institute card)_
[Attach your localhost screenshot here]

## Checklist
- [x] No hardcoded secrets or credentials
- [x] `.env.local` is not committed
- [x] Code follows project style
- [x] Changes are documented
- [ ] Build passes locally (`npm run build`)
- [x] No console errors/warnings

> ⚠️ `npm run build` could not be verified locally as Firebase and MongoDB credentials were not available. However, the change is limited to a single UI component with no impact on build configuration.
<img width="2880" height="1800" alt="Screenshot 2026-05-17 112413" src="https://github.com/user-attachments/assets/f2a3f97f-2d70-4208-8109-f60a64d91e9d" />

