### PR TITLE
Implemented backend userStats service and integrated with signup and activities.

### DIFF
--- a/app/activity/page.js
+++ b/app/activity/page.js
@@ -29,6 +29,7 @@ import { Navbar } from "@/components/Navbar";
 
 import { useAuth } from "@/hooks/useAuth";
 import { logActivity } from "@/services/activityService";
+import { updateUserStat } from "@/services/statsService";
 
 // Reusable animation component
 const Reveal = ({ children, className = "", delay = 0, y = 28 }) => (
@@ -227,6 +228,9 @@ export default function ActivityPage() {
       type: activity.type || "course",
       progress: 0,
     });
+
+    // Increment "Courses Enrolled" statistic
+    await updateUserStat(user.uid, "Courses Enrolled", 1);
 
     // Here add logic to actually open the quiz/game
     alert(`Started ${activity.title}! Progress is now being tracked.`);

--- a/services/statsService.js
+++ b/services/statsService.js
@@ -1,0 +1,54 @@
+import { db } from "@/lib/firebaseConfig";
+import { doc, setDoc, updateDoc, increment, getDoc } from "firebase/firestore";
+
+/**
+ * Initializes a new user's statistics in Firestore.
+ * @param {string} userId - The unique ID of the user.
+ */
+export const initializeUserStats = async (userId) => {
+  if (!userId) return;
+  const statsRef = doc(db, "userStats", userId);
+  
+  const defaultStats = {
+    "Courses Enrolled": 0,
+    "Attendance Rate": "0%",
+    "Assignments Done": 0,
+    "Study Hours": 0,
+    lastUpdated: new Date()
+  };
+
+  try {
+    await setDoc(statsRef, defaultStats);
+    console.log("Stats initialized for user:", userId);
+  } catch (error) {
+    console.error("Error initializing stats:", error);
+  }
+};
+
+/**
+ * Increments a specific statistic for a user.
+ * @param {string} userId - The unique ID of the user.
+ * @param {string} statField - The name of the stat (must match dashboard labels).
+ * @param {number} value - The amount to increment (default is 1).
+ */
+export const updateUserStat = async (userId, statField, value = 1) => {
+  if (!userId) return;
+  const statsRef = doc(db, "userStats", userId);
+
+  try {
+    const statsSnap = await getDoc(statsRef);
+    
+    if (!statsSnap.exists()) {
+      // If doc doesn't exist for some reason, create it first
+      await initializeUserStats(userId);
+    }
+
+    await updateDoc(statsRef, {
+      [statField]: increment(value),
+      lastUpdated: new Date()
+    });
+    console.log(`Updated ${statField} for user:`, userId);
+  } catch (error) {
+    console.error(`Error updating ${statField}:`, error);
+  }
+};

--- a/utils/authUtils.js
+++ b/utils/authUtils.js
@@ -1,6 +1,8 @@
 import { doc, setDoc } from "firebase/firestore";
 import { db } from "@/lib/firebaseConfig";
 import { USER_ROLES } from "@/constants/userRoles";
+import { initializeUserStats } from "@/services/statsService";
+
 
 /**
  * Returns a user-friendly authentication error message.
@@ -58,6 +60,10 @@ export const createUserProfile = async (user, role, additionalData = {}) => {
   }
 
   await setDoc(doc(db, "users", user.uid), userProfile);
+  
+  // Initialize their empty dashboard stats
+  await initializeUserStats(user.uid);
+
   return userProfile;
 };
 


### PR DESCRIPTION
closes issue #48 
## Description
This PR implements a centralized statistics service (`userStats`) for the dashboard and integrates it into the user signup flow and the activity page. This replaces the default 0-stats placeholder values on the User Profile with live, incrementing, real-time progress values when users interact with the app.

### Key Changes & Line References

#### 1. Created User Stats Backend Service
*   **Created `services/statsService.js` (Lines 1–54):**
    *   `initializeUserStats(userId)`: Overwrites/creates a default stats scorecard (`Courses Enrolled`: 0, `Attendance Rate`: "0%", `Assignments Done`: 0, `Study Hours`: 0) upon signup.
    *   `updateUserStat(userId, statField, value)`: A robust, reusable service that uses Firestore's atomic `increment` function to safely adjust dashboard metrics.

#### 2. User Registration Integration
*   **Modified `utils/authUtils.js`:**
    *   **Line 4:** Imported the new `initializeUserStats` service.
    *   **Line 60:** Integrated the initialization inside `createUserProfile` so all newly registered users automatically get a blank, customized metrics document created.

#### 3. Activity Interactivity Integration
*   **Modified `app/activity/page.js`:**
    *   **Line 30:** Imported `updateUserStat`.
    *   **Line 210:** Linked the "Courses Enrolled" dashboard stat to user interaction. Starting any activity (game or quiz) now automatically increments their "Courses Enrolled" metric by 1 in real-time.

### Technical Implementation Details
*   **Firestore Collection:** `userStats` (keyed directly by the user's `uid`).
*   **Database Concurrency:** Used Firestore's native `increment()` to avoid race conditions if a user performs actions rapidly.
*   **Graceful Degradation:** The stats updater checks for document existence first, dynamically initializing stats if they don't exist for older accounts.

## Testing Instructions
1. Register a new user on the platform.
2. Verify that a default `userStats` document is created in Firestore.
3. Log in, navigate to the `/activity` page, and click **Play Now** or **Start Quiz** on any card.
4. Go to your **Profile Dashboard** and verify that the "Courses Enrolled" statistic has incremented from `0` to `1`.

***

### Verification Checklist
- [x] Statistics engine (`services/statsService.js`) initialized.
- [x] Automatic stats document creation for new users (`authUtils.js`).
- [x] Live-incrementing courses tracker hooked to activity start buttons (`page.js`).
- [x] Zero-conflict integration with the dynamic UI we built previously.
