### PR TITLE
fix(contact): align displayed email with mailto href

### DIFF
--- a/app/contact/page.js
+++ b/app/contact/page.js
@@ -105,7 +105,7 @@ export default function Contact() {
     {
       icon: Mail,
       label: "Email",
-      value: "shawprem217@gmail.com",
+      value: "hello@learnova.com",
       href: "mailto:hello@learnova.com",
       gradient: "from-blue-500 to-cyan-500",
     },


### PR DESCRIPTION
## Summary
- Fixes mismatched contact email on `/contact`: visible text and `mailto:` now both use `hello@learnova.com`.

## Why
Users clicking the email link were composing to a different address than the one shown on the page.

## Test plan
- [ ] Open `/contact` and verify Email shows `hello@learnova.com`
- [ ] Click the email link and confirm the mail client addresses `hello@learnova.com`

Fixes #66