### PR TITLE
feat(ui): add scroll-to-top button above chat assistant

### DIFF
--- a/app/layout.js
+++ b/app/layout.js
@@ -9,6 +9,7 @@ import LearnovaChatbot from "@/components/ChatBot";
 import ClientLayout from "@/components/ClientLayout";
 import Footer from "@/components/Footer";
 import PageTransition from "@/components/PageTransition";
+import ScrollToTop from "@/components/ScrollToTop";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -234,6 +235,7 @@ export default function RootLayout({ children }) {
         <AuthProvider>
           <Suspense fallback={null}>
             <PageTransition>{children}</PageTransition>
+            <ScrollToTop />
             {/* Chatbot injected globally */}
             <div className="z-50">
               <LearnovaChatbot />

--- a/components/ScrollToTop.js
+++ b/components/ScrollToTop.js
@@ -1,0 +1,39 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { ArrowUp } from "lucide-react";
+
+const SCROLL_THRESHOLD_PX = 320;
+
+export default function ScrollToTop() {
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    const onScroll = () => {
+      setVisible(window.scrollY > SCROLL_THRESHOLD_PX);
+    };
+
+    onScroll();
+    window.addEventListener("scroll", onScroll, { passive: true });
+    return () => window.removeEventListener("scroll", onScroll);
+  }, []);
+
+  const scrollToTop = () => {
+    window.scrollTo({ top: 0, behavior: "smooth" });
+  };
+
+  if (!visible) {
+    return null;
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={scrollToTop}
+      aria-label="Scroll to top"
+      className="fixed bottom-24 right-6 z-40 flex h-11 w-11 items-center justify-center rounded-full border border-slate-600/80 bg-slate-900/90 text-white shadow-lg backdrop-blur-sm transition hover:border-purple-400/60 hover:bg-slate-800 focus:outline-none focus-visible:ring-2 focus-visible:ring-purple-400"
+    >
+      <ArrowUp className="h-5 w-5" aria-hidden />
+    </button>
+  );
+}


### PR DESCRIPTION
## Summary
- Floating scroll-to-top control appears after scrolling ~320px.
- Positioned at `bottom-24 right-6` (above the chat widget at `bottom-6`).
- Smooth scroll to top on click; includes `aria-label`.

## Test plan
- [ ] Scroll down on a long page — button appears
- [ ] Click — page scrolls smoothly to top
- [ ] Confirm button sits above the chat FAB and does not overlap it

Fixes #26