### PR TITLE
Fix mismatched contact email and mailto link

### DIFF
--- a/app/contact/page.js
+++ b/app/contact/page.js
@@ -105,7 +105,7 @@ export default function Contact() {
     {
       icon: Mail,
       label: "Email",
-      value: "shawprem217@gmail.com",
+      value: "hello@learnova.com",
       href: "mailto:hello@learnova.com",
       gradient: "from-blue-500 to-cyan-500",
     },


### PR DESCRIPTION
## What type of PR is this?

* [x] 🐛 Bug fix
* [ ] ✨ New feature
* [ ] 📚 Documentation
* [x] 🎨 UI/UX improvement
* [ ] ⚡ Performance improvement
* [ ] 🔒 Security fix

## Description

Fixed the mismatch between the displayed contact email and the underlying `mailto:` link on the `/contact` page. This ensures users are redirected to the correct email address when clicking the contact email.

## Related Issues

Closes #72

## Changes Made

* Updated the contact email configuration on the `/contact` page
* Ensured the displayed email and `mailto:` href point to the same address
* Verified the contact link works correctly across browsers

## Testing

How did you test these changes?

* [x] Tested locally
* [x] Tested on mobile
* [x] Tested different user roles
* [x] All roles tested

## Screenshots (if applicable)

Added before/after verification locally for the contact email link behavior.
<img width="1445" height="644" alt="image" src="https://github.com/user-attachments/assets/9fac9e60-deed-4c29-aa05-98614e8862ad" />


## Checklist

* [x] No hardcoded secrets or credentials
* [x] `.env.local` is not committed
* [x] Code follows project style
* [x] Changes are documented
* [ ] Build passes locally (`npm run build`)
* [x] No console errors/warnings
