### PR TITLE
fix(ui): show Navbar on custom 404 page

### DIFF
--- a/app/not-found.js
+++ b/app/not-found.js
@@ -4,6 +4,7 @@ import Link from "next/link";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { ArrowRight, Home } from "lucide-react";
 import DarkVeil from "@/components/ui-block/DarkVeil";
+import { Navbar } from "@/components/Navbar";
 
 const PARTICLES_DATA = [
   { id: 1, left: 16, top: 22, delay: 0, duration: 10 },
@@ -58,6 +59,7 @@ export default function NotFound() {
 
   return (
     <>
+      <Navbar />
       <div className="fixed inset-0 -z-10">
         <DarkVeil />
 


### PR DESCRIPTION
## Summary
- Renders the shared `Navbar` on `app/not-found.js` so 404 pages match the rest of the site chrome

## Test plan
- [ ] Visit a non-existent route (e.g. `/randompage`)
- [ ] Navbar appears at the top with working navigation links
- [ ] **Go back home** still works

Fixes #73