### PR TITLE
fix: remove leftover console.log debug statement from page.js

### DIFF
--- a/app/not-found.js
+++ b/app/not-found.js
@@ -5,7 +5,6 @@ import { Navbar } from "@/components/Navbar";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { Home } from "lucide-react";
 import DarkVeil from "@/components/ui-block/DarkVeil";
-import { Navbar } from "@/components/Navbar";
 
 const PARTICLES_DATA = [
   { id: 1, left: 16, top: 22, delay: 0, duration: 10 },

--- a/app/page.js
+++ b/app/page.js
@@ -213,8 +213,7 @@ export default function AboutPage() {
     setScrollY(window.scrollY);
   }, []);
 
-  const handleAnimationComplete = useCallback(() => {
-    console.log("Animation completed");
+ const handleAnimationComplete = useCallback(() => {
   }, []);
 
   useEffect(() => {


### PR DESCRIPTION
Fixes #80

## Problem
A debug console.log("Animation completed") statement 
was left in app/page.js which clutters the browser 
console for all users in production.

## Fix
Removed the console.log statement from the 
handleAnimationComplete callback in app/page.js.

## Tested
✅ No console.log output in browser console
✅ Animation functionality still works correctly