### PR TITLE
feat: improve lazy loading across the app (#61)

### DIFF
--- a/app/admin/dashboard/loading.js
+++ b/app/admin/dashboard/loading.js
@@ -1,0 +1,5 @@
+import RouteLoading from "@/components/RouteLoading";
+
+export default function Loading() {
+  return <RouteLoading />;
+}

--- a/app/admin/dashboard/page.js
+++ b/app/admin/dashboard/page.js
@@ -1,12 +1,20 @@
-// app/admin/dashboard/page.jsx
 "use client";
-import SuperAdminDashboard from "@/components/AdminDashboard";
+
+import dynamic from "next/dynamic";
 import ProtectedRoute from "@/components/ProtectedRoute";
+import RouteLoading from "@/components/RouteLoading";
+
+const SuperAdminDashboard = dynamic(
+  () => import("@/components/AdminDashboard"),
+  {
+    loading: () => <RouteLoading />,
+  }
+);
 
 export default function AdminDashboard() {
   return (
     <ProtectedRoute allowedRoles={["admin"]}>
-      <SuperAdminDashboard/>
+      <SuperAdminDashboard />
     </ProtectedRoute>
   );
 }

--- a/app/not-found.js
+++ b/app/not-found.js
@@ -5,7 +5,6 @@ import { Navbar } from "@/components/Navbar";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { Home } from "lucide-react";
 import DarkVeil from "@/components/ui-block/DarkVeil";
-import { Navbar } from "@/components/Navbar";
 
 const PARTICLES_DATA = [
   { id: 1, left: 16, top: 22, delay: 0, duration: 10 },

--- a/app/page.js
+++ b/app/page.js
@@ -1,9 +1,8 @@
 "use client";
 import { Navbar } from "@/components/Navbar";
 import { useMemo, useEffect, useState, useCallback } from "react";
+import dynamic from "next/dynamic";
 import { motion } from "framer-motion";
-import SplitText from "@/components/ui-block/SplitText";
-import DarkVeil from "@/components/ui-block/DarkVeil";
 import {
   Card,
   CardContent,
@@ -28,7 +27,23 @@ import {
 import Link from "next/link";
 import { analytics } from "@/lib/firebaseConfig";
 import { logEvent } from "firebase/analytics";
-import LearnovaChatbot from "@/components/ChatBot";
+
+const DarkVeil = dynamic(() => import("@/components/ui-block/DarkVeil"), {
+  ssr: false,
+});
+
+const SplitText = dynamic(() => import("@/components/ui-block/SplitText"), {
+  ssr: false,
+  loading: () => (
+    <span className="text-4xl sm:text-5xl md:text-7xl font-bold text-white opacity-60">
+      …
+    </span>
+  ),
+});
+
+const LearnovaChatbot = dynamic(() => import("@/components/ChatBot"), {
+  ssr: false,
+});
 
 // Constants moved outside component for better performance
 const PARTICLES_DATA = [
@@ -664,6 +679,8 @@ export default function AboutPage() {
           </Reveal>
         </section>
       </div>
+
+      <LearnovaChatbot />
 
       <style jsx>{`
         @keyframes float {

--- a/app/student/dashboard/loading.js
+++ b/app/student/dashboard/loading.js
@@ -1,0 +1,5 @@
+import RouteLoading from "@/components/RouteLoading";
+
+export default function Loading() {
+  return <RouteLoading />;
+}

--- a/app/student/dashboard/page.js
+++ b/app/student/dashboard/page.js
@@ -1,12 +1,20 @@
-// app/student/dashboard/page.jsx
 "use client";
+
+import dynamic from "next/dynamic";
 import ProtectedRoute from "@/components/ProtectedRoute";
-import StudentDashboard from "@/components/StudentDashboard";
+import RouteLoading from "@/components/RouteLoading";
+
+const StudentDashboard = dynamic(
+  () => import("@/components/StudentDashboard"),
+  {
+    loading: () => <RouteLoading />,
+  }
+);
 
 export default function Student() {
   return (
     <ProtectedRoute allowedRoles={["student"]}>
-        <StudentDashboard/>
+      <StudentDashboard />
     </ProtectedRoute>
   );
 }

--- a/app/teacher/dashboard/loading.js
+++ b/app/teacher/dashboard/loading.js
@@ -1,0 +1,5 @@
+import RouteLoading from "@/components/RouteLoading";
+
+export default function Loading() {
+  return <RouteLoading />;
+}

--- a/app/teacher/dashboard/page.js
+++ b/app/teacher/dashboard/page.js
@@ -1,12 +1,20 @@
-// app/teacher/dashboard/page.jsx
 "use client";
+
+import dynamic from "next/dynamic";
 import ProtectedRoute from "@/components/ProtectedRoute";
-import TeacherDashboard from "@/components/TeacherDashboardComponent "
+import RouteLoading from "@/components/RouteLoading";
+
+const TeacherDashboard = dynamic(
+  () => import("@/components/TeacherDashboardComponent "),
+  {
+    loading: () => <RouteLoading />,
+  }
+);
 
 export default function Teacher() {
   return (
     <ProtectedRoute allowedRoles={["teacher"]}>
-      <TeacherDashboard/>
+      <TeacherDashboard />
     </ProtectedRoute>
   );
 }

--- a/components/RouteLoading.js
+++ b/components/RouteLoading.js
@@ -1,0 +1,14 @@
+export default function RouteLoading() {
+  return (
+    <div
+      className="min-h-[60vh] flex items-center justify-center"
+      aria-busy="true"
+      aria-label="Loading"
+    >
+      <div
+        className="h-10 w-10 rounded-full border-2 border-accent border-t-transparent animate-spin"
+        role="status"
+      />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Dynamically import `DarkVeil`, `SplitText`, and `ChatBot` on the home page
- Lazy-load student, teacher, and admin dashboard components with `next/dynamic`
- Add route-level `loading.js` for dashboard routes and shared `RouteLoading` spinner

Closes #61

## Test plan
- [ ] `npm run dev` — home page hero animations and chatbot still work
- [ ] Navigate to `/student/dashboard`, `/teacher/dashboard`, `/admin/dashboard` (authenticated) and confirm loading UI appears briefly
- [ ] No console errors from dynamic imports