### PR TITLE
feat(auth): password strength indicator on sign-up (#14)

### DIFF
--- a/components/AuthForm.js
+++ b/components/AuthForm.js
@@ -1,7 +1,8 @@
 "use client";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { Eye, EyeOff, Mail, Lock, Sparkles } from "lucide-react";
 import { ROLE_CONFIG, USER_ROLES } from "@/constants/userRoles";
+import { getPasswordStrength } from "@/utils/passwordStrength";
 
 export default function AuthForm({
   isLogin,
@@ -24,6 +25,10 @@ export default function AuthForm({
   onForgotPassword,
 }) {
   const [showPassword, setShowPassword] = useState(false);
+  const passwordStrength = useMemo(
+    () => getPasswordStrength(password),
+    [password]
+  );
 
   const clearError = (field) => {
     if (errors[field]) {
@@ -195,6 +200,27 @@ export default function AuthForm({
             </div>
             {errors.password && (
               <p className="text-red-400 text-sm mt-1">{errors.password}</p>
+            )}
+            {!isLogin && password.length > 0 && (
+              <div className="mt-3" aria-live="polite">
+                <div className="flex gap-1 mb-1.5">
+                  {[0, 1, 2, 3].map((segment) => (
+                    <div
+                      key={segment}
+                      className={`h-1.5 flex-1 rounded-full transition-colors ${
+                        segment < passwordStrength.score
+                          ? passwordStrength.barClass
+                          : "bg-gray-600"
+                      }`}
+                    />
+                  ))}
+                </div>
+                <p
+                  className={`text-xs font-medium ${passwordStrength.textClass}`}
+                >
+                  Password strength: {passwordStrength.label}
+                </p>
+              </div>
             )}
           </div>
 

--- a/utils/passwordStrength.js
+++ b/utils/passwordStrength.js
@@ -1,0 +1,24 @@
+const STRENGTH_LEVELS = [
+  { label: "Weak", barClass: "bg-red-500", textClass: "text-red-400" },
+  { label: "Fair", barClass: "bg-orange-500", textClass: "text-orange-400" },
+  { label: "Strong", barClass: "bg-yellow-500", textClass: "text-yellow-400" },
+  { label: "Very Strong", barClass: "bg-green-500", textClass: "text-green-400" },
+];
+
+/**
+ * Score password strength from 0–4 based on length, case, digit, and symbol.
+ */
+export function getPasswordStrength(password = "") {
+  if (!password) {
+    return { score: 0, ...STRENGTH_LEVELS[0] };
+  }
+
+  let score = 0;
+  if (password.length >= 8) score += 1;
+  if (/[A-Z]/.test(password)) score += 1;
+  if (/\d/.test(password)) score += 1;
+  if (/[^A-Za-z0-9]/.test(password)) score += 1;
+
+  const level = STRENGTH_LEVELS[Math.max(0, Math.min(score, 3))];
+  return { score, ...level };
+}


### PR DESCRIPTION
## Summary
- Add `getPasswordStrength` helper (length, uppercase, digit, symbol)
- Show a four-segment bar with text label during sign-up only

Closes #14

## Test plan
- [ ] Sign-up form shows strength bar while typing password
- [ ] Login form does not show the indicator
- [ ] Label updates across Weak → Very Strong