### PR TITLE
chore: remove debug console.log from production components

### DIFF
--- a/components/InstallPWA.js
+++ b/components/InstallPWA.js
@@ -19,17 +19,6 @@ export default function InstallPWA() {
     if ("serviceWorker" in navigator) {
       navigator.serviceWorker
         .register("/sw.js", { scope: "/" })
-        .then((registration) => {
-          console.log(
-            "Service Worker registered successfully:",
-            registration.scope
-          );
-
-          // Check for updates
-          registration.addEventListener("updatefound", () => {
-            console.log("Service Worker update found!");
-          });
-        })
         .catch((error) => {
           console.error("Service Worker registration failed:", error);
         });
@@ -62,7 +51,6 @@ export default function InstallPWA() {
 
     // Listen for successful installation
     window.addEventListener("appinstalled", () => {
-      console.log("PWA was installed successfully");
       setIsInstalled(true);
       setIsVisible(false);
     });

--- a/components/universal-settings.js
+++ b/components/universal-settings.js
@@ -240,7 +240,6 @@ export default function UniversalSettings() {
   const saveSettings = async () => {
     setIsLoading(true);
     try {
-      console.log("Saving settings:", settings);
       await new Promise((resolve) => setTimeout(resolve, 1000));
       setHasChanges(false);
     } catch (error) {


### PR DESCRIPTION
Removes debug console.log calls from InstallPWA and universal-settings so production users do not see noisy logs or sensitive settings data in the console.

Fixes #86