### PR TITLE
chore: remove debug console.log from services and home page

### DIFF
--- a/app/page.js
+++ b/app/page.js
@@ -213,9 +213,7 @@ export default function AboutPage() {
     setScrollY(window.scrollY);
   }, []);
 
-  const handleAnimationComplete = useCallback(() => {
-    console.log("Animation completed");
-  }, []);
+  const handleAnimationComplete = useCallback(() => {}, []);
 
   useEffect(() => {
     // Throttled event listeners

--- a/services/activityService.js
+++ b/services/activityService.js
@@ -19,7 +19,6 @@ export const logActivity = async (userId, activityData) => {
             progress: activityData.progress || 0,
             timestamp: serverTimestamp(), // Record when the activity happened
         });
-        console.log("Activity logged successfully!");
     } catch (error) {
         console.error("Error logging activity to Firestore:", error);
     }

--- a/services/statsService.js
+++ b/services/statsService.js
@@ -19,7 +19,6 @@ export const initializeUserStats = async (userId) => {
 
   try {
     await setDoc(statsRef, defaultStats);
-    console.log("Stats initialized for user:", userId);
   } catch (error) {
     console.error("Error initializing stats:", error);
   }
@@ -47,7 +46,6 @@ export const updateUserStat = async (userId, statField, value = 1) => {
       [statField]: increment(value),
       lastUpdated: new Date()
     });
-    console.log(`Updated ${statField} for user:`, userId);
   } catch (error) {
     console.error(`Error updating ${statField}:`, error);
   }


### PR DESCRIPTION
Removes leftover debug console.log calls from statsService, activityService, and the home page animation callback.

Fixes #80