### PR TITLE
fix: remove leftover console.log statements from components

### DIFF
--- a/components/InstallPWA.js
+++ b/components/InstallPWA.js
@@ -19,10 +19,7 @@ export default function InstallPWA() {
     if ("serviceWorker" in navigator) {
       navigator.serviceWorker
         .register("/sw.js", { scope: "/" })
-        .then((registration) => {
-          // Check for updates
-          registration.addEventListener("updatefound", () => {});
-        })
+        .then(() => {})
         .catch((error) => {
           console.error("Service Worker registration failed:", error);
         });

--- a/components/InstallPWA.js
+++ b/components/InstallPWA.js
@@ -15,20 +15,13 @@ export default function InstallPWA() {
     // Check if running in browser
     if (typeof window === "undefined") return;
 
-    // Register the service worker (sw.js will handle the swe-worker automatically)
+    // Register the service worker
     if ("serviceWorker" in navigator) {
       navigator.serviceWorker
         .register("/sw.js", { scope: "/" })
         .then((registration) => {
-          console.log(
-            "Service Worker registered successfully:",
-            registration.scope
-          );
-
           // Check for updates
-          registration.addEventListener("updatefound", () => {
-            console.log("Service Worker update found!");
-          });
+          registration.addEventListener("updatefound", () => {});
         })
         .catch((error) => {
           console.error("Service Worker registration failed:", error);
@@ -54,7 +47,6 @@ export default function InstallPWA() {
     const handler = (e) => {
       e.preventDefault();
       setInstallPrompt(e);
-      // Show prompt after 5 seconds
       setTimeout(() => setIsVisible(true), 5000);
     };
 
@@ -62,7 +54,6 @@ export default function InstallPWA() {
 
     // Listen for successful installation
     window.addEventListener("appinstalled", () => {
-      console.log("PWA was installed successfully");
       setIsInstalled(true);
       setIsVisible(false);
     });
@@ -79,11 +70,8 @@ export default function InstallPWA() {
       const result = await installPrompt.prompt();
 
       if (result.outcome === "accepted") {
-        console.log("User accepted the install prompt");
         setIsVisible(false);
         setInstallPrompt(null);
-      } else {
-        console.log("User dismissed the install prompt");
       }
     } catch (error) {
       console.error("Error during installation:", error);

--- a/components/universal-settings.js
+++ b/components/universal-settings.js
@@ -240,7 +240,7 @@ export default function UniversalSettings() {
   const saveSettings = async () => {
     setIsLoading(true);
     try {
-      console.log("Saving settings:", settings);
+      
       await new Promise((resolve) => setTimeout(resolve, 1000));
       setHasChanges(false);
     } catch (error) {

--- a/components/universal-settings.js
+++ b/components/universal-settings.js
@@ -241,7 +241,6 @@ export default function UniversalSettings() {
     setIsLoading(true);
    try {
       await new Promise((resolve) => setTimeout(resolve, 1000));
-      await new Promise((resolve) => setTimeout(resolve, 1000));
       setHasChanges(false);
     } catch (error) {
       console.error("Failed to save settings:", error);


### PR DESCRIPTION
Fixes #80

## Problem
Multiple debug console.log statements found in 
production components:
- components/InstallPWA.js (5 console.logs)
- components/universal-settings.js (1 console.log 
  exposing user settings data)

## Fix
- Removed all debug console.log statements
- Kept all console.error statements for error tracking

## Tested
✅ No debug logs in browser console
✅ PWA install functionality still works
✅ Settings save functionality still works