### PR TITLE
fix: remove console.log statements from services files

### DIFF
--- a/app/not-found.js
+++ b/app/not-found.js
@@ -5,7 +5,7 @@ import { Navbar } from "@/components/Navbar";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { Home } from "lucide-react";
 import DarkVeil from "@/components/ui-block/DarkVeil";
-import { Navbar } from "@/components/Navbar";
+
 
 const PARTICLES_DATA = [
   { id: 1, left: 16, top: 22, delay: 0, duration: 10 },

--- a/services/activityService.js
+++ b/services/activityService.js
@@ -11,18 +11,14 @@ export const logActivity = async (userId, activityData) => {
     if (!userId) return;
 
     try {
-        // Add a new document to the "activities" collection
         await addDoc(collection(db, "activities"), {
             userId,
             title: activityData.title,
             type: activityData.type || "course",
             progress: activityData.progress || 0,
-            timestamp: serverTimestamp(), // Record when the activity happened
+            timestamp: serverTimestamp(),
         });
-        console.log("Activity logged successfully!");
     } catch (error) {
         console.error("Error logging activity to Firestore:", error);
     }
 };
-
-

--- a/services/statsService.js
+++ b/services/statsService.js
@@ -19,7 +19,6 @@ export const initializeUserStats = async (userId) => {
 
   try {
     await setDoc(statsRef, defaultStats);
-    console.log("Stats initialized for user:", userId);
   } catch (error) {
     console.error("Error initializing stats:", error);
   }
@@ -39,7 +38,6 @@ export const updateUserStat = async (userId, statField, value = 1) => {
     const statsSnap = await getDoc(statsRef);
     
     if (!statsSnap.exists()) {
-      // If doc doesn't exist for some reason, create it first
       await initializeUserStats(userId);
     }
 
@@ -47,7 +45,6 @@ export const updateUserStat = async (userId, statField, value = 1) => {
       [statField]: increment(value),
       lastUpdated: new Date()
     });
-    console.log(`Updated ${statField} for user:`, userId);
   } catch (error) {
     console.error(`Error updating ${statField}:`, error);
   }


### PR DESCRIPTION
Fixes #92 

## Problem
Debug console.log statements found in service files
exposing sensitive user data:
- services/statsService.js — logs userId twice
- services/activityService.js — logs activity status

## Fix
Removed all console.log statements from:
- services/statsService.js
- services/activityService.js
Kept all console.error statements for error tracking.

## Tested
✅ Stats initialization still works
✅ Activity logging still works
✅ No user data exposed in console