### PR TITLE
fix(attendance): persist face recognition check-ins

### DIFF
--- a/app/attendance/page.js
+++ b/app/attendance/page.js
@@ -191,7 +191,7 @@ const AttendancePage = () => {
         </div>
       ) : (
         <div className="pt-16">
-          <FaceRecognizer labels={labels} onBack={handleBackToValidation} />
+          <FaceRecognizer authUser={user} />
         </div>
       )}
     </div>

--- a/components/FaceRecognizer.js
+++ b/components/FaceRecognizer.js
@@ -5,10 +5,13 @@ import * as faceapi from "face-api.js";
 import { Button } from "@/components/ui/button";
 import Link from "next/link";
 import useLabels from "@/components/useLabels"; // MongoDB hook
+import { recordAttendance } from "@/services/attendanceService";
 import { analytics } from "@/lib/firebaseConfig";
 import { logEvent } from "firebase/analytics";
 
-export default function FaceRecognizer() {
+const MIN_CONFIDENCE_TO_RECORD = 60;
+
+export default function FaceRecognizer({ authUser }) {
   const videoRef = useRef(null);
   const canvasRef = useRef(null);
   const { labels: fetchedLabels, loading: labelsLoading, error } = useLabels();
@@ -18,6 +21,7 @@ export default function FaceRecognizer() {
   const [detectedPerson, setDetectedPerson] = useState(null);
   const [isLoading, setIsLoading] = useState(true);
   const [confidence, setConfidence] = useState(0);
+  const [attendanceState, setAttendanceState] = useState("idle");
 
   const MODEL_URL = "/models";
 
@@ -38,6 +42,7 @@ export default function FaceRecognizer() {
       }
       setMessage("Camera access granted ✅");
       setFinished(false);
+      setAttendanceState("idle");
     } catch (err) {
       // Handle permanent denial gracefully
       if (err.name === "NotAllowedError") {
@@ -216,6 +221,47 @@ export default function FaceRecognizer() {
     }
   }, []);
 
+  useEffect(() => {
+    const persistAttendance = async () => {
+      if (!finished || !detectedPerson || !authUser?.uid) {
+        return;
+      }
+
+      if (confidence < MIN_CONFIDENCE_TO_RECORD) {
+        setAttendanceState("low-confidence");
+        return;
+      }
+
+      const detectedEmail = detectedPerson.email?.trim().toLowerCase();
+      const userEmail = authUser.email?.trim().toLowerCase();
+
+      if (detectedEmail && userEmail && detectedEmail !== userEmail) {
+        setAttendanceState("mismatch");
+        setMessage("Face recognized but does not match your signed-in account.");
+        return;
+      }
+
+      setAttendanceState("saving");
+
+      try {
+        const result = await recordAttendance({
+          userId: authUser.uid,
+          studentName: detectedPerson.name,
+          email: detectedPerson.email || authUser.email,
+          confidenceScore: confidence,
+        });
+
+        setAttendanceState(result.alreadyRecorded ? "already-recorded" : "saved");
+      } catch (err) {
+        console.error("Attendance save error:", err);
+        setAttendanceState("error");
+        setMessage(err.message || "Could not save attendance. Please try again.");
+      }
+    };
+
+    persistAttendance();
+  }, [authUser, confidence, detectedPerson, finished]);
+
   return (
     <div className="min-h-screen bg-gradient-to-br from-slate-900 via-purple-900 to-slate-900 flex flex-col items-center justify-start py-12 px-4 relative overflow-hidden">
       <div className="absolute inset-0 bg-[radial-gradient(ellipse_at_top,_var(--tw-gradient-stops))] from-purple-900/20 via-slate-900/40 to-slate-900"></div>
@@ -359,6 +405,17 @@ export default function FaceRecognizer() {
               </div>
             )}
           </div>
+
+          {attendanceState === "saved" && (
+            <p className="text-center text-sm font-medium text-emerald-300">
+              Attendance recorded for today.
+            </p>
+          )}
+          {attendanceState === "already-recorded" && (
+            <p className="text-center text-sm font-medium text-amber-300">
+              You have already checked in today.
+            </p>
+          )}
         </div>
       )}
 

--- a/services/attendanceService.js
+++ b/services/attendanceService.js
@@ -1,0 +1,61 @@
+import {
+  collection,
+  addDoc,
+  getDocs,
+  query,
+  serverTimestamp,
+  where,
+} from "firebase/firestore";
+
+import { db } from "@/lib/firebaseConfig";
+
+import { recalculateAttendanceRate } from "./statsService";
+
+function getTodayKey() {
+  return new Date().toISOString().slice(0, 10);
+}
+
+export async function hasCheckedInToday(userId) {
+  if (!userId || !db) {
+    return false;
+  }
+
+  const attendanceQuery = query(
+    collection(db, "attendance_records"),
+    where("userId", "==", userId)
+  );
+
+  const snapshot = await getDocs(attendanceQuery);
+  const today = getTodayKey();
+
+  return snapshot.docs.some((docSnap) => docSnap.data().date === today);
+}
+
+export async function recordAttendance({
+  userId,
+  studentName,
+  email,
+  confidenceScore,
+}) {
+  if (!userId || !db) {
+    throw new Error("Attendance cannot be saved without a signed-in user.");
+  }
+
+  if (await hasCheckedInToday(userId)) {
+    return { alreadyRecorded: true };
+  }
+
+  await addDoc(collection(db, "attendance_records"), {
+    userId,
+    studentName,
+    email,
+    timestamp: serverTimestamp(),
+    date: getTodayKey(),
+    status: "present",
+    confidenceScore: confidenceScore ?? 0,
+  });
+
+  await recalculateAttendanceRate(userId);
+
+  return { alreadyRecorded: false };
+}

--- a/services/statsService.js
+++ b/services/statsService.js
@@ -1,5 +1,30 @@
 import { db } from "@/lib/firebaseConfig";
-import { doc, setDoc, updateDoc, increment, getDoc } from "firebase/firestore";
+import {
+  collection,
+  doc,
+  getDoc,
+  getDocs,
+  increment,
+  query,
+  setDoc,
+  updateDoc,
+  where,
+} from "firebase/firestore";
+
+function getWeekdaysSinceYearStart() {
+  const start = new Date(new Date().getFullYear(), 0, 1);
+  const end = new Date();
+  let weekdays = 0;
+
+  for (let day = new Date(start); day <= end; day.setDate(day.getDate() + 1)) {
+    const weekday = day.getDay();
+    if (weekday >= 1 && weekday <= 5) {
+      weekdays += 1;
+    }
+  }
+
+  return Math.max(weekdays, 1);
+}
 
 /**
  * Initializes a new user's statistics in Firestore.
@@ -47,5 +72,44 @@ export const updateUserStat = async (userId, statField, value = 1) => {
     });
   } catch (error) {
     console.error(`Error updating ${statField}:`, error);
+  }
+};
+
+/**
+ * Recomputes attendance rate from persisted attendance_records.
+ * @param {string} userId - Firebase Auth user id.
+ */
+export const recalculateAttendanceRate = async (userId) => {
+  if (!userId || !db) {
+    return;
+  }
+
+  const statsRef = doc(db, "userStats", userId);
+  const attendanceQuery = query(
+    collection(db, "attendance_records"),
+    where("userId", "==", userId)
+  );
+
+  try {
+    const statsSnap = await getDoc(statsRef);
+    if (!statsSnap.exists()) {
+      await initializeUserStats(userId);
+    }
+
+    const attendanceSnap = await getDocs(attendanceQuery);
+    const presentDays = attendanceSnap.size;
+    const totalDays = getWeekdaysSinceYearStart();
+    const rate = Math.min(100, Math.round((presentDays / totalDays) * 100));
+
+    await updateDoc(statsRef, {
+      "Attendance Rate": `${rate}%`,
+      attendancePresentDays: presentDays,
+      lastUpdated: new Date(),
+    });
+
+    return rate;
+  } catch (error) {
+    console.error("Error recalculating attendance rate:", error);
+    throw error;
   }
 };


### PR DESCRIPTION
## Summary
- Save successful face matches to Firestore `attendance_records` (user, date, confidence)
- Prevent more than one check-in per calendar day
- Recalculate `Attendance Rate` in `userStats` after each new record
- Require the recognized face to match the signed-in user's email

Fixes #65