### PR TITLE
fix(navbar): use dynamic year in mobile menu footer

### DIFF
--- a/components/Navbar.js
+++ b/components/Navbar.js
@@ -623,7 +623,7 @@ export function Navbar() {
               )}
               <div className="text-center">
                 <p className="text-white/40 text-xs">
-                  © 2024 Learnova. All rights reserved.
+                  © {new Date().getFullYear()} Learnova. All rights reserved.
                 </p>
               </div>
             </div>


### PR DESCRIPTION
## Summary
- Replace hardcoded © 2024 in the mobile menu with `new Date().getFullYear()`

Fixes #97

## Test plan
- [ ] Open mobile nav menu — footer shows current year
- [ ] Matches main Footer copyright year