### PR TITLE
fix(contact): align displayed contact info with mailto/tel hrefs

### DIFF
--- a/app/contact/page.js
+++ b/app/contact/page.js
@@ -105,14 +105,14 @@ export default function Contact() {
     {
       icon: Mail,
       label: "Email",
-      value: "hello@learnova.com",
-      href: "mailto:hello@learnova.com",
+      value: "shawprem217@gmail.com",
+      href: "mailto:shawprem217@gmail.com",
       gradient: "from-blue-500 to-cyan-500",
     },
     {
       icon: Phone,
       label: "Phone",
-      value: "+91 81004 839XX",
+      value: "+91 93102 43800",
       href: "tel:+919310243800",
       gradient: "from-green-500 to-emerald-500",
     },


### PR DESCRIPTION
## Summary
- Align email display and `mailto:` href to shawprem217@gmail.com
- Align phone display with `tel:+919310243800`

Fixes #95

## Test plan
- [ ] Contact page email link opens correct address
- [ ] Phone link dials the number shown in the UI