### PR TITLE
fix(api): standardize JSON success and error responses

### DIFF
--- a/app/api/exceptions/all/route.js
+++ b/app/api/exceptions/all/route.js
@@ -1,6 +1,6 @@
 import { connectDb } from "@/lib/mongodb";
 import { verifyFirebaseToken } from "@/lib/firebase-admin";
-import { jsonError, jsonSuccess } from "@/lib/api-response";
+import { jsonError, jsonSuccess, jsonUnauthorized } from "@/lib/api-response";
 
 export async function GET(request) {
   try {
@@ -10,7 +10,7 @@ export async function GET(request) {
     const decodedToken = await verifyFirebaseToken(token);
 
     if (!decodedToken) {
-      return Response.json({ error: "Unauthorized" }, { status: 401 });
+      return jsonUnauthorized();
     }
 
     const db = await connectDb();
@@ -21,15 +21,9 @@ export async function GET(request) {
       .sort({ createdAt: -1 })
       .toArray();
 
-    return Response.json(
-      {
-        success: true,
-        data: exceptions,
-      },
-      { status: 200 },
-    );
+    return jsonSuccess(exceptions);
   } catch (error) {
     console.error("Exception fetch error:", error);
-    return Response.json({ error: "Internal server error" }, { status: 500 });
+    return jsonError("Internal server error", 500);
   }
 }

--- a/app/api/exceptions/create/route.js
+++ b/app/api/exceptions/create/route.js
@@ -1,6 +1,6 @@
 import { connectDb } from "@/lib/mongodb";
 import { verifyFirebaseToken } from "@/lib/firebase-admin";
-import { jsonError, jsonSuccess } from "@/lib/api-response";
+import { jsonError, jsonSuccess, jsonUnauthorized } from "@/lib/api-response";
 
 export async function POST(request) {
   try {
@@ -10,7 +10,7 @@ export async function POST(request) {
     const decodedToken = await verifyFirebaseToken(token);
 
     if (!decodedToken) {
-      return Response.json({ error: "Unauthorized" }, { status: 401 });
+      return jsonUnauthorized();
     }
 
     const body = await request.json();
@@ -28,16 +28,13 @@ export async function POST(request) {
 
     return jsonSuccess(
       {
-        success: true,
-        data: {
-          id: result.insertedId,
-          message: "Exception request created successfully",
-        },
+        id: result.insertedId,
+        message: "Exception request created successfully",
       },
-      { status: 201 },
+      201,
     );
   } catch (error) {
     console.error("Exception creation error:", error);
-    return Response.json({ error: "Internal server error" }, { status: 500 });
+    return jsonError("Internal server error", 500);
   }
 }

--- a/app/api/exceptions/list/route.js
+++ b/app/api/exceptions/list/route.js
@@ -1,6 +1,6 @@
 import { connectDb } from "@/lib/mongodb";
 import { verifyFirebaseToken } from "@/lib/firebase-admin";
-import { jsonError, jsonSuccess } from "@/lib/api-response";
+import { jsonError, jsonSuccess, jsonUnauthorized } from "@/lib/api-response";
 
 export async function GET(request) {
   try {
@@ -10,7 +10,7 @@ export async function GET(request) {
     const decodedToken = await verifyFirebaseToken(token);
 
     if (!decodedToken) {
-      return Response.json({ error: "Unauthorized" }, { status: 401 });
+      return jsonUnauthorized();
     }
 
     const db = await connectDb();
@@ -21,15 +21,9 @@ export async function GET(request) {
       .sort({ createdAt: -1 })
       .toArray();
 
-    return Response.json(
-      {
-        success: true,
-        data: exceptions,
-      },
-      { status: 200 },
-    );
+    return jsonSuccess(exceptions);
   } catch (error) {
     console.error("Exception fetch error:", error);
-    return Response.json({ error: "Internal server error" }, { status: 500 });
+    return jsonError("Internal server error", 500);
   }
 }

--- a/app/api/exceptions/update/route.js
+++ b/app/api/exceptions/update/route.js
@@ -1,7 +1,7 @@
 import { connectDb } from "@/lib/mongodb";
 import { verifyFirebaseToken } from "@/lib/firebase-admin";
 import { ObjectId } from "mongodb";
-import { jsonError, jsonSuccess } from "@/lib/api-response";
+import { jsonError, jsonSuccess, jsonUnauthorized } from "@/lib/api-response";
 
 export async function PUT(request) {
   try {
@@ -11,7 +11,7 @@ export async function PUT(request) {
     const decodedToken = await verifyFirebaseToken(token);
 
     if (!decodedToken) {
-      return Response.json({ error: "Unauthorized" }, { status: 401 });
+      return jsonUnauthorized();
     }
 
     const body = await request.json();
@@ -37,20 +37,14 @@ export async function PUT(request) {
     );
 
     if (result.matchedCount === 0) {
-      return Response.json({ error: "Exception not found" }, { status: 404 });
+      return jsonError("Exception not found", 404);
     }
 
-    return Response.json(
-      {
-        success: true,
-        data: {
-          message: "Exception updated successfully",
-        },
-      },
-      { status: 200 },
-    );
+    return jsonSuccess({
+      message: "Exception updated successfully",
+    });
   } catch (error) {
     console.error("Exception update error:", error);
-    return Response.json({ error: "Internal server error" }, { status: 500 });
+    return jsonError("Internal server error", 500);
   }
 }

--- a/app/api/labels/route.js
+++ b/app/api/labels/route.js
@@ -1,5 +1,5 @@
-import { NextResponse } from "next/server";
 import { connectDb } from "@/lib/mongodb";
+import { jsonError, jsonSuccess } from "@/lib/api-response";
 
 export async function GET() {
   try {
@@ -10,20 +10,9 @@ export async function GET() {
       .find({}, { projection: { _id: 0 } })
       .toArray();
 
-    return NextResponse.json(
-      {
-        success: true,
-        data: allUsers,
-      },
-      { status: 200 },
-    );
+    return jsonSuccess(allUsers);
   } catch (err) {
-    console.error("❌ Error fetching labels:", err);
-    return NextResponse.json(
-      {
-        error: "Failed to fetch labels",
-      },
-      { status: 500 },
-    );
+    console.error("Error fetching labels:", err);
+    return jsonError("Failed to fetch labels", 500);
   }
 }

--- a/app/api/register/route.js
+++ b/app/api/register/route.js
@@ -11,67 +11,45 @@ export async function POST(req) {
     const file = formData.get("photo");
 
     if (!name || !rollNo || !email || !file) {
-      return NextResponse.json(
-        {
-          error: "Name, rollNo, email, and photo are required",
-        },
-        { status: 400 },
-      );
+      return jsonError("Name, rollNo, email, and photo are required", 400);
     }
 
-    // Get DB
     const db = await connectDb();
     const users = db.collection("users");
 
-    // Check if user already registered
     const existingUser = await users.findOne({ rollNo });
     if (existingUser) {
-      return NextResponse.json(
-        { error: "User already registered with a photo" },
-        { status: 409 }, // conflict
-      );
+      return jsonError("User already registered with a photo", 409);
     }
 
-    // Convert file to buffer
     const arrayBuffer = await file.arrayBuffer();
     const buffer = Buffer.from(arrayBuffer);
 
-    // Generate unique filename
     const safeName = name.replace(/[^a-zA-Z0-9_-]/g, "_");
     const fileName = `labels/${safeName}/1.jpg`;
 
-    // Upload to Vercel Blob
     const blob = await put(fileName, buffer, {
       contentType: file.type || "image/jpeg",
       access: "public",
     });
 
-    // Save user record in DB
     const user = {
       name,
       rollNo,
       email,
-      image: blob.url, // only one photo allowed
+      image: blob.url,
     };
     await users.insertOne(user);
 
-    return NextResponse.json(
+    return jsonSuccess(
       {
-        success: true,
-        data: {
-          message: "User registered successfully",
-          user,
-        },
+        message: "User registered successfully",
+        user,
       },
-      { status: 201 },
+      201,
     );
   } catch (error) {
     console.error(error);
-    return NextResponse.json(
-      {
-        error: error.message || "Internal server error",
-      },
-      { status: 500 },
-    );
+    return jsonError(error.message || "Internal server error", 500);
   }
 }

--- a/lib/api-response.js
+++ b/lib/api-response.js
@@ -1,9 +1,13 @@
 import { NextResponse } from "next/server";
 
 export function jsonError(error, status = 500) {
-  return NextResponse.json({ error }, { status });
+  return NextResponse.json({ success: false, error }, { status });
 }
 
 export function jsonSuccess(data, status = 200) {
   return NextResponse.json({ success: true, data }, { status });
+}
+
+export function jsonUnauthorized(error = "Unauthorized") {
+  return jsonError(error, 401);
 }


### PR DESCRIPTION
## Summary
- Extends `lib/api-response` with `jsonUnauthorized` and `success: false` on errors
- Migrates register, labels, and exception API routes to shared helpers

Closes #15

## Test plan
- [ ] Register user — 201 `{ success: true, data: ... }`
- [ ] Validation errors return `{ success: false, error }` with correct status
- [ ] Unauthorized exception routes return 401 consistently