### PR TITLE
move groq calls server-side so the api key is not exposed

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -47,9 +47,9 @@ NEXT_PUBLIC_EMAILJS_USER_ID=your_emailjs_public_key
 # ========================================
 # AI/ML Services
 # ========================================
-# Groq API (for AI features)
+# Groq API (server-side only)
 # https://console.groq.com
-NEXT_PUBLIC_GROQ_API_KEY=your_groq_api_key_here
+GROQ_API_KEY=your_groq_api_key_here
 
 # ========================================
 # Optional: Development Settings

--- a/app/api/groq/route.js
+++ b/app/api/groq/route.js
@@ -1,0 +1,66 @@
+import { jsonError, jsonSuccess } from "@/lib/api-response";
+
+const GROQ_API_URL = "https://api.groq.com/openai/v1/chat/completions";
+const MAX_MESSAGE_LENGTH = 2000;
+
+export async function POST(request) {
+  try {
+    const { message, userMessage } = await request.json();
+    const rawMessage = typeof message === "string" ? message : userMessage;
+    const trimmedMessage = rawMessage?.trim();
+
+    if (!trimmedMessage) {
+      return jsonError("Message is required", 400);
+    }
+
+    if (trimmedMessage.length > MAX_MESSAGE_LENGTH) {
+      return jsonError("Message is too long", 400);
+    }
+
+    const apiKey = process.env.GROQ_API_KEY;
+    if (!apiKey) {
+      return jsonError("Groq API key is not configured", 500);
+    }
+
+    const response = await fetch(GROQ_API_URL, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        model: "llama-3.1-8b-instant",
+        messages: [
+          {
+            role: "system",
+            content:
+              "You are Nova, the friendly AI assistant for Learnova - a Smart Student Engagement Ecosystem. You help with questions about attendance automation, smart activities, security features, analytics, and educational technology. Always be helpful, informative, and encouraging. Keep responses concise but comprehensive.",
+          },
+          { role: "user", content: trimmedMessage },
+        ],
+        max_tokens: 400,
+        temperature: 0.7,
+      }),
+    });
+
+    if (!response.ok) {
+      const errorBody = await response.json().catch(() => ({}));
+      return jsonError(
+        errorBody?.error?.message || "Groq request failed",
+        response.status,
+      );
+    }
+
+    const data = await response.json();
+    const content = data?.choices?.[0]?.message?.content;
+
+    if (!content) {
+      return jsonError("Groq response was empty", 502);
+    }
+
+    return jsonSuccess({ message: content });
+  } catch (error) {
+    console.error("Groq API route error:", error);
+    return jsonError("Internal server error", 500);
+  }
+}

--- a/components/ChatBot.js
+++ b/components/ChatBot.js
@@ -47,10 +47,7 @@ const LearnovaChatbot = () => {
   const [inputMessage, setInputMessage] = useState("");
   const [isLoading, setIsLoading] = useState(false);
   const [currentCategory, setCurrentCategory] = useState("general");
-
-  // Get API key from environment variable
-  const apiKey = process.env.NEXT_PUBLIC_GROQ_API_KEY || "";
-  const hasApiKey = Boolean(apiKey);
+  const [isAiAvailable, setIsAiAvailable] = useState(false);
 
   const messagesEndRef = useRef(null);
 
@@ -280,43 +277,27 @@ const LearnovaChatbot = () => {
       return `🛟 **Support & Contact Information**\n\n📧 **Email:** ${contactInfo.email}\n📞 **Phone:** ${contactInfo.phone}\n🌐 **Website:** ${contactInfo.website}\n🎯 **Live Demo:** ${contactInfo.demo}\n\n**Support Options:**\n• 24/7 AI chatbot assistance\n• Live chat with technical team\n• Video call support sessions\n• Comprehensive documentation\n• Community forums\n• Training workshops\n\n**Response Times:**\n• General inquiries: Within 4 hours\n• Technical issues: Within 2 hours\n• Urgent/Critical: Within 30 minutes\n\nHow can I connect you with the right support channel?`;
     }
 
-    // API integration check - only if API key is available
-    if (hasApiKey) {
-      try {
-        const response = await fetch(
-          "https://api.groq.com/openai/v1/chat/completions",
-          {
-            method: "POST",
-            headers: {
-              Authorization: `Bearer ${apiKey}`,
-              "Content-Type": "application/json",
-            },
-            body: JSON.stringify({
-              model: "llama-3.1-8b-instant",
-              messages: [
-                {
-                  role: "system",
-                  content: `You are Nova, the friendly AI assistant for Learnova - a Smart Student Engagement Ecosystem. You help with questions about attendance automation, smart activities, security features, analytics, and educational technology. Always be helpful, informative, and encouraging. Keep responses concise but comprehensive.`,
-                },
-                { role: "user", content: userMessage },
-              ],
-              max_tokens: 400,
-              temperature: 0.7,
-            }),
-          }
-        );
+    // API integration check via server-side proxy
+    try {
+      const response = await fetch("/api/groq", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ message: userMessage }),
+      });
 
-        if (response.ok) {
-          const data = await response.json();
-          return (
-            data.choices[0]?.message?.content ||
-            "I'm here to help with Learnova!"
-          );
+      if (response.ok) {
+        const data = await response.json();
+        const aiMessage = data?.data?.message;
+        if (aiMessage) {
+          setIsAiAvailable(true);
+          return aiMessage;
         }
-      } catch (err) {
-        console.error("Groq API error:", err);
-        // Fall through to built-in responses
       }
+    } catch (err) {
+      console.error("Groq API error:", err);
+      // Fall through to built-in responses
     }
 
     // Enhanced fallback responses
@@ -552,7 +533,7 @@ const LearnovaChatbot = () => {
             <h3 className="font-bold text-lg">Nova AI</h3>
             <p className="text-xs opacity-90 flex items-center gap-1">
               <Sparkles size={10} />
-              Learnova Assistant {hasApiKey && "⚡"}
+              Learnova Assistant {isAiAvailable && "⚡"}
             </p>
           </div>
         </div>
@@ -786,7 +767,7 @@ const LearnovaChatbot = () => {
             </div>
             <div className="flex justify-between items-center mt-3">
               <div className="flex items-center space-x-2">
-                {hasApiKey && (
+                {isAiAvailable && (
                   <div className="flex items-center space-x-1 text-xs">
                     <div className="w-2 h-2 bg-green-500 rounded-full"></div>
                     <span


### PR DESCRIPTION
## What type of PR is this?

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [ ] 🎨 UI/UX improvement
- [ ] ⚡ Performance improvement
- [x] 🔒 Security fix

## Description

moved the groq request to a server api route and removed the public env key usage so the key is not visible in the browser.

## Related Issues

closes #119 

## Changes Made

- added a server api route that calls groq using a private env key
- updated the chatbot to call the new api route instead of groq directly
- updated env example to use a server-only groq key

## Testing

How did you test these changes?
- [x] Tested locally
- [x] Tested on mobile
- [x] Tested different user roles
- [x] All roles tested

## Screenshots (if applicable)

not applicable

## Checklist

- [x] No hardcoded secrets or credentials
- [x] `.env.local` is not committed
- [x] Code follows project style
- [x] Changes are documented
- [x] Build passes locally (`npm run build`)
- [x] No console errors/warnings