### PR TITLE
fix: align useLabels hook with /api/labels response shape

### DIFF
--- a/components/useLabels.js
+++ b/components/useLabels.js
@@ -16,7 +16,7 @@ export default function useLabels() {
         if (!data.success) {
           throw new Error(data.error || "Failed to fetch labels");
         }
-        setLabels(data.data?.labels ?? []);
+        setLabels(Array.isArray(data.data) ? data.data : []);
       } catch (err) {
         console.error(err);
         setError(err.message);


### PR DESCRIPTION
### Description
This PR resolves issue #114 where the face attendance functionality was failing and incorrectly showing "No Students Registered" despite data existing in the database.

The root cause was an API response parsing mismatch. As verified via the `/api/labels` endpoint, the server returns the student records as a direct array inside the `data` property:
`{"success": true, "data": [{ "name": "Ranjana", "rollNo": "23", ... }, ...]}`

The `useLabels` hook was incorrectly attempting to access `data.data?.labels`, which resulted in `undefined` and caused the fallback empty array to be used. This PR updates the hook to correctly identify and use the `data.data` array.

Closes #114

### Changes Made
- Updated the state initialization in `components/useLabels.js`.
- Changed `setLabels(data.data?.labels ?? [])` to `setLabels(Array.isArray(data.data) ? data.data : [])` to match the actual API response shape.


### Testing Done
- [x] Verified local API response at `/api/labels` returns the expected array format.
- [x] Confirmed the `/attendance` page successfully parses the array and displays the registered students.
