### PR TITLE
fix: replace native alert() with toast notification for password reset

### DIFF
--- a/app/auth/page.js
+++ b/app/auth/page.js
@@ -11,6 +11,7 @@ import AuthForm from "@/components/AuthForm";
 import HeroSection from "@/components/HeroSection";
 import ForgotPasswordModal from "@/components/ForgotPasswordModal";
 import ErrorBoundary from "@/components/ErrorBoundary";
+import toast from "react-hot-toast";
 
 // Services and Utils
 import {
@@ -185,7 +186,7 @@ export default function AuthPage() {
       const result = await resetPassword(emailToReset);
 
       if (result.success) {
-        alert("Password reset email sent! Check your inbox and spam folder.");
+        toast.success("Password reset email sent! Check your inbox and spam folder.");
         setShowForgotPassword(false);
         setForgotPasswordEmail("");
       } else {


### PR DESCRIPTION
Fixes #133

## Problem
A native browser alert() was used to confirm 
password reset email, which:
- Blocks the entire page
- Looks inconsistent with the app UI
- Cannot be styled to match the design

## Fix
Replaced alert() with react-hot-toast (already 
in the project dependencies) toast.success() 
notification for a better user experience.

## Tested
✅ Toast notification shows on successful password reset
✅ Consistent with rest of the UI
✅ No page blocking behavior