### PR TITLE
fix: replace browser alert with redirect to login page on protected routes

### DIFF
--- a/app/activity/page.js
+++ b/app/activity/page.js
@@ -26,6 +26,7 @@ import {
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Navbar } from "@/components/Navbar";
+import { useRouter } from "next/navigation";
 
 import { useAuth } from "@/hooks/useAuth";
 import { logActivity } from "@/services/activityService";
@@ -46,6 +47,7 @@ const Reveal = ({ children, className = "", delay = 0, y = 28 }) => (
 
 export default function ActivityPage() {
   const { user } = useAuth();
+  const router = useRouter();
   const [scrollY, setScrollY] = useState(0);
   const [mousePosition, setMousePosition] = useState({ x: 0, y: 0 });
   const [selectedCategory, setSelectedCategory] = useState("all");
@@ -225,7 +227,7 @@ export default function ActivityPage() {
 
   const handleStartActivity = async (activity) => {
     if (!user) {
-      alert("Please log in to track your learning progress!");
+      router.push("/auth");
       return;
     }
 


### PR DESCRIPTION
Closes #147

## Problem
When unauthenticated users click on activities, 
a native browser alert popup appears saying 
"Please log in to track your learning progress!"
This is poor UX.

## Fix
- Added useRouter from next/navigation
- Replaced alert() with router.push('/auth')
- User is now seamlessly redirected to login page

## Files Changed
- app/activity/page.js

## Testing
- [x] Tested on live site — alert confirmed
- [x] Fix redirects to /auth immediately