### PR TITLE
fix(ui): prevent duplicate ChatBot API calls on enter key press

### DIFF
--- a/components/ChatBot.js
+++ b/components/ChatBot.js
@@ -448,7 +448,9 @@ const LearnovaChatbot = () => {
   const handleKeyPress = (e) => {
     if (e.key === "Enter" && !e.shiftKey) {
       e.preventDefault();
-      handleSendMessage();
+      if (!isLoading && inputMessage.trim()) {
+        handleSendMessage();
+      }
     }
   };
 
@@ -746,8 +748,9 @@ const LearnovaChatbot = () => {
                   value={inputMessage}
                   onChange={(e) => setInputMessage(e.target.value)}
                   onKeyDown={handleKeyPress}
+                  disabled={isLoading}
                   placeholder="Ask Nova about Learnova..."
-                  className={`w-full px-4 py-3 border rounded-xl resize-none focus:outline-none focus:ring-2 focus:ring-purple-500 transition-all ${themeClasses.input}`}
+                  className={`w-full px-4 py-3 border rounded-xl resize-none focus:outline-none focus:ring-2 focus:ring-purple-500 transition-all disabled:opacity-50 disabled:cursor-not-allowed ${themeClasses.input}`}
                   rows="1"
                   onInput={(e) => {
                     e.target.style.height = "auto";


### PR DESCRIPTION
## What type of PR is this?

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [x] 🎨 UI/UX improvement
- [ ] ⚡ Performance improvement
- [ ] 🔒 Security fix

## Description
Fixed a UI loophole and race condition in the Nova AI ChatBot component where users could bypass the "Send" button's disabled state by pressing the Enter key while the bot was processing a response. 
Previously, this caused duplicate API requests to overlap and broke the chat history UI.Fixed a UI loophole and race condition in the Nova AI ChatBot component where users could bypass the "Send" button's disabled state by pressing the Enter key while the bot was processing a response. Previously, this caused duplicate API requests to overlap and broke the chat history UI.


## Related Issues

Closes #158 

## Changes Made

-Updated handleKeyPress to verify !isLoading and inputMessage.trim() before executing handleSendMessage().
-Added disabled={isLoading} state to the <textarea> to lock input during API processing.
-Added Tailwind utility classes (disabled:opacity-50 disabled:cursor-not-allowed) to the textarea so it visually matches the disabled state of the Send button.

## Testing

How did you test these changes?
- [x] Tested locally
- [ ] Tested on mobile
- [ ] Tested different user roles
- [ ] All roles tested

## Checklist

- [x] No hardcoded secrets or credentials
- [x] `.env.local` is not committed
- [x] Code follows project style
- [x] Changes are documented
- [x] Build passes locally (`npm run build`)
- [x] No console errors/warnings
