### PR TITLE
docs: add jsdoc comments to utils, lib, and services functions

### DIFF
--- a/lib/api-response.js
+++ b/lib/api-response.js
@@ -1,9 +1,27 @@
 import { NextResponse } from "next/server";
 
+/**
+ * Creates a JSON error response for Next.js API routes.
+ * @param {string|Object} error - The error message or object to include in the response body.
+ * @param {number} [status=500] - HTTP status code for the response.
+ * @returns {NextResponse} A Next.js JSON response with the error payload.
+ * @example
+ * return jsonError('User not found', 404);
+ * // Response body: { "error": "User not found" }
+ */
 export function jsonError(error, status = 500) {
   return NextResponse.json({ error }, { status });
 }
 
+/**
+ * Creates a JSON success response for Next.js API routes.
+ * @param {*} data - The data payload to include in the response body.
+ * @param {number} [status=200] - HTTP status code for the response.
+ * @returns {NextResponse} A Next.js JSON response with `success: true` and the data payload.
+ * @example
+ * return jsonSuccess({ user: { id: '123', name: 'Alice' } }, 201);
+ * // Response body: { "success": true, "data": { "user": { ... } } }
+ */
 export function jsonSuccess(data, status = 200) {
   return NextResponse.json({ success: true, data }, { status });
 }

--- a/lib/firebase-admin.js
+++ b/lib/firebase-admin.js
@@ -19,6 +19,14 @@ const initializeFirebase = () => {
   }
 };
 
+/**
+ * Verifies a Firebase ID token using the Firebase Admin SDK.
+ * @param {string} token - The Firebase ID token string to verify.
+ * @returns {Promise<Object|null>} The decoded token payload if valid, or null if verification fails.
+ * @example
+ * const decoded = await verifyFirebaseToken(idToken);
+ * if (decoded) console.log(decoded.uid);
+ */
 export const verifyFirebaseToken = async (token) => {
   try {
     initializeFirebase();

--- a/lib/mongodb.js
+++ b/lib/mongodb.js
@@ -2,6 +2,16 @@ import { MongoClient } from "mongodb";
 
 let client;
 
+/**
+ * Connects to MongoDB and returns the database instance.
+ * Reuses an existing connection via a global client promise to avoid
+ * opening multiple connections during hot-reload in development.
+ * @returns {Promise<import('mongodb').Db>} A MongoDB Db instance for the configured database.
+ * @throws {Error} If MONGODB_URI is missing or the connection fails.
+ * @example
+ * const db = await connectDb();
+ * const users = await db.collection('users').find().toArray();
+ */
 export async function connectDb() {
   if (!process.env.MONGODB_URI) {
     throw new Error('Invalid/Missing environment variable: "MONGODB_URI"');

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -2,9 +2,13 @@ import { clsx } from "clsx";
 import { twMerge } from "tailwind-merge";
 
 /**
- * Merges conditional Tailwind CSS class names into a single string.
- * @param {...string} inputs - The class names to be merged.
- * @returns {string} A merged Tailwind CSS class string.
+ * Merges conditional Tailwind CSS class names into a single deduplicated string.
+ * Uses clsx for conditional logic and tailwind-merge to resolve conflicting utilities.
+ * @param {...(string|string[]|Record<string,boolean>)} inputs - Class names or clsx-compatible values to merge.
+ * @returns {string} A single merged Tailwind CSS class string with conflicts resolved.
+ * @example
+ * cn('px-4 py-2', isActive && 'bg-blue-500', 'px-6');
+ * // 'py-2 bg-blue-500 px-6'  (px-4 overridden by px-6)
  */
 export function cn(...inputs) {
   return twMerge(clsx(inputs));

--- a/services/activityService.js
+++ b/services/activityService.js
@@ -2,9 +2,15 @@ import { db } from "@/lib/firebaseConfig";
 import { collection, addDoc, serverTimestamp } from "firebase/firestore";
 
 /**
- * Logs a new user activity to Firestore.
- * @param {string} userId - The unique ID of the user.
- * @param {Object} activityData - Data including title, type, and progress.
+ * Logs a new user activity entry to the Firestore `activities` collection.
+ * @param {string} userId - The unique ID of the user performing the activity.
+ * @param {Object} activityData - Activity details.
+ * @param {string} activityData.title - Human-readable title of the activity.
+ * @param {string} [activityData.type='course'] - Category of the activity (e.g. 'course', 'quiz').
+ * @param {number} [activityData.progress=0] - Completion progress as a percentage (0–100).
+ * @returns {Promise<void>} Resolves when the activity has been written to Firestore.
+ * @example
+ * await logActivity('user_abc123', { title: 'Intro to React', type: 'course', progress: 50 });
  */
 
 export const logActivity = async (userId, activityData) => {

--- a/services/attendanceService.js
+++ b/services/attendanceService.js
@@ -15,6 +15,14 @@ function getTodayKey() {
   return new Date().toISOString().slice(0, 10);
 }
 
+/**
+ * Checks whether a user has already recorded attendance for today.
+ * @param {string} userId - The Firebase Auth user ID to check.
+ * @returns {Promise<boolean>} True if the user has checked in today, false otherwise.
+ * @example
+ * const alreadyIn = await hasCheckedInToday('user_abc123');
+ * if (alreadyIn) console.log('Already checked in today');
+ */
 export async function hasCheckedInToday(userId) {
   if (!userId || !db) {
     return false;
@@ -31,6 +39,25 @@ export async function hasCheckedInToday(userId) {
   return snapshot.docs.some((docSnap) => docSnap.data().date === today);
 }
 
+/**
+ * Records a new attendance entry for a user if they have not already checked in today.
+ * Also triggers a recalculation of the user's overall attendance rate.
+ * @param {Object} params - Attendance parameters.
+ * @param {string} params.userId - The Firebase Auth user ID.
+ * @param {string} params.studentName - The student's full name.
+ * @param {string} params.email - The student's email address.
+ * @param {number} params.confidenceScore - Face-recognition confidence score (0 to 1).
+ * @returns {Promise<{alreadyRecorded: boolean}>} Object indicating whether attendance was already recorded for today.
+ * @throws {Error} If userId or db is unavailable.
+ * @example
+ * const result = await recordAttendance({
+ *   userId: 'user_abc123',
+ *   studentName: 'Alice Smith',
+ *   email: 'alice@example.com',
+ *   confidenceScore: 0.97,
+ * });
+ * // { alreadyRecorded: false }
+ */
 export async function recordAttendance({
   userId,
   studentName,

--- a/services/statsService.js
+++ b/services/statsService.js
@@ -27,8 +27,12 @@ function getWeekdaysSinceYearStart() {
 }
 
 /**
- * Initializes a new user's statistics in Firestore.
+ * Initializes a new user's statistics document in Firestore with default zero values.
  * @param {string} userId - The unique ID of the user.
+ * @returns {Promise<void>} Resolves when the stats document has been written.
+ * @example
+ * await initializeUserStats('user_abc123');
+ * // Creates { 'Courses Enrolled': 0, 'Attendance Rate': '0%', ... } in Firestore
  */
 export const initializeUserStats = async (userId) => {
   if (!userId) return;
@@ -50,10 +54,15 @@ export const initializeUserStats = async (userId) => {
 };
 
 /**
- * Increments a specific statistic for a user.
+ * Increments a specific statistic field for a user in Firestore.
+ * Creates the stats document first if it does not yet exist.
  * @param {string} userId - The unique ID of the user.
- * @param {string} statField - The name of the stat (must match dashboard labels).
- * @param {number} value - The amount to increment (default is 1).
+ * @param {string} statField - The stat field name (must match dashboard labels, e.g. 'Courses Enrolled').
+ * @param {number} [value=1] - The amount to increment; can be negative to decrement.
+ * @returns {Promise<void>} Resolves when the stat has been updated.
+ * @example
+ * await updateUserStat('user_abc123', 'Courses Enrolled', 1);
+ * await updateUserStat('user_abc123', 'Study Hours', 2);
  */
 export const updateUserStat = async (userId, statField, value = 1) => {
   if (!userId) return;
@@ -76,8 +85,14 @@ export const updateUserStat = async (userId, statField, value = 1) => {
 };
 
 /**
- * Recomputes attendance rate from persisted attendance_records.
- * @param {string} userId - Firebase Auth user id.
+ * Recomputes and persists a user's attendance rate as a percentage
+ * based on their attendance_records relative to total weekdays since the start of the year.
+ * @param {string} userId - The Firebase Auth user ID.
+ * @returns {Promise<number|undefined>} The calculated attendance percentage (0–100), or undefined on early return.
+ * @throws {Error} If the Firestore update fails.
+ * @example
+ * const rate = await recalculateAttendanceRate('user_abc123');
+ * console.log(rate); // e.g. 87
  */
 export const recalculateAttendanceRate = async (userId) => {
   if (!userId || !db) {

--- a/utils/passwordStrength.js
+++ b/utils/passwordStrength.js
@@ -6,7 +6,15 @@ const STRENGTH_LEVELS = [
 ];
 
 /**
- * Score password strength from 0–4 based on length, case, digit, and symbol.
+ * Scores a password's strength on a 0–4 scale based on length, case, digit, and symbol criteria.
+ * @param {string} [password=''] - The password string to evaluate.
+ * @returns {{ score: number, label: string, barClass: string, textClass: string }}
+ *   An object with a numeric score and Tailwind CSS classes for rendering a strength indicator.
+ * @example
+ * getPasswordStrength('Hello1!');
+ * // { score: 3, label: 'Strong', barClass: 'bg-yellow-500', textClass: 'text-yellow-400' }
+ * getPasswordStrength('');
+ * // { score: 0, label: 'Weak', barClass: 'bg-red-500', textClass: 'text-red-400' }
  */
 export function getPasswordStrength(password = "") {
   if (!password) {


### PR DESCRIPTION
## What type of PR is this?

- [x] 📚 Documentation

## Description

added jsdoc comments to all exported functions across `utils/`, `lib/`, and `services/` that were either fully undocumented or had incomplete comments. every function now has a description, `@param`, `@returns`, and `@example` tag. no logic was changed.

## Related Issues

Closes #191 

## Changes Made

- `lib/api-response.js` - added jsdoc to `jsonError` and `jsonSuccess`
- `lib/firebase-admin.js` - added jsdoc to `verifyFirebaseToken`
- `lib/mongodb.js` - added jsdoc to `connectDb`
- `lib/utils.js` - enhanced existing jsdoc on `cn` with `@example`
- `utils/passwordStrength.js` - replaced one-liner comment on `getPasswordStrength` with full jsdoc
- `services/attendanceService.js` - added jsdoc to `hasCheckedInToday` and `recordAttendance`
- `services/activityService.js` - enhanced existing jsdoc on `logActivity` with `@returns` and `@example`
- `services/statsService.js` - enhanced all three functions (`initializeUserStats`, `updateUserStat`, `recalculateAttendanceRate`) with `@returns` and `@example`

## Testing

- [x] tested locally
- documentation only, no logic changed, no runtime behavior affected

## Screenshots (if applicable)

n/a

## Checklist

- [x] no hardcoded secrets or credentials
- [x] `.env.local` is not committed
- [x] code follows project style
- [x] changes are documented
- [x] build passes locally (`npm run build`)
- [x] no console errors/warnings
