### PR TITLE
Fix: enforce email validation on registration- Enforce email format v…

### DIFF
--- a/app/api/register/route.js
+++ b/app/api/register/route.js
@@ -38,6 +38,10 @@ export async function POST(req) {
       return jsonError("Name, rollNo, email, and photo are required", 400);
     }
 
+    if (!EMAIL_PATTERN.test(email)) {
+      return jsonError("Invalid email address", 400);
+    }
+
     // Get DB
     const db = await connectDb();
     const users = db.collection("users");

--- a/components/_tests_/registerRoute.test.js
+++ b/components/_tests_/registerRoute.test.js
@@ -1,0 +1,101 @@
+import { POST } from "@/app/api/register/route";
+import { connectDb } from "@/lib/mongodb";
+import { put } from "@vercel/blob";
+
+jest.mock("next/server", () => ({
+  NextResponse: {
+    json: jest.fn().mockImplementation((body, init) => {
+      return {
+        status: init?.status || 200,
+        json: async () => body,
+        headers: new Map(),
+      };
+    }),
+  },
+}));
+
+jest.mock("@vercel/blob", () => ({
+  put: jest.fn(),
+}));
+
+jest.mock("@/lib/mongodb", () => ({
+  connectDb: jest.fn(),
+}));
+
+describe("POST /api/register - Email Validation Security Tests", () => {
+  let mockFindOne;
+  let mockInsertOne;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockFindOne = jest.fn();
+    mockInsertOne = jest.fn();
+
+    connectDb.mockResolvedValue({
+      collection: jest.fn().mockReturnValue({
+        findOne: mockFindOne,
+        insertOne: mockInsertOne,
+      }),
+    });
+
+    put.mockResolvedValue({ url: "https://example.com/blob.jpg" });
+  });
+
+  const mockFile = {
+    arrayBuffer: jest.fn().mockResolvedValue(new ArrayBuffer(8)),
+    type: "image/jpeg",
+  };
+
+  const createMockRequest = (data) => {
+    return {
+      formData: jest.fn().mockResolvedValue({
+        get: (key) => data[key],
+      }),
+    };
+  };
+
+  test("accepts valid email and registers user successfully", async () => {
+    mockFindOne.mockResolvedValue(null);
+    mockInsertOne.mockResolvedValue({ insertedId: "mock-id" });
+
+    const req = createMockRequest({
+      name: "John Doe",
+      rollNo: "123456",
+      email: "user+tag@domain.co.uk",
+      photo: mockFile,
+    });
+
+    const response = await POST(req);
+    const body = await response.json();
+
+    expect(response.status).toBe(201);
+    expect(body.success).toBe(true);
+    expect(body.data.user.email).toBe("user+tag@domain.co.uk");
+    expect(mockInsertOne).toHaveBeenCalled();
+  });
+
+  test.each([
+    ["invalid-email"],
+    ["test@domain"],
+    ["@domain.com"],
+    ["user@domain."],
+    ["user @domain.com"],
+    ["user@ domain.com"],
+  ])("rejects invalid email format '%s' with 400 Bad Request", async (invalidEmail) => {
+    const req = createMockRequest({
+      name: "John Doe",
+      rollNo: "123456",
+      email: invalidEmail,
+      photo: mockFile,
+    });
+
+    const response = await POST(req);
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.error).toBe("Invalid email address");
+    expect(mockInsertOne).not.toHaveBeenCalled();
+    expect(connectDb).not.toHaveBeenCalled(); // Validation must happen before DB connection or insertion
+  });
+});


### PR DESCRIPTION
## What type of PR is this?

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [ ] 🎨 UI/UX improvement
- [ ] ⚡ Performance improvement
- [x] 🔒 Security fix

## Description

Enforces the pre-declared `EMAIL_PATTERN` in the register endpoint to ensure only valid email formats are processed and stored in the database. Previously, the validation pattern was declared but not used, allowing invalid emails to bypass verification.

## Related Issues

Closes #167

## Changes Made

- Integrated `EMAIL_PATTERN.test(email)` check in `app/api/register/route.js` to reject invalid email formats.
- Set up an early rejection with a `400 Bad Request` and message `"Invalid email address"` if validation fails, preventing any file upload or database operations.
- Created `components/_tests_/registerRoute.test.js` to add comprehensive Jest unit tests covering valid emails (like sub-addressed emails e.g. `user+tag@domain.co.uk`) and multiple invalid formats.
- Verified in the test suite that validation occurs before database insertion.

## Testing

How did you test these changes?
- [x] Tested locally
- [ ] Tested on mobile
- [ ] Tested different user roles
- [ ] All roles tested

## Screenshots (if applicable)

N/A (Backend API validation and test suite enhancements)

## Checklist

- [x] No hardcoded secrets or credentials
- [x] `.env.local` is not committed
- [x] Code follows project style
- [x] Changes are documented
- [x] Build passes locally (`npm run build`)
- [x] No console errors/warnings