### PR TITLE
perf: implement pagination for exceptions APIs

### DIFF
--- a/app/api/exceptions/all/route.js
+++ b/app/api/exceptions/all/route.js
@@ -25,15 +25,35 @@ export async function GET(request) {
       return jsonError("Forbidden", 403);
     }
 
-    const db = await connectDb();
+    const { searchParams } = new URL(request.url);
+    const page = Math.max(1, parseInt(searchParams.get("page") || "1", 10));
+    const limit = Math.min(100, Math.max(1, parseInt(searchParams.get("limit") || "20", 10)));
+    const skip = (page - 1) * limit;
 
-    const exceptions = await db
-      .collection("exceptions")
+    const db = await connectDb();
+    const collection = db.collection("exceptions");
+
+    // Fetch total document count
+    const total = await collection.countDocuments({});
+
+    const exceptions = await collection
       .find({})
       .sort({ createdAt: -1 })
+      .skip(skip)
+      .limit(limit)
       .toArray();
 
-    return jsonSuccess(exceptions, 200);
+    const totalPages = Math.ceil(total / limit);
+
+    return jsonSuccess({
+      exceptions,
+      pagination: {
+        total,
+        page,
+        limit,
+        totalPages,
+      },
+    }, 200);
   } catch (error) {
     console.error("Exception fetch error:", error);
     return jsonError("Internal server error", 500);

--- a/app/api/exceptions/list/route.js
+++ b/app/api/exceptions/list/route.js
@@ -13,15 +13,36 @@ export async function GET(request) {
       return jsonError("Unauthorized", 401);
     }
 
-    const db = await connectDb();
+    const { searchParams } = new URL(request.url);
+    const page = Math.max(1, parseInt(searchParams.get("page") || "1", 10));
+    const limit = Math.min(100, Math.max(1, parseInt(searchParams.get("limit") || "20", 10)));
+    const skip = (page - 1) * limit;
 
-    const exceptions = await db
-      .collection("exceptions")
-      .find({ status: "pending" })
+    const db = await connectDb();
+    const collection = db.collection("exceptions");
+    const query = { status: "pending" };
+
+    // Fetch total document count under query
+    const total = await collection.countDocuments(query);
+
+    const exceptions = await collection
+      .find(query)
       .sort({ createdAt: -1 })
+      .skip(skip)
+      .limit(limit)
       .toArray();
 
-    return jsonSuccess(exceptions, 200);
+    const totalPages = Math.ceil(total / limit);
+
+    return jsonSuccess({
+      exceptions,
+      pagination: {
+        total,
+        page,
+        limit,
+        totalPages,
+      },
+    }, 200);
   } catch (error) {
     console.error("Exception fetch error:", error);
     return jsonError("Internal server error", 500);


### PR DESCRIPTION
### Description

This Pull Request addresses a high-severity scalability and performance issue in the exceptions retrieval APIs. Currently, both the `/api/exceptions/all` and `/api/exceptions/list` endpoints query the entire MongoDB collection directly into memory using unrestricted `find({}).toArray()` calls. As the database scales in production, this causes massive network payloads, significant server CPU usage, and high risks of Out of Memory (OOM) backend crashes.


Closes #217 
### Changes Implemented

1. **Added Bounded Offset Pagination**: Integrated pagination support based on `page` and `limit` query parameters parsed directly from the incoming request URL.
2. **Applied Bounded Safeguards**: Implemented safe bounds using `Math.min` and `Math.max` to guarantee a default limit of `20`, a maximum page limit of `100`, and a minimum page index of `1`.
3. **Optimized Collection Queries**: Replaced unrestricted `.toArray()` calls with efficient cursor modifiers `.skip(skip)` and `.limit(limit)` to fetch only the requested slice of documents.
4. **Added Metadata Calculation**: Queried the database via `.countDocuments()` to compute the total matching records (`total`) and calculate the aggregate number of pages (`totalPages`).
5. **Returned Standard Schema**: Structured the API response payload to include a standard `pagination` metadata object alongside the paginated `exceptions` array inside `jsonSuccess`.
6. **Preserved Access Controls**: Left the existing Firebase authentication boundaries and role check restrictions (for admin and teacher access) fully intact.

### Verification & Testing

- **Default Pagination Test**: Queried `/api/exceptions/all` without query parameters. Verified it returned the first 20 records along with correct default pagination metadata.
- **Custom Bounded Page Test**: Queried `/api/exceptions/all?page=2&limit=5`. Verified the API accurately retrieved page 2 with a slice size of 5 records and returned correct `total` and `totalPages` calculations.
- **Limit Safeguard boundary Test**: Queried `/api/exceptions/all?limit=150&page=-5`. Verified the bounds capped the limit back down to `100` and normalized the page to `1`.

### Checklist

- [x] High-severity performance bottleneck fixed and kept minimal.
- [x] Avoided unrelated refactors or file modifications.
- [x] Enforced safe query bounds to prevent memory leaks and payload bloat.
- [x] All routes handle potential parsing errors gracefully.
