### PR TITLE
Feature/security allowed image types 166

### DIFF
--- a/app/api/register/route.js
+++ b/app/api/register/route.js
@@ -43,7 +43,7 @@ export async function POST(req) {
     }
 
     if (file.size > MAX_FILE_SIZE) {
-      return jsonError("File size exceeds 5MB limit", 400);
+      return jsonError("File too large. Max size is 5MB.", 413);
     }
 
     if (!ALLOWED_IMAGE_TYPES.has(file.type)) {

--- a/app/api/register/route.js
+++ b/app/api/register/route.js
@@ -14,6 +14,38 @@ const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 const normalizeText = (value) =>
   typeof value === "string" ? value.trim() : "";
 
+const isValidImageMagicBytes = async (file) => {
+  try {
+    if (typeof file.slice !== "function") return null;
+    const headerBuffer = await file.slice(0, 12).arrayBuffer();
+    const arr = new Uint8Array(headerBuffer);
+    if (arr.length < 4) return null;
+
+    // Check PNG: 89 50 4E 47
+    if (arr[0] === 0x89 && arr[1] === 0x50 && arr[2] === 0x4e && arr[3] === 0x47) {
+      return "image/png";
+    }
+
+    // Check JPEG: FF D8 FF
+    if (arr[0] === 0xff && arr[1] === 0xd8 && arr[2] === 0xff) {
+      return "image/jpeg";
+    }
+
+    // Check WebP: RIFF (bytes 0-3) and WEBP (bytes 8-11)
+    if (
+      arr[0] === 0x52 && arr[1] === 0x49 && arr[2] === 0x46 && arr[3] === 0x46 &&
+      arr.length >= 12 &&
+      arr[8] === 0x57 && arr[9] === 0x45 && arr[10] === 0x42 && arr[11] === 0x50
+    ) {
+      return "image/webp";
+    }
+
+    return null;
+  } catch (err) {
+    return null;
+  }
+};
+
 const getImageExtension = (mimeType) => {
   switch (mimeType) {
     case "image/png":
@@ -38,6 +70,10 @@ export async function POST(req) {
       return jsonError("Name, rollNo, email, and photo are required", 400);
     }
 
+    if (typeof file.arrayBuffer !== "function" || typeof file.slice !== "function") {
+      return jsonError("Invalid file upload. Photo must be a valid image file.", 400);
+    }
+
     if (!EMAIL_PATTERN.test(email)) {
       return jsonError("Invalid email address", 400);
     }
@@ -48,6 +84,11 @@ export async function POST(req) {
 
     if (!ALLOWED_IMAGE_TYPES.has(file.type)) {
       return jsonError("Invalid file type. Only JPEG, PNG, and WebP images are allowed.", 400);
+    }
+
+    const detectedMimeType = await isValidImageMagicBytes(file);
+    if (!detectedMimeType || detectedMimeType !== file.type) {
+      return jsonError("Invalid file content. The file headers do not match the expected image format.", 400);
     }
 
     // Get DB

--- a/components/_tests_/registerRoute.test.js
+++ b/components/_tests_/registerRoute.test.js
@@ -22,7 +22,7 @@ jest.mock("@/lib/mongodb", () => ({
   connectDb: jest.fn(),
 }));
 
-describe("POST /api/register - Email Validation Security Tests", () => {
+describe("POST /api/register - Security & Validation Tests", () => {
   let mockFindOne;
   let mockInsertOne;
 
@@ -45,6 +45,7 @@ describe("POST /api/register - Email Validation Security Tests", () => {
   const mockFile = {
     arrayBuffer: jest.fn().mockResolvedValue(new ArrayBuffer(8)),
     type: "image/jpeg",
+    size: 1024,
   };
 
   const createMockRequest = (data) => {
@@ -97,5 +98,51 @@ describe("POST /api/register - Email Validation Security Tests", () => {
     expect(body.error).toBe("Invalid email address");
     expect(mockInsertOne).not.toHaveBeenCalled();
     expect(connectDb).not.toHaveBeenCalled(); // Validation must happen before DB connection or insertion
+  });
+
+  test("rejects request if file size exceeds MAX_FILE_SIZE (5MB)", async () => {
+    const oversizedFile = {
+      ...mockFile,
+      size: 6 * 1024 * 1024, // 6MB
+    };
+
+    const req = createMockRequest({
+      name: "John Doe",
+      rollNo: "123456",
+      email: "user@domain.com",
+      photo: oversizedFile,
+    });
+
+    const response = await POST(req);
+    const body = await response.json();
+
+    expect(response.status).toBe(413);
+    expect(body.error).toContain("File too large");
+    expect(mockInsertOne).not.toHaveBeenCalled();
+    expect(connectDb).not.toHaveBeenCalled(); // Validation must happen before DB connection or insertion
+  });
+
+  test("accepts request if file size is exactly at the limit (5MB)", async () => {
+    mockFindOne.mockResolvedValue(null);
+    mockInsertOne.mockResolvedValue({ insertedId: "mock-id" });
+
+    const limitFile = {
+      ...mockFile,
+      size: 5 * 1024 * 1024, // 5MB
+    };
+
+    const req = createMockRequest({
+      name: "John Doe",
+      rollNo: "123456",
+      email: "user@domain.com",
+      photo: limitFile,
+    });
+
+    const response = await POST(req);
+    const body = await response.json();
+
+    expect(response.status).toBe(201);
+    expect(body.success).toBe(true);
+    expect(mockInsertOne).toHaveBeenCalled();
   });
 });

--- a/components/_tests_/registerRoute.test.js
+++ b/components/_tests_/registerRoute.test.js
@@ -42,11 +42,20 @@ describe("POST /api/register - Security & Validation Tests", () => {
     put.mockResolvedValue({ url: "https://example.com/blob.jpg" });
   });
 
-  const mockFile = {
-    arrayBuffer: jest.fn().mockResolvedValue(new ArrayBuffer(8)),
-    type: "image/jpeg",
-    size: 1024,
+  const createMockFile = (mimeType, size, magicBytes = []) => {
+    const buffer = new Uint8Array(magicBytes.concat(new Array(Math.max(0, 12 - magicBytes.length)).fill(0))).buffer;
+    const mockFileObj = {
+      type: mimeType,
+      size: size,
+      arrayBuffer: jest.fn().mockResolvedValue(buffer),
+      slice: jest.fn().mockReturnValue({
+        arrayBuffer: jest.fn().mockResolvedValue(buffer),
+      }),
+    };
+    return mockFileObj;
   };
+
+  const mockFile = createMockFile("image/jpeg", 1024, [0xff, 0xd8, 0xff]);
 
   const createMockRequest = (data) => {
     return {
@@ -144,5 +153,101 @@ describe("POST /api/register - Security & Validation Tests", () => {
     expect(response.status).toBe(201);
     expect(body.success).toBe(true);
     expect(mockInsertOne).toHaveBeenCalled();
+  });
+
+  test("accepts valid PNG image upload successfully", async () => {
+    mockFindOne.mockResolvedValue(null);
+    mockInsertOne.mockResolvedValue({ insertedId: "mock-id" });
+
+    const pngFile = createMockFile("image/png", 2048, [0x89, 0x50, 0x4e, 0x47]);
+
+    const req = createMockRequest({
+      name: "John Doe",
+      rollNo: "123456",
+      email: "user@domain.com",
+      photo: pngFile,
+    });
+
+    const response = await POST(req);
+    const body = await response.json();
+
+    expect(response.status).toBe(201);
+    expect(body.success).toBe(true);
+  });
+
+  test("accepts valid WebP image upload successfully", async () => {
+    mockFindOne.mockResolvedValue(null);
+    mockInsertOne.mockResolvedValue({ insertedId: "mock-id" });
+
+    const webpFile = createMockFile("image/webp", 2048, [
+      0x52, 0x49, 0x46, 0x46, // "RIFF"
+      0, 0, 0, 0,
+      0x57, 0x45, 0x42, 0x50  // "WEBP"
+    ]);
+
+    const req = createMockRequest({
+      name: "John Doe",
+      rollNo: "123456",
+      email: "user@domain.com",
+      photo: webpFile,
+    });
+
+    const response = await POST(req);
+    const body = await response.json();
+
+    expect(response.status).toBe(201);
+    expect(body.success).toBe(true);
+  });
+
+  test("rejects request if file is not a valid File object (e.g. string)", async () => {
+    const req = createMockRequest({
+      name: "John Doe",
+      rollNo: "123456",
+      email: "user@domain.com",
+      photo: "not-a-file-object",
+    });
+
+    const response = await POST(req);
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.error).toContain("must be a valid image file");
+    expect(mockInsertOne).not.toHaveBeenCalled();
+  });
+
+  test("rejects request if MIME type is not allowed (e.g. application/zip)", async () => {
+    const zipFile = createMockFile("application/zip", 1024, [0x50, 0x4b, 0x03, 0x04]);
+
+    const req = createMockRequest({
+      name: "John Doe",
+      rollNo: "123456",
+      email: "user@domain.com",
+      photo: zipFile,
+    });
+
+    const response = await POST(req);
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.error).toContain("Only JPEG, PNG, and WebP images are allowed");
+    expect(mockInsertOne).not.toHaveBeenCalled();
+  });
+
+  test("rejects request if MIME type is spoofed (e.g. EXE file named as PNG)", async () => {
+    const exeFile = createMockFile("image/png", 1024, [0x4d, 0x5a]);
+
+    const req = createMockRequest({
+      name: "John Doe",
+      rollNo: "123456",
+      email: "user@domain.com",
+      photo: exeFile,
+    });
+
+    const response = await POST(req);
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.error).toContain("headers do not match the expected image format");
+    expect(mockInsertOne).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
- Verify file MIME type matches allowed image types

- Verify file magic bytes match the expected signature

- Reject invalid and spoofed image uploads with 400 status

- Add unit tests for valid PNG/WebP, invalid, and spoofed files

- Closes #166

## What type of PR is this?

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [ ] 🎨 UI/UX improvement
- [ ] ⚡ Performance improvement
- [x] 🔒 Security fix

## Description

Validate the client-provided MIME type of user photos (`file.type`) and inspect the file headers (magic bytes) on the server to prevent attackers from bypassing extension limits by renaming files (e.g. renaming an executable to `.png`). Supported formats are PNG, JPEG, and WebP. 

Added automated test cases covering valid PNG, WebP, invalid formats (like `.zip`), and spoofed files (like `.exe` renamed as `.png`).

## Related Issues

Closes #166

## Changes Made

- Added helper function `isValidImageMagicBytes` to parse the file's first 12 bytes and check for PNG, JPEG, and WebP magic byte headers.
- Enforced MIME type checks against `ALLOWED_IMAGE_TYPES` and matched them against the parsed magic bytes.
- Returns a `400 Bad Request` with a clear explanation of allowed file formats when the check fails.
- Modified tests in `registerRoute.test.js` to mock `.slice()` and custom magic bytes on the file buffer.
- Added test coverage for invalid, spoofed, and valid PNG/WebP upload scenarios.

## Testing

How did you test these changes?
- [x] Tested locally
- [ ] Tested on mobile
- [ ] Tested different user roles
- [x] All roles tested

## Screenshots (if applicable)

*N/A (Backend logic changes)*

## Checklist

- [x] No hardcoded secrets or credentials
- [x] `.env.local` is not committed
- [x] Code follows project style
- [x] Changes are documented
- [x] Build passes locally (`npm run build`)
- [x] No console errors/warnings