### PR TITLE
Fix: enforce token authentication, email matching authorization, and …

### DIFF
--- a/app/api/register/route.js
+++ b/app/api/register/route.js
@@ -2,6 +2,11 @@ import { put } from "@vercel/blob";
 import { randomUUID } from "crypto";
 import { connectDb } from "@/lib/mongodb";
 import { jsonError, jsonSuccess } from "@/lib/api-response";
+import { verifyFirebaseToken } from "@/lib/firebase-admin";
+
+export const rateLimitMap = new Map();
+const RATE_LIMIT_WINDOW = 60 * 1000; // 1 minute
+const MAX_ATTEMPTS = 5;
 
 const MAX_FILE_SIZE = 5 * 1024 * 1024;
 const ALLOWED_IMAGE_TYPES = new Set([
@@ -40,6 +45,34 @@ export async function POST(req) {
 
     if (!EMAIL_PATTERN.test(email)) {
       return jsonError("Invalid email address", 400);
+    }
+
+    // Rate Limiting Check
+    const ip = req.headers.get("x-forwarded-for") || "127.0.0.1";
+    const now = Date.now();
+    if (!rateLimitMap.has(ip)) {
+      rateLimitMap.set(ip, []);
+    }
+    const attempts = rateLimitMap.get(ip).filter((timestamp) => now - timestamp < RATE_LIMIT_WINDOW);
+    attempts.push(now);
+    rateLimitMap.set(ip, attempts);
+
+    if (attempts.length > MAX_ATTEMPTS) {
+      console.warn(`[Rate Limit] Registration rate limit exceeded for IP: ${ip} at ${new Date(now).toISOString()}`);
+      return jsonError("Too many registration attempts. Please try again later.", 429);
+    }
+
+    // Token Authentication & Authorization Check
+    const authorization = req.headers.get("authorization");
+    const token = authorization?.split(" ")[1];
+    const decodedToken = await verifyFirebaseToken(token);
+
+    if (!decodedToken) {
+      return jsonError("Unauthorized", 401);
+    }
+
+    if (decodedToken.email !== email) {
+      return jsonError("Forbidden: You can only register using your authenticated email.", 403);
     }
 
     // Get DB

--- a/components/_tests_/registerRoute.test.js
+++ b/components/_tests_/registerRoute.test.js
@@ -1,6 +1,7 @@
-import { POST } from "@/app/api/register/route";
+import { POST, rateLimitMap } from "@/app/api/register/route";
 import { connectDb } from "@/lib/mongodb";
 import { put } from "@vercel/blob";
+import { verifyFirebaseToken } from "@/lib/firebase-admin";
 
 jest.mock("next/server", () => ({
   NextResponse: {
@@ -22,12 +23,25 @@ jest.mock("@/lib/mongodb", () => ({
   connectDb: jest.fn(),
 }));
 
-describe("POST /api/register - Email Validation Security Tests", () => {
+jest.mock("@/lib/firebase-admin", () => ({
+  verifyFirebaseToken: jest.fn(),
+}));
+
+describe("POST /api/register - Authentication & Validation Security Tests", () => {
   let mockFindOne;
   let mockInsertOne;
 
   beforeEach(() => {
     jest.clearAllMocks();
+
+    if (rateLimitMap) {
+      rateLimitMap.clear();
+    }
+
+    verifyFirebaseToken.mockImplementation(async (token) => {
+      if (!token || token === "invalid-token") return null;
+      return { uid: "mock-uid", email: token };
+    });
 
     mockFindOne = jest.fn();
     mockInsertOne = jest.fn();
@@ -47,8 +61,21 @@ describe("POST /api/register - Email Validation Security Tests", () => {
     type: "image/jpeg",
   };
 
-  const createMockRequest = (data) => {
+  const createMockRequest = (data, tokenVal) => {
+    const emailVal = data.email;
+    const authHeader = tokenVal !== undefined ? (tokenVal ? `Bearer ${tokenVal}` : "") : `Bearer ${emailVal}`;
     return {
+      headers: {
+        get: jest.fn().mockImplementation((name) => {
+          if (name.toLowerCase() === "authorization") {
+            return authHeader;
+          }
+          if (name.toLowerCase() === "x-forwarded-for") {
+            return data.ip || "127.0.0.1";
+          }
+          return null;
+        }),
+      },
       formData: jest.fn().mockResolvedValue({
         get: (key) => data[key],
       }),
@@ -97,5 +124,83 @@ describe("POST /api/register - Email Validation Security Tests", () => {
     expect(body.error).toBe("Invalid email address");
     expect(mockInsertOne).not.toHaveBeenCalled();
     expect(connectDb).not.toHaveBeenCalled(); // Validation must happen before DB connection or insertion
+  });
+
+  test("rejects request if Authorization header is missing (401)", async () => {
+    const req = createMockRequest({
+      name: "John Doe",
+      rollNo: "123456",
+      email: "user@domain.com",
+      photo: mockFile,
+    }, ""); // empty token
+
+    const response = await POST(req);
+    const body = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(body.error).toBe("Unauthorized");
+    expect(mockInsertOne).not.toHaveBeenCalled();
+  });
+
+  test("rejects request if Firebase token is invalid (401)", async () => {
+    const req = createMockRequest({
+      name: "John Doe",
+      rollNo: "123456",
+      email: "user@domain.com",
+      photo: mockFile,
+    }, "invalid-token");
+
+    const response = await POST(req);
+    const body = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(body.error).toBe("Unauthorized");
+    expect(mockInsertOne).not.toHaveBeenCalled();
+  });
+
+  test("rejects request if authenticated email does not match requested email (403)", async () => {
+    const req = createMockRequest({
+      name: "John Doe",
+      rollNo: "123456",
+      email: "user@domain.com",
+      photo: mockFile,
+    }, "different-user@domain.com");
+
+    const response = await POST(req);
+    const body = await response.json();
+
+    expect(response.status).toBe(403);
+    expect(body.error).toContain("Forbidden");
+    expect(mockInsertOne).not.toHaveBeenCalled();
+  });
+
+  test("rate limits requests if more than MAX_ATTEMPTS (5) per IP are made (429)", async () => {
+    mockFindOne.mockResolvedValue(null);
+    mockInsertOne.mockResolvedValue({ insertedId: "mock-id" });
+
+    // Send 5 successful requests
+    for (let i = 0; i < 5; i++) {
+      const req = createMockRequest({
+        name: "John Doe",
+        rollNo: `12345${i}`,
+        email: "user@domain.com",
+        photo: mockFile,
+      });
+      const response = await POST(req);
+      expect(response.status).toBe(201);
+    }
+
+    // 6th request from the same IP should trigger 429
+    const req6 = createMockRequest({
+      name: "John Doe",
+      rollNo: "123456",
+      email: "user@domain.com",
+      photo: mockFile,
+    });
+    const response6 = await POST(req6);
+    const body6 = await response6.json();
+
+    expect(response6.status).toBe(429);
+    expect(body6.error).toContain("Too many registration attempts");
   });
 });

--- a/components/register.js
+++ b/components/register.js
@@ -68,8 +68,15 @@ export default function RegisterPage() {
     }
 
     try {
+      const token = await user?.getIdToken();
+      const headers = {};
+      if (token) {
+        headers["Authorization"] = `Bearer ${token}`;
+      }
+
       const res = await fetch("/api/register", {
         method: "POST",
+        headers,
         body: formData,
       });
 


### PR DESCRIPTION
## What type of PR is this?

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [ ] 🎨 UI/UX improvement
- [ ] ⚡ Performance improvement
- [x] 🔒 Security fix

## Description

Enforces token-based authentication, user identity authorization, and client IP rate-limiting on the registration API endpoint (`/api/register`). This mitigates automated spam, fake profile registration, and unauthorized face image collection.

## Related Issues

Closes #170

## Changes Made

- **Firebase ID Token Verification**: Validates that incoming registration requests carry a valid Firebase ID token in the `Authorization: Bearer <token>` header, rejecting requests with `401 Unauthorized` if invalid or missing.
- **Identity Authorization**: Asserts that the registration form `email` matches the authenticated `email` from the decoded token, returning `403 Forbidden` on mismatch.
- **Client IP Rate Limiting**: Capped registration dispatches at a limit of 5 requests per minute per client IP, returning a `429 Too Many Requests` status when exceeded.
- **Frontend Integration**: Integrated `user.getIdToken()` into `components/register.js` to automatically forward the user's bearer token.
- **Test Suite Updates**: Added new Jest unit tests validating missing headers, invalid tokens, mismatched emails, and rate limit exhaustion.

## Testing

How did you test these changes?
- [x] Tested locally (Ran `npm test` - all 44 unit tests passed successfully)
- [x] Verified local production build compiles successfully via `npm run build`

### Test Suite Output
```bash
PASS components/_tests_/AuthForm.test.js
PASS components/_tests_/registerRoute.test.js
PASS components/_tests_/authUtils.test.js
PASS components/_tests_/formValidation.test.js

Test Suites: 4 passed, 4 total