### PR TITLE
Fix: require token authentication, limit payload fields, and rate lim…

### DIFF
--- a/app/api/labels/route.js
+++ b/app/api/labels/route.js
@@ -2,11 +2,30 @@ import { connectDb } from "@/lib/mongodb";
 import { verifyFirebaseToken } from "@/lib/firebase-admin";
 import { jsonError, jsonSuccess } from "@/lib/api-response";
 
+export const rateLimitMap = new Map();
+const RATE_LIMIT_WINDOW = 60 * 1000; // 1 minute
+const MAX_ATTEMPTS = 10;
+
 export async function GET(request) {
   try {
+    // Rate Limiting Check
+    const ip = request.headers.get("x-forwarded-for") || "127.0.0.1";
+    const now = Date.now();
+    if (!rateLimitMap.has(ip)) {
+      rateLimitMap.set(ip, []);
+    }
+    const attempts = rateLimitMap.get(ip).filter((timestamp) => now - timestamp < RATE_LIMIT_WINDOW);
+    attempts.push(now);
+    rateLimitMap.set(ip, attempts);
+
+    if (attempts.length > MAX_ATTEMPTS) {
+      console.warn(`[Rate Limit] Labels fetch rate limit exceeded for IP: ${ip} at ${new Date(now).toISOString()}`);
+      return jsonError("Too many attempts. Please try again later.", 429);
+    }
+
+    // Token Authentication Check
     const authorization = request.headers.get("authorization");
     const token = authorization?.split(" ")[1];
-
     const decodedToken = await verifyFirebaseToken(token);
 
     if (!decodedToken) {
@@ -17,7 +36,7 @@ export async function GET(request) {
     const users = db.collection("users");
 
     const allUsers = await users
-      .find({}, { projection: { _id: 0 } })
+      .find({}, { projection: { _id: 0, name: 1, email: 1, image: 1 } })
       .toArray();
 
     return jsonSuccess(allUsers, 200);

--- a/app/attendance/page.js
+++ b/app/attendance/page.js
@@ -13,8 +13,8 @@ const FaceRecognizer = dynamic(() => import("@/components/FaceRecognizer"), {
 });
 
 const AttendancePage = () => {
-  const { labels, loading: labelsLoading, error: labelsError } = useLabels();
   const { user, loading: authLoading } = useAuth();
+  const { labels, loading: labelsLoading, error: labelsError } = useLabels(user);
   const router = useRouter();
   const [currentStep, setCurrentStep] = useState("validation"); // 'validation' or 'recognition'
   const [validationComplete, setValidationComplete] = useState(false);

--- a/components/FaceRecognizer.js
+++ b/components/FaceRecognizer.js
@@ -14,7 +14,7 @@ const MIN_CONFIDENCE_TO_RECORD = 60;
 export default function FaceRecognizer({ authUser }) {
   const videoRef = useRef(null);
   const canvasRef = useRef(null);
-  const { labels: fetchedLabels, loading: labelsLoading, error } = useLabels();
+  const { labels: fetchedLabels, loading: labelsLoading, error } = useLabels(authUser);
 
   const [message, setMessage] = useState("Loading models...");
   const [finished, setFinished] = useState(false);

--- a/components/_tests_/labelsRoute.test.js
+++ b/components/_tests_/labelsRoute.test.js
@@ -1,0 +1,128 @@
+import { GET, rateLimitMap } from "@/app/api/labels/route";
+import { connectDb } from "@/lib/mongodb";
+import { verifyFirebaseToken } from "@/lib/firebase-admin";
+
+jest.mock("next/server", () => ({
+  NextResponse: {
+    json: jest.fn().mockImplementation((body, init) => {
+      return {
+        status: init?.status || 200,
+        json: async () => body,
+        headers: new Map(),
+      };
+    }),
+  },
+}));
+
+jest.mock("@/lib/mongodb", () => ({
+  connectDb: jest.fn(),
+}));
+
+jest.mock("@/lib/firebase-admin", () => ({
+  verifyFirebaseToken: jest.fn(),
+}));
+
+describe("GET /api/labels - Security & Authentication Tests", () => {
+  let mockToArray;
+  let mockFind;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    if (rateLimitMap) {
+      rateLimitMap.clear();
+    }
+
+    verifyFirebaseToken.mockImplementation(async (token) => {
+      if (!token || token === "invalid-token") return null;
+      return { uid: "mock-uid", email: "user@domain.com" };
+    });
+
+    mockToArray = jest.fn();
+    mockFind = jest.fn().mockReturnValue({
+      toArray: mockToArray,
+    });
+
+    connectDb.mockResolvedValue({
+      collection: jest.fn().mockReturnValue({
+        find: mockFind,
+      }),
+    });
+  });
+
+  const createMockRequest = (tokenVal, ip = "127.0.0.1") => {
+    const authHeader = tokenVal !== undefined ? (tokenVal ? `Bearer ${tokenVal}` : "") : "Bearer valid-token";
+    return {
+      headers: {
+        get: jest.fn().mockImplementation((name) => {
+          if (name.toLowerCase() === "authorization") {
+            return authHeader;
+          }
+          if (name.toLowerCase() === "x-forwarded-for") {
+            return ip;
+          }
+          return null;
+        }),
+      },
+    };
+  };
+
+  test("rejects request if Authorization header is missing (401)", async () => {
+    const req = createMockRequest("");
+
+    const response = await GET(req);
+    const body = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(body.error).toBe("Unauthorized");
+    expect(connectDb).not.toHaveBeenCalled();
+  });
+
+  test("rejects request if Firebase token is invalid (401)", async () => {
+    const req = createMockRequest("invalid-token");
+
+    const response = await GET(req);
+    const body = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(body.error).toBe("Unauthorized");
+    expect(connectDb).not.toHaveBeenCalled();
+  });
+
+  test("returns projected labels list for authenticated users (200)", async () => {
+    const mockUsers = [
+      { name: "Alice", email: "alice@domain.com", image: "https://example.com/alice.jpg", sensitiveField: "secret" },
+      { name: "Bob", email: "bob@domain.com", image: "https://example.com/bob.jpg", sensitiveField: "secret" },
+    ];
+    mockToArray.mockResolvedValue(mockUsers);
+
+    const req = createMockRequest("valid-token");
+    const response = await GET(req);
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.success).toBe(true);
+    expect(body.data).toEqual(mockUsers);
+    expect(connectDb).toHaveBeenCalled();
+    expect(mockFind).toHaveBeenCalledWith({}, { projection: { _id: 0, name: 1, email: 1, image: 1 } });
+  });
+
+  test("rate limits requests if more than MAX_ATTEMPTS (10) per IP are made (429)", async () => {
+    mockToArray.mockResolvedValue([]);
+
+    // Send 10 successful requests
+    for (let i = 0; i < 10; i++) {
+      const req = createMockRequest("valid-token");
+      const response = await GET(req);
+      expect(response.status).toBe(200);
+    }
+
+    // 11th request from same IP should trigger 429
+    const req11 = createMockRequest("valid-token");
+    const response11 = await GET(req11);
+    const body11 = await response11.json();
+
+    expect(response11.status).toBe(429);
+    expect(body11.error).toContain("Too many attempts");
+  });
+});

--- a/components/useLabels.js
+++ b/components/useLabels.js
@@ -2,15 +2,24 @@
 
 import { useEffect, useState } from "react";
 
-export default function useLabels() {
+export default function useLabels(user) {
   const [labels, setLabels] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
 
   useEffect(() => {
+    if (!user) {
+      return;
+    }
+
     const fetchLabels = async () => {
       try {
-        const res = await fetch("/api/labels");
+        const token = await user.getIdToken();
+        const res = await fetch("/api/labels", {
+          headers: {
+            Authorization: `Bearer ${token}`,
+          },
+        });
         if (!res.ok) throw new Error("Failed to fetch labels");
         const data = await res.json();
         if (!data.success) {
@@ -26,7 +35,7 @@ export default function useLabels() {
     };
 
     fetchLabels();
-  }, []);
+  }, [user]);
 
-  return { labels, loading, error };
+  return { labels, loading: !user ? true : loading, error };
 }


### PR DESCRIPTION
## What type of PR is this?

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [ ] 🎨 UI/UX improvement
- [ ] ⚡ Performance improvement
- [x] 🔒 Security fix

## Description

Secures the `/api/labels` endpoint by requiring Firebase ID token authentication, enforcing data projections to prevent PII exposure, and adding rate limiting to block user enumeration attacks.

## Related Issues

Closes #171

## Changes Made

- **Authentication Check**: Added Firebase token decoding on the `/api/labels` GET route to verify authenticated users. Returns `401 Unauthorized` on failure.
- **PII Exposure Protection**: Restricted output fields by applying a projection `{ _id: 0, name: 1, email: 1, image: 1 }`, ensuring internal database IDs or metadata are never returned.
- **Enumeration Protection**: Implemented client IP rate limiting (10 attempts per minute per IP), responding with `429 Too Many Requests` when exceeded.
- **Client hook/component update**: Updated `useLabels` hook to expect the logged-in user and include the Bearer token header in request fetching.
- **New Unit Tests**: Created `components/_tests_/labelsRoute.test.js` checking missing headers, token errors, projection correctness, and rate limit triggers.

## Testing

How did you test these changes?
- [x] Tested locally (Ran `npm test` - all 48 unit tests passed successfully)
- [x] Verified local production build compiles successfully via `npm run build`

### Test Suite Output
```bash
PASS components/_tests_/labelsRoute.test.js
PASS components/_tests_/AuthForm.test.js
PASS components/_tests_/registerRoute.test.js
PASS components/_tests_/authUtils.test.js
PASS components/_tests_/formValidation.test.js

Test Suites: 5 passed, 5 total