### PR TITLE
feat: Add empty state message to Notice Board

### DIFF
--- a/components/noticeBoard.js
+++ b/components/noticeBoard.js
@@ -483,13 +483,13 @@ const SmartNoticeBoard = () => {
               ) : filteredNotices.length === 0 ? (
                 <div className="text-center py-20">
                   <div className="w-16 h-16 bg-gray-600 rounded-full flex items-center justify-center mx-auto mb-4">
-                    <Bell className="w-8 h-8 text-gray-400" />
+                    <BellOff className="w-8 h-8 text-gray-400" />
                   </div>
                   <h3 className="text-xl font-semibold text-gray-400 mb-2">
-                    No matching notices
+                    No Notices Yet
                   </h3>
                   <p className="text-gray-500">
-                    Try adjusting your search or filters to find what you're looking for.
+                    Check back later for updates.
                   </p>
                 </div>
               ) : (


### PR DESCRIPTION

## Changes Made
- Added empty state message for Notice Board
- Added friendly UI when no notices are available
- Improved user experience using lucide-react icon

## Testing
- Tested locally using npm run dev
- Verified UI renders correctly

Fixes #190