### PR TITLE
Fix overlap between chatbot and back to top button

### DIFF
--- a/components/BackToTop.js
+++ b/components/BackToTop.js
@@ -24,7 +24,7 @@ export default function BackToTop() {
     <button
       onClick={scrollToTop}
       aria-label="Back to top"
-      className="fixed bottom-6 right-6 z-50 p-3 rounded-full bg-gradient-to-r from-accent to-purple-600 text-white shadow-lg hover:shadow-accent/40 hover:scale-110 transition-all duration-300 animate-fadeIn"
+      className="fixed bottom-24 right-6 z-50 p-3 rounded-full bg-gradient-to-r from-accent to-purple-600 text-white shadow-lg hover:shadow-accent/40 hover:scale-110 transition-all duration-300 animate-fadeIn"
     >
       <ChevronUp className="h-5 w-5" />
     </button>


### PR DESCRIPTION
## What type of PR is this?

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [x] 🎨 UI/UX improvement
- [ ] ⚡ Performance improvement
- [ ] 🔒 Security fix

## Description

The back to top button was overlapping with the chatbot this PR fixes that

## Related Issues

Closes #195 

## Changes Made

- Fixed backto top button and moved it up so that chatbot can be easily accesses

## Testing

How did you test these changes?
- [x] Tested locally
- [x] Tested on mobile
- [x] Tested different user roles
- [x] All roles tested

## Screenshots (if applicable)

<img width="1919" height="876" alt="image" src="https://github.com/user-attachments/assets/97eebe7d-e7ac-47e8-b7f3-6d85fa2005cd" />
<img width="267" height="569" alt="image" src="https://github.com/user-attachments/assets/c10b29af-6004-4bc3-a95a-cf53229a4331" />


## Checklist

- [x] No hardcoded secrets or credentials
- [x] `.env.local` is not committed
- [x] Code follows project style
- [x] Changes are documented
- [x] Build passes locally (`npm run build`)
- [x] No console errors/warnings

AI USage: AI used to write commit message 