### PR TITLE
Fix: Resolve Navbar overlapping content and User Dropdown visual bleeding

### DIFF
--- a/app/auth/page.js
+++ b/app/auth/page.js
@@ -210,7 +210,7 @@ export default function AuthPage() {
   };
 
   return (
-    <div className="min-h-screen pt-10 bg-gradient-to-br from-gray-900 via-gray-800 to-black">
+    <div className="min-h-screen pt-24 lg:pt-32 bg-gradient-to-br from-gray-900 via-gray-800 to-black">
       <Navbar />
 
       <div className="relative overflow-hidden">

--- a/components/Navbar.js
+++ b/components/Navbar.js
@@ -499,7 +499,7 @@ export function Navbar() {
                     </button>
 
                     {isDropdownOpen && (
-                      <div className="absolute right-0 mt-3 min-w-64 bg-black/95 backdrop-blur-2xl rounded-2xl shadow-2xl border border-white/20 py-2 z-[52]">
+                      <div className="absolute right-0 mt-3 min-w-64 bg-black/95 backdrop-blur-2xl rounded-2xl shadow-2xl border border-white/20 py-2 z-[100] overflow-hidden">
                         {userMenuItems.map(
                           (item) => (
                             <Link


### PR DESCRIPTION

## What was changed:

Navbar Layout Spacing: Added top padding (pt-24 lg:pt-32) to the authentication layout wrapper (app/auth/page.js) to provide top-spacing compensation for the fixed navigation bar.

User Dropdown Cleanup: Added overflow-hidden and bumped the z-index (z-[100]) on the User Profile dropdown (components/Navbar.js).

closes #238 

## Why this change is necessary:

Previously, the fixed navigation bar was acting as an absolute element with no top-spacing compensation, effectively swallowing up and truncating the top headings and text strings of the authentication page.

When clicking the user profile to open the dropdown menu, hover states and child elements would visually bleed outside the rounded-2xl menu container corners due to missing overflow containment, appearing as a misaligned layout artifact through the UI.

## Steps to Verify:

Navigate to the Login / Signup page and verify that the "Premium Access" section on the right is fully visible and not being truncated by the navbar.

Click the user profile icon in the navbar.

Observe that the user dropdown opens smoothly with clean, rounded corners, and hovering over the menu items no longer bleeds outside the container.
