### PR TITLE
Fix inconsistent card heights in homepage sections

### DIFF
--- a/app/page.js
+++ b/app/page.js
@@ -219,7 +219,7 @@ export default function AboutPage() {
     setScrollY(window.scrollY);
   }, []);
 
- const handleAnimationComplete = useCallback(() => {
+  const handleAnimationComplete = useCallback(() => {
   }, []);
 
   useEffect(() => {
@@ -410,10 +410,10 @@ export default function AboutPage() {
                   </p>
                 </div>
 
-                  <ActionButton href="/activity">
-                      Learn More
-                      <ArrowRight className="ml-2 w-5 h-5 group-hover:translate-x-1 transition-transform duration-300" />
-                  </ActionButton>
+                <ActionButton href="/activity">
+                  Learn More
+                  <ArrowRight className="ml-2 w-5 h-5 group-hover:translate-x-1 transition-transform duration-300" />
+                </ActionButton>
               </Reveal>
 
               <Reveal className="relative" delay={0.1}>
@@ -470,7 +470,7 @@ export default function AboutPage() {
               </p>
             </Reveal>
 
-            <div className="grid md:grid-cols-3 gap-8">
+            <div className="grid md:grid-cols-3 gap-8 items-stretch">
               {VALUES_DATA.map((value, index) => (
                 <Reveal key={value.title} delay={index * 0.08}>
                   <Card className="group bg-black/40 border-white/10 backdrop-blur-xl hover:border-accent/50 transition-all duration-700 hover:scale-[1.02] hover:shadow-2xl hover:shadow-accent/25">
@@ -521,8 +521,8 @@ export default function AboutPage() {
             <div className="grid md:grid-cols-3 gap-8">
               {TEAM_MEMBERS.map((member, index) => (
                 <Reveal key={member.name} delay={index * 0.08}>
-                  <Card className="group bg-black/40 border-white/10 backdrop-blur-xl hover:border-accent/50 transition-all duration-700 hover:scale-[1.02]">
-                    <CardContent className="pt-8 text-center">
+                  <Card className="group h-full flex flex-col bg-black/40 border-white/10 backdrop-blur-xl hover:border-accent/50 transition-all duration-700 hover:scale-[1.02]">
+                    <CardContent className="pt-8 text-center flex flex-col h-full">
                       <div className="relative mb-6">
                         <div
                           className={`w-28 h-28 bg-gradient-to-br ${member.color} rounded-full flex items-center justify-center mx-auto group-hover:scale-105 transition-transform duration-500 relative overflow-hidden`}
@@ -625,10 +625,10 @@ export default function AboutPage() {
               </p>
             </Reveal>
 
-            <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-8">
+            <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-8 items-stretch">
               {IMPACT_DATA.map((impact, index) => (
                 <Reveal key={impact.title} delay={index * 0.08}>
-                  <div className="group bg-white/10 backdrop-blur-xl rounded-3xl p-8 border border-white/20 hover:border-accent/40 transition-all duration-700 hover:scale-[1.02] hover:shadow-2xl hover:shadow-accent/25 text-center">
+                  <div className="group h-full flex flex-col bg-white/10 backdrop-blur-xl rounded-3xl p-8 border border-white/20 hover:border-accent/40 transition-all duration-700 hover:scale-[1.02] hover:shadow-2xl hover:shadow-accent/25 text-center">
                     <impact.icon className="w-12 h-12 text-accent mx-auto mb-6 group-hover:scale-110 transition-transform duration-500" />
                     <h3 className="text-xl font-semibold text-white mb-3 group-hover:text-accent transition-colors duration-500">
                       {impact.title}


### PR DESCRIPTION
## What type of PR is this?

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [x] 🎨 UI/UX improvement
- [ ] ⚡ Performance improvement
- [ ] 🔒 Security fix

## Description

The card heights are inconsistent in the same section on the homepage. 

## Related Issues

Closes #196 

## Changes Made

- Fixed card heights on our team section
- Fixed card heights on our impact section

## Testing

How did you test these changes?
- [x] Tested locally
- [x] Tested on mobile
- [x] Tested different user roles
- [x] All roles tested

## Screenshots (if applicable)

Before
<img width="1919" height="433" alt="image" src="https://github.com/user-attachments/assets/eaa57ba3-bcaa-4cd8-9828-76c55b072cf7" />
<img width="1727" height="454" alt="image" src="https://github.com/user-attachments/assets/b6782a51-8394-4d46-a612-6d6e58a1fc5f" />



After

<img width="1915" height="964" alt="image" src="https://github.com/user-attachments/assets/7f3c737a-f234-4311-bd2e-93bf26771b92" />
<img width="1919" height="797" alt="image" src="https://github.com/user-attachments/assets/3d7d379e-d20e-4ca2-b12c-eeb460f95432" />


## Checklist

- [x] No hardcoded secrets or credentials
- [x] `.env.local` is not committed
- [x] Code follows project style
- [x] Changes are documented
- [x] Build passes locally (`npm run build`)
- [x] No console errors/warnings
