### PR TITLE
Fix card height alignment in Our Impact and Visionaries sections

### DIFF
--- a/app/page.js
+++ b/app/page.js
@@ -520,9 +520,9 @@ export default function AboutPage() {
 
             <div className="grid md:grid-cols-3 gap-8">
               {TEAM_MEMBERS.map((member, index) => (
-                <Reveal key={member.name} delay={index * 0.08}>
-                  <Card className="group h-full flex flex-col bg-black/40 border-white/10 backdrop-blur-xl hover:border-accent/50 transition-all duration-700 hover:scale-[1.02]">
-                    <CardContent className="pt-8 text-center flex flex-col h-full">
+                <Reveal key={member.name} delay={index * 0.08} className="h-full">
+                  <Card className="group bg-black/40 border-white/10 backdrop-blur-xl hover:border-accent/50 transition-all duration-700 hover:scale-[1.02] h-full flex flex-col">
+                    <CardContent className="pt-8 text-center flex-grow flex flex-col">
                       <div className="relative mb-6">
                         <div
                           className={`w-28 h-28 bg-gradient-to-br ${member.color} rounded-full flex items-center justify-center mx-auto group-hover:scale-105 transition-transform duration-500 relative overflow-hidden`}
@@ -627,9 +627,9 @@ export default function AboutPage() {
 
             <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-8 items-stretch">
               {IMPACT_DATA.map((impact, index) => (
-                <Reveal key={impact.title} delay={index * 0.08}>
-                  <div className="group h-full flex flex-col bg-white/10 backdrop-blur-xl rounded-3xl p-8 border border-white/20 hover:border-accent/40 transition-all duration-700 hover:scale-[1.02] hover:shadow-2xl hover:shadow-accent/25 text-center">
-                    <impact.icon className="w-12 h-12 text-accent mx-auto mb-6 group-hover:scale-110 transition-transform duration-500" />
+                <Reveal key={impact.title} delay={index * 0.08} className="h-full">
+                  <div className="group bg-white/10 backdrop-blur-xl rounded-3xl p-8 border border-white/20 hover:border-accent/40 transition-all duration-700 hover:scale-[1.02] hover:shadow-2xl hover:shadow-accent/25 text-center h-full flex flex-col">
+                    <impact.icon className="w-12 h-12 text-accent mx-auto mb-6 group-hover:scale-110 transition-transform duration-500 shrink-0" />
                     <h3 className="text-xl font-semibold text-white mb-3 group-hover:text-accent transition-colors duration-500">
                       {impact.title}
                     </h3>


### PR DESCRIPTION
## What was changed:

Added h-full to the Reveal wrapper components in both the "Our Impact" and "Meet the Visionaries" sections.
Updated the inner Card and div content containers to utilize h-full flex flex-col and flex-grow for proper internal scaling.

## Related Issues

Closes #239 

##Why this change is necessary:

Previously, varying lengths of bios, descriptions, and content in the cards caused the grid rows to stretch unevenly, breaking the clean alignment of the UI.
By enforcing h-full on the animation wrappers and utilizing flexbox for the card interiors, the cards now seamlessly inherit the height of the tallest item in their respective CSS grid row, ensuring a uniform and cohesive layout regardless of content length.

## Steps to Verify:

Navigate to the landing page and scroll down to the "Meet the Visionaries" section.
Observe that all profile cards in the same row share the exact same height, even if their bios are different lengths.
Scroll further down to the "Our Impact" section and confirm that the four target audience cards are perfectly aligned at the bottom.
