### PR TITLE
fix(exceptions): validate status field against allowed enum values

### DIFF
--- a/app/api/exceptions/update/route.js
+++ b/app/api/exceptions/update/route.js
@@ -33,6 +33,11 @@ export async function PUT(request) {
       return jsonError("exceptionId is required", 400);
     }
 
+    const validStatuses = ["pending", "approved", "rejected"];
+    if (status && !validStatuses.includes(status)) {
+      return jsonError("Invalid status value", 400);
+    }
+
     const db = await connectDb();
 
     const result = await db.collection("exceptions").updateOne(


### PR DESCRIPTION
## What type of PR is this?

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [ ] 🎨 UI/UX improvement
- [ ] ⚡ Performance improvement
- [x] 🔒 Security fix

## Description
This PR addresses a missing validation check in the `PUT /api/exceptions/update` route. Previously, the API accepted any arbitrary string for the `status` field, allowing invalid states to be written to the database. I have added strict server-side validation to ensure the `status` must be one of the allowed enum values (`pending`, `approved`, `rejected`) before processing the database update.

## Related Issues

Closes #252 

## Changes Made
- **`app/api/exceptions/update/route.js`**: Added array inclusion check for valid exception statuses, returning a `400 Bad Request` if an invalid state is provided.

## Testing

How did you test these changes?
- [x] Tested locally
- [ ] Tested on mobile
- [ ] Tested different user roles
- [ ] All roles tested

## Screenshots (if applicable)


## Checklist

- [x] No hardcoded secrets or credentials
- [x] `.env.local` is not committed
- [x] Code follows project style
- [ ] Changes are documented
- [x] Build passes locally (`npm run build`)
- [x] No console errors/warnings
