### PR TITLE
fix(api):  Fix Rate-Limiting IP Extraction Logic

### DIFF
--- a/app/api/labels/route.js
+++ b/app/api/labels/route.js
@@ -9,7 +9,8 @@ const MAX_ATTEMPTS = 10;
 export async function GET(request) {
   try {
     // Rate Limiting Check
-    const ip = request.headers.get("x-forwarded-for") || "127.0.0.1";
+    const forwardedFor = request.headers.get("x-forwarded-for");
+    const ip = forwardedFor ? forwardedFor.split(',')[0].trim() : "127.0.0.1";
     const now = Date.now();
     if (!rateLimitMap.has(ip)) {
       rateLimitMap.set(ip, []);

--- a/app/api/register/route.js
+++ b/app/api/register/route.js
@@ -84,7 +84,8 @@ export async function POST(req) {
     }
 
     // Rate Limiting Check
-    const ip = req.headers.get("x-forwarded-for") || "127.0.0.1";
+    const forwardedFor = req.headers.get("x-forwarded-for");
+    const ip = forwardedFor ? forwardedFor.split(',')[0].trim() : "127.0.0.1";
     const now = Date.now();
     if (!rateLimitMap.has(ip)) {
       rateLimitMap.set(ip, []);


### PR DESCRIPTION
## What type of PR is this?

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [ ] 🎨 UI/UX improvement
- [ ] ⚡ Performance improvement
- [x] 🔒 Security fix

## Description

This PR fixes a bug in the rate-limiting logic across the API routes. The `x-forwarded-for` header can often contain a comma-separated list of IP addresses (e.g., when routing through multiple proxies or load balancers). Previously, the code treated the entire string as a single IP, which breaks rate-limiting for users behind identical proxy chains or allows evasion via IP spoofing. 


## Related Issues

Closes #274 

## Changes Made
- **`app/api/labels/route.js`**: Safely split the `x-forwarded-for` header and extract only the first (client) IP.
- **`app/api/register/route.js`**: Applied the exact same robust extraction logic for the registration rate limiter.

## Testing

How did you test these changes?
- [x] Tested locally
- [ ] Tested on mobile
- [ ] Tested different user roles
- [ ] All roles tested

## Screenshots (if applicable)


## Checklist

- [x] No hardcoded secrets or credentials
- [x] `.env.local` is not committed
- [x] Code follows project style
- [ ] Changes are documented
- [x] Build passes locally (`npm run build`)
- [x] No console errors/warnings
