### PR TITLE
fix: resolve user session not cleared after logout (#244)

### DIFF
--- a/components/Navbar.js
+++ b/components/Navbar.js
@@ -332,21 +332,9 @@ export function Navbar() {
                 );
               })}
 
-              { true ? (
+              { isAuthenticated ? (
                 <div className="flex items-center space-x-2 md:space-x-4 ml-2 md:ml-6">
-                 <button
-                  onClick={() =>
-                    addNotification({
-                      message: "Test notification works!",
-                      time: "Just now",
-                      read: false,
-                      type: "success",
-                    })
-                  }
-                  className="bg-blue-500 text-white px-3 py-1 rounded"
-                >
-                  Test Notification
-                </button>
+                
                   <Button asChild className="hidden md:block relative bg-gradient-to-r from-accent to-blue-500 hover:from-accent/90 hover:to-blue-600 text-white font-medium shadow-lg hover:shadow-2xl hover:shadow-accent/30 transition-all duration-300 hover:scale-105 group overflow-hidden">
                     <Link href="/attendance">
                       <span className="absolute inset-0 bg-gradient-to-r from-white/20 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-300" />

--- a/hooks/useAuth.js
+++ b/hooks/useAuth.js
@@ -1,6 +1,6 @@
 import { useState, useEffect } from "react";
 import { auth, db } from "@/lib/firebaseConfig";
-import { onAuthStateChanged } from "firebase/auth";
+import { onAuthStateChanged, signOut as firebaseSignOut } from "firebase/auth";
 import { doc, getDoc } from "firebase/firestore";
 
 /**
@@ -60,7 +60,7 @@ export const useAuth = () => {
   */
   const signOut = async () => {
     try {
-      await auth.signOut();
+      await firebaseSignOut(auth);
       setUser(null);
       setUserProfile(null);
     } catch (err) {

--- a/services/authService.js
+++ b/services/authService.js
@@ -6,6 +6,8 @@ import {
   createUserWithEmailAndPassword,
   sendPasswordResetEmail,
   sendEmailVerification,
+  signOut,
+  
 } from "firebase/auth";
 import { doc, setDoc, getDoc } from "firebase/firestore";
 import {
@@ -50,7 +52,7 @@ export const loginWithEmail = async (email, password, selectedRole) => {
 
       // Check if role matches selected role
       if (userData.role !== selectedRole) {
-        await auth.signOut();
+        await signOut(auth);
         return {
           success: false,
           error: `This account is registered as ${
@@ -162,7 +164,8 @@ export const loginWithGoogle = async (
     if (!userDoc.exists()) {
       if (isLogin) {
         // New Google user trying to login - need to sign up first
-        await auth.signOut();
+        // ✅ modular style
+        await signOut(auth);
         return {
           success: false,
           error: "Account not found. Please sign up first.",
@@ -171,7 +174,8 @@ export const loginWithGoogle = async (
         // New Google user signing up - create profile with selected role
         const nameToUse = user.displayName || additionalData.fullName?.trim();
         if (!nameToUse) {
-          await auth.signOut();
+          // ✅ modular style
+          await signOut(auth);
           return {
             success: false,
             error: "Please enter your full name",
@@ -192,7 +196,7 @@ export const loginWithGoogle = async (
 
     // For existing users, check if role matches selected role (for login)
     if (isLogin && userData && userData.role !== selectedRole) {
-      await auth.signOut();
+      await signOut(auth);
       return {
         success: false,
         error: `This account is registered as ${


### PR DESCRIPTION
## What type of PR is this?
- [x] 🐛 Bug fix

## Description
After logging out, the navbar/profile section continued displaying the 
user as logged in due to two compounding bugs. First, `auth.signOut()` 
was being used instead of the modular `signOut(auth)` — on Firebase v9+ 
this silently fails, meaning the session was never actually cleared and 
`onAuthStateChanged` never fired with null. Second, the desktop navbar 
condition was hardcoded to `true` instead of `isAuthenticated`, so the 
logged-in UI always rendered regardless of actual auth state.

## Related Issues
Closes #244

## Changes Made
- Replace `auth.signOut()` with `firebaseSignOut(auth)` in `hooks/useAuth.js`
- Replace all `auth.signOut()` calls with `signOut(auth)` in `services/authService.js` (4 occurrences across `loginWithEmail` and `loginWithGoogle`)
- Fix hardcoded `true` condition to `isAuthenticated` in `components/Navbar.js` so navbar re-renders correctly after logout
- Remove leftover test notification button from desktop nav in `components/Navbar.js`

## Testing
- [x] Tested locally
- [x] Tested on mobile
- [x] Tested different user roles
- [x] All roles tested

## Screenshots (if applicable)
N/A — bug was in auth logic and conditional rendering, no visual design changes.

## Checklist
- [x] No hardcoded secrets or credentials
- [x] `.env.local` is not committed
- [x] Code follows project style
- [x] Changes are documented
- [x] Build passes locally (`npm run build`)
- [x] No console errors/warnings