### PR TITLE
fix: add Zod schema validation to prevent mass assignment in /api/settings (#256)

### DIFF
--- a/app/api/settings/route.js
+++ b/app/api/settings/route.js
@@ -1,6 +1,77 @@
 import { NextResponse } from "next/server";
 import { connectDb } from "@/lib/mongodb";
 import { verifyFirebaseToken, getUserProfile } from "@/lib/firebase-admin";
+import { z } from "zod";
+
+const settingsSchema = z.object({
+  userId: z.string().optional(),
+  theme: z.string().optional(),
+  profile: z.object({
+    name: z.string().optional(),
+    email: z.string().optional(),
+    phone: z.string().optional(),
+    bio: z.string().optional(),
+    avatar: z.string().optional(),
+  }).strict().optional(),
+  notifications: z.union([
+    z.boolean(),
+    z.object({
+      emailNotifications: z.boolean().optional(),
+      pushNotifications: z.boolean().optional(),
+      courseReminders: z.boolean().optional(),
+      achievementAlerts: z.boolean().optional(),
+      weeklyReports: z.boolean().optional(),
+      marketingEmails: z.boolean().optional(),
+      attendanceAlerts: z.boolean().optional(),
+      gradeUpdates: z.boolean().optional(),
+      classReminders: z.boolean().optional(),
+      gradingAlerts: z.boolean().optional(),
+      studentSubmissions: z.boolean().optional(),
+      parentMessages: z.boolean().optional(),
+      systemAlerts: z.boolean().optional(),
+      maintenanceReminders: z.boolean().optional(),
+      securityAlerts: z.boolean().optional(),
+      reportReminders: z.boolean().optional(),
+      performanceAlerts: z.boolean().optional(),
+      enrollmentAlerts: z.boolean().optional(),
+      performanceReports: z.boolean().optional(),
+      childProgressAlerts: z.boolean().optional(),
+      meetingReminders: z.boolean().optional(),
+      childProgress: z.boolean().optional(),
+      schoolUpdates: z.boolean().optional(),
+    }).strict(),
+  ]).optional(),
+  privacy: z.object({
+    profileVisibility: z.string().optional(),
+    showProgress: z.boolean().optional(),
+    showAchievements: z.boolean().optional(),
+    allowMessages: z.boolean().optional(),
+    dataCollection: z.boolean().optional(),
+  }).strict().optional(),
+  learning: z.object({
+    dailyGoal: z.number().optional(),
+    weeklyGoal: z.number().optional(),
+    preferredLanguage: z.string().optional(),
+    difficulty: z.string().optional(),
+    autoplay: z.boolean().optional(),
+    subtitles: z.boolean().optional(),
+    studyReminders: z.boolean().optional(),
+    assignmentAlerts: z.boolean().optional(),
+    classReminders: z.boolean().optional(),
+    gradingAlerts: z.boolean().optional(),
+    systemAlerts: z.boolean().optional(),
+    maintenanceReminders: z.boolean().optional(),
+    reportReminders: z.boolean().optional(),
+    performanceAlerts: z.boolean().optional(),
+    childProgressAlerts: z.boolean().optional(),
+    meetingReminders: z.boolean().optional(),
+  }).strict().optional(),
+  appearance: z.object({
+    theme: z.string().optional(),
+    language: z.string().optional(),
+    timezone: z.string().optional(),
+  }).strict().optional(),
+}).strict();
 
 export async function PATCH(request) {
   try {
@@ -17,7 +88,16 @@ export async function PATCH(request) {
     }
 
     const body = await request.json();
-    const { userId: bodyUserId, ...settings } = body;
+    const parsed = settingsSchema.safeParse(body);
+
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: "Bad Request: Unrecognized or invalid fields." },
+        { status: 400 }
+      );
+    }
+
+    const { userId: bodyUserId, ...settings } = parsed.data;
     
     let targetUserId = decodedToken.uid;
     let isOperatorAdmin = false;


### PR DESCRIPTION
Fixes #256

## Problem
The PATCH /api/settings endpoint was spreading the entire request body directly into MongoDB $set with no field whitelisting, allowing any authenticated user to inject arbitrary fields into their document.

## Fix
Added a strict Zod schema (`settingsSchema`) that whitelists exactly which fields are allowed:
- `theme`
- `profile` (name, email, phone, bio, avatar)
- `notifications` (all notification preference fields)
- `privacy` (visibility, progress, achievements, messages, data collection)
- `learning` (goals, language, difficulty, reminders)
- `appearance` (theme, language, timezone)

The schema uses `.strict()` on all nested objects so any unrecognized field returns `400 Bad Request` immediately before touching the database.

## Changes
- `app/api/settings/route.js` — added Zod schema validation, replaced raw spread with `parsed.data`

## Testing
- Valid settings payload → 200 OK ✅
- Unknown field in payload → 400 Bad Request ✅
- Unauthorized request → 401 ✅
- Non-admin updating another user → 403 ✅

## Acceptance Criteria
- [x] Only whitelisted fields can be updated
- [x] Unrecognized fields return 400 Bad Request
- [x] Zod validation is used