### PR TITLE
feat(conversations): implement secure GET handler for chat history re…

### DIFF
--- a/app/api/conversations/route.js
+++ b/app/api/conversations/route.js
@@ -84,3 +84,31 @@ export async function POST(req) {
     return jsonError(err.message || "Failed to save conversation", 500);
   }
 }
+
+export async function GET(request) {
+  try {
+    const authorization = request.headers.get("authorization");
+    const token = authorization?.split(" ")[1];
+
+    const decodedToken = await verifyFirebaseToken(token);
+
+    if (!decodedToken) {
+      return jsonError("Unauthorized", 401);
+    }
+
+    const db = await connectDb();
+    const collection = db.collection("conversations");
+
+    const history = await collection
+      .find({ userId: decodedToken.uid })
+      .sort({ timestamp: 1 })
+      .limit(50)
+      .toArray();
+
+    return jsonSuccess(history);
+  } catch (err) {
+    console.error("Get History Error:", err);
+    return jsonError(err.message || "Failed to retrieve conversation history", 500);
+  }
+}
+

--- a/components/_tests_/conversationsRoute.test.js
+++ b/components/_tests_/conversationsRoute.test.js
@@ -1,4 +1,4 @@
-import { POST } from "@/app/api/conversations/route";
+import { POST, GET } from "@/app/api/conversations/route";
 import { connectDb } from "@/lib/mongodb";
 import { verifyFirebaseToken } from "@/lib/firebase-admin";
 
@@ -210,3 +210,133 @@ describe("POST /api/conversations - Authentication and Validation Security Tests
     expect(body.data.userMessage).toBe("Hello World"); // <script> tag stripped
   });
 });
+
+describe("GET /api/conversations - History Retrieval Security and Performance Tests", () => {
+  let mockFind, mockSort, mockLimit, mockToArray;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockToArray = jest.fn();
+    mockLimit = jest.fn().mockReturnValue({ toArray: mockToArray });
+    mockSort = jest.fn().mockReturnValue({ limit: mockLimit });
+    mockFind = jest.fn().mockReturnValue({ sort: mockSort });
+
+    connectDb.mockResolvedValue({
+      collection: jest.fn().mockReturnValue({
+        find: mockFind,
+      }),
+    });
+  });
+
+  const createMockRequest = (headers) => {
+    return {
+      headers: {
+        get: (name) => headers[name.toLowerCase()] || null,
+      },
+    };
+  };
+
+  test("rejects unauthenticated request (no authorization header) with 401 Unauthorized", async () => {
+    verifyFirebaseToken.mockResolvedValue(null);
+
+    const req = createMockRequest({});
+
+    const response = await GET(req);
+    const body = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(body.error).toBe("Unauthorized");
+    expect(connectDb).not.toHaveBeenCalled();
+  });
+
+  test("rejects request with invalid token with 401 Unauthorized", async () => {
+    verifyFirebaseToken.mockResolvedValue(null);
+
+    const req = createMockRequest({ authorization: "Bearer invalid-token" });
+
+    const response = await GET(req);
+    const body = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(body.error).toBe("Unauthorized");
+    expect(connectDb).not.toHaveBeenCalled();
+  });
+
+  test("accepts request with valid token, retrieves user-specific history sorted chronologically and limited to 50 records", async () => {
+    const mockDecodedToken = {
+      uid: "user-123",
+      email: "user@example.com",
+    };
+    verifyFirebaseToken.mockResolvedValue(mockDecodedToken);
+
+    const dummyConversations = [
+      {
+        userId: "user-123",
+        userEmail: "user@example.com",
+        userMessage: "Hello",
+        botMessage: "Hi",
+        timestamp: new Date("2026-05-21T10:00:00Z"),
+      },
+      {
+        userId: "user-123",
+        userEmail: "user@example.com",
+        userMessage: "How are you?",
+        botMessage: "I'm great",
+        timestamp: new Date("2026-05-21T10:01:00Z"),
+      },
+    ];
+    mockToArray.mockResolvedValue(dummyConversations);
+
+    const req = createMockRequest({ authorization: "Bearer valid-token" });
+
+    const response = await GET(req);
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.success).toBe(true);
+    expect(body.data).toEqual(dummyConversations);
+
+    expect(mockFind).toHaveBeenCalledWith({ userId: "user-123" });
+    expect(mockSort).toHaveBeenCalledWith({ timestamp: 1 });
+    expect(mockLimit).toHaveBeenCalledWith(50);
+  });
+
+  test("returns empty array if user has no saved conversations", async () => {
+    const mockDecodedToken = {
+      uid: "user-456",
+      email: "newuser@example.com",
+    };
+    verifyFirebaseToken.mockResolvedValue(mockDecodedToken);
+    mockToArray.mockResolvedValue([]);
+
+    const req = createMockRequest({ authorization: "Bearer valid-token" });
+
+    const response = await GET(req);
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.success).toBe(true);
+    expect(body.data).toEqual([]);
+    expect(mockFind).toHaveBeenCalledWith({ userId: "user-456" });
+  });
+
+  test("handles database connection/query errors gracefully returning 500", async () => {
+    const mockDecodedToken = {
+      uid: "user-123",
+      email: "user@example.com",
+    };
+    verifyFirebaseToken.mockResolvedValue(mockDecodedToken);
+
+    connectDb.mockRejectedValue(new Error("Database offline"));
+
+    const req = createMockRequest({ authorization: "Bearer valid-token" });
+
+    const response = await GET(req);
+    const body = await response.json();
+
+    expect(response.status).toBe(500);
+    expect(body.error).toBe("Database offline");
+  });
+});
+


### PR DESCRIPTION
Closes #281 
## Description
This Pull Request implements the missing `GET` handler for the `/api/conversations` endpoint. Previously, only the `POST` handler existed, meaning that although chat messages were successfully saved to the MongoDB database, they could not be retrieved by the frontend upon page refresh, user navigation, or re-authentication. 

With this implementation, users will now have persistent Nova AI chat sessions restored seamlessly.

## Key Changes
- **Implemented GET Endpoint**: Added `export async function GET(request)` in `app/api/conversations/route.js` that:
  - Extracts the bearer token from the `Authorization` header.
  - Verifies credentials via the existing `verifyFirebaseToken` helper, rejecting unauthorized requests with a `401 Unauthorized` response.
  - Queries conversations from MongoDB matching the authenticated user's `userId` (`decodedToken.uid`).
  - Sorts conversations chronologically (`timestamp: 1`).
  - Safely limits the returned records to `50` for optimal response payload sizes and performance.
- **Added Comprehensive Unit Tests**: Added a complete suite of unit tests in `components/_tests_/conversationsRoute.test.js` verifying:
  - Rejection of unauthenticated requests.
  - Rejection of invalid bearer tokens.
  - Proper data querying, sorting, and limiting (capped at 50) for valid requests.
  - Correct responses for users with empty conversation histories.
  - Graceful internal server error handling (`500`) when database connection/query failures occur.

## How to Test and Verify

### 1. Verification of Security and Authentication
You can manually query the endpoint using `curl` or Javascript `fetch`.

**Unauthenticated Request (Expected: 401 Unauthorized)**
```bash
curl -i -X GET http://localhost:3000/api/conversations
