### PR TITLE
test: add unit tests for AuthForm component

### DIFF
--- a/components/__tests__/AuthForm.test.js
+++ b/components/__tests__/AuthForm.test.js
@@ -1,0 +1,113 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import AuthForm from "../AuthForm";
+
+const defaultProps = {
+  isLogin: true,
+  selectedRole: "student",
+  email: "",
+  setEmail: jest.fn(),
+  password: "",
+  setPassword: jest.fn(),
+  fullName: "",
+  setFullName: jest.fn(),
+  instituteName: "",
+  setInstituteName: jest.fn(),
+  errors: {},
+  setErrors: jest.fn(),
+  isLoading: false,
+  onSubmit: jest.fn((e) => e.preventDefault()),
+  onGoogleLogin: jest.fn(),
+  onRoleChange: jest.fn(),
+  onToggleLogin: jest.fn(),
+  onForgotPassword: jest.fn(),
+};
+
+describe("AuthForm", () => {
+  test("renders login form with correct heading", () => {
+    render(<AuthForm {...defaultProps} />);
+
+    expect(screen.getByRole("heading", { name: "Welcome Back" })).toBeInTheDocument();
+    expect(screen.getByText(/sign in to your student/i)).toBeInTheDocument();
+  });
+
+  test("renders signup form when isLogin is false", () => {
+    render(<AuthForm {...defaultProps} isLogin={false} />);
+
+    expect(screen.getByRole("heading", { name: "Create Account" })).toBeInTheDocument();
+    expect(screen.getByText(/create your student/i)).toBeInTheDocument();
+  });
+
+  test("shows full name field only on signup", () => {
+    const { rerender } = render(<AuthForm {...defaultProps} />);
+
+    expect(screen.queryByText("Full Name")).not.toBeInTheDocument();
+
+    rerender(<AuthForm {...defaultProps} isLogin={false} />);
+
+    expect(screen.getByText("Full Name")).toBeInTheDocument();
+  });
+
+  test("shows institute name field when role is institute on signup", () => {
+    render(<AuthForm {...defaultProps} isLogin={false} selectedRole="institute" />);
+
+    expect(screen.getByText("Institute Name")).toBeInTheDocument();
+  });
+
+  test("calls onSubmit when form is submitted", async () => {
+    const user = userEvent.setup();
+    const handleSubmit = jest.fn((e) => e.preventDefault());
+
+    render(<AuthForm {...defaultProps} onSubmit={handleSubmit} />);
+
+    const submitBtn = screen.getByRole("button", { name: /sign in/i });
+    await user.click(submitBtn);
+
+    expect(handleSubmit).toHaveBeenCalledTimes(1);
+  });
+
+  test("shows loading state when isLoading is true", () => {
+    render(<AuthForm {...defaultProps} isLoading={true} />);
+
+    expect(screen.getByText("Processing...")).toBeInTheDocument();
+
+    const submitBtn = screen.getByRole("button", { name: /processing/i });
+    expect(submitBtn).toBeDisabled();
+  });
+
+  test("displays submit error when present in errors object", () => {
+    render(<AuthForm {...defaultProps} errors={{ submit: "Invalid credentials" }} />);
+
+    expect(screen.getByText("Invalid credentials")).toBeInTheDocument();
+  });
+
+  test("calls onToggleLogin when sign up link is clicked", async () => {
+    const user = userEvent.setup();
+    render(<AuthForm {...defaultProps} />);
+
+    const toggleLink = screen.getByRole("button", { name: /sign up/i });
+    await user.click(toggleLink);
+
+    expect(defaultProps.onToggleLogin).toHaveBeenCalledTimes(1);
+  });
+
+  test("calls onForgotPassword when forgot password link is clicked", async () => {
+    const user = userEvent.setup();
+    render(<AuthForm {...defaultProps} />);
+
+    const forgotLink = screen.getByRole("button", { name: /forgot password/i });
+    await user.click(forgotLink);
+
+    expect(defaultProps.onForgotPassword).toHaveBeenCalledTimes(1);
+  });
+
+  test("calls onGoogleLogin when Google button is clicked", async () => {
+    const user = userEvent.setup();
+    render(<AuthForm {...defaultProps} />);
+
+    const googleBtn = screen.getByRole("button", { name: /continue with google/i });
+    await user.click(googleBtn);
+
+    expect(defaultProps.onGoogleLogin).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Description

This PR adds basic unit tests for the `AuthForm` component as requested in issue #311.

## Test Coverage

Created `components/__tests__/AuthForm.test.js` with **10 test cases**:

1. **Login form renders correctly** — verifies "Welcome Back" heading and role-specific subtitle
2. **Signup form renders correctly** — verifies "Create Account" heading when `isLogin` is false
3. **Full name field only on signup** — confirms name field is hidden on login, visible on signup
4. **Institute name field for institute role** — checks conditional field rendering for institute users
5. **Form submission calls onSubmit** — verifies submit handler is triggered on button click
6. **Loading state disables submit button** — checks "Processing..." text and disabled state
7. **Submit error is displayed** — verifies error messages from the `errors.submit` prop render correctly
8. **Toggle login/signup link works** — confirms `onToggleLogin` callback fires on click
9. **Forgot password link works** — confirms `onForgotPassword` callback fires on click
10. **Google login button works** — confirms `onGoogleLogin` callback fires on click

## Test Results

```
Test Suites: 1 passed, 1 total
Tests:       10 passed, 10 total
```

## Notes

- No production code was changed
- Uses Jest + React Testing Library (already set up in the project)
- Follows the same patterns as existing tests in `utils/__tests__/formValidation.test.js`

## Acceptance Criteria

- [x] Test file at `components/__tests__/AuthForm.test.js`
- [x] At least 5 test cases (10 provided)
- [x] All tests pass (`npm test`)
- [x] No production code changed

## Related Issue

Closes #311