### PR TITLE
ui: add loading skeleton for dashboard cards

### DIFF
--- a/components/InstituteDashboard.js
+++ b/components/InstituteDashboard.js
@@ -44,6 +44,7 @@ import {
 import { Navbar } from "./Navbar";
 import dynamic from "next/dynamic";
 import ChartSkeleton from "@/components/ui/ChartSkeleton";
+import DashboardSkeleton from "@/components/ui/DashboardSkeleton";
 
 const AttendanceTrendsChart = dynamic(
   () => import("@/components/charts/AttendanceTrendsChart"),
@@ -60,6 +61,12 @@ const InstituteDashboard = () => {
   );
   const [currentTime, setCurrentTime] = useState(new Date());
   const [isLoading, setIsLoading] = useState(false);
+  const [initialLoading, setInitialLoading] = useState(true);
+
+  useEffect(() => {
+    const timer = setTimeout(() => setInitialLoading(false), 1200);
+    return () => clearTimeout(timer);
+  }, []);
 
   // Mock data - in real app, this would come from your backend
   const [dashboardData, setDashboardData] = useState({
@@ -1031,6 +1038,10 @@ const InstituteDashboard = () => {
       </div>
     </div>
   );
+
+  if (initialLoading) {
+    return <DashboardSkeleton />;
+  }
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-gray-900 via-gray-800 to-gray-900">

--- a/components/TeacherDashboardComponent.js
+++ b/components/TeacherDashboardComponent.js
@@ -54,6 +54,7 @@ import {
 import dynamic from "next/dynamic";
 import ChartSkeleton from "@/components/ui/ChartSkeleton";
 import DashboardSkeleton from "@/components/ui/DashboardSkeleton";
+import SkeletonCard from "@/components/ui/SkeletonCard";
 
 const AttendanceTrendsChart = dynamic(
   () => import("@/components/charts/AttendanceTrendsChart"),
@@ -664,9 +665,10 @@ const TeacherDashboard = () => {
 
             <div className="space-y-3">
               {isLoadingRequests ? (
-                <div className="text-center py-8">
-                  <RefreshCw className="w-8 h-8 text-gray-600 mx-auto mb-3 animate-spin" />
-                  <p className="text-gray-400">Loading exception requests...</p>
+                <div className="space-y-3">
+                  {[1, 2, 3].map((i) => (
+                    <SkeletonCard key={i} />
+                  ))}
                 </div>
               ) : requestsError ? (
                 <div className="text-center py-8">

--- a/components/ui/SkeletonCard.js
+++ b/components/ui/SkeletonCard.js
@@ -1,8 +1,14 @@
-const SkeletonCard = () => {
+const SkeletonCard = ({ lines = 2, height = "h-4" }) => {
   return (
-    <div className="animate-pulse bg-gray-800 rounded-xl p-6">
-      <div className="h-4 bg-gray-700/50 rounded w-3/4 mb-3"></div>
-      <div className="h-4 bg-gray-700/50 rounded w-1/2"></div>
+    <div className="animate-pulse bg-gray-800/50 rounded-xl p-4 border border-gray-700/50">
+      {Array.from({ length: lines }).map((_, i) => (
+        <div
+          key={i}
+          className={`${height} bg-gray-700/40 rounded ${
+            i === lines - 1 ? "w-1/2" : i === 0 ? "w-3/4" : "w-2/3"
+          } ${i > 0 ? "mt-3" : ""}`}
+        />
+      ))}
     </div>
   );
 };


### PR DESCRIPTION
## Description

This PR adds skeleton loaders to dashboard components as requested in issue #305.

## Changes

### `components/InstituteDashboard.js`
- Added `initialLoading` state with 1.2s timer
- Shows `DashboardSkeleton` during initial load (was missing before)
- Imported `DashboardSkeleton` from `@/components/ui/`

### `components/TeacherDashboardComponent.js`
- Replaced the spinning loader in exception requests section with `SkeletonCard` components
- Shows 3 skeleton cards while requests are being fetched instead of a plain spinner
- Imported `SkeletonCard` from `@/components/ui/`

### `components/ui/SkeletonCard.js`
- Added `lines` prop to control number of skeleton lines (default: 2)
- Added `height` prop to control line height (default: `h-4`)
- Added border and proper background styling to match dashboard card design
- Uses `animate-pulse` from Tailwind as required

## Screenshots

Before:
- InstituteDashboard: no loading state at all
- TeacherDashboard exception requests: plain spinner with text

After:
- InstituteDashboard: full-page skeleton during initial load
- TeacherDashboard exception requests: 3 skeleton cards matching the actual card layout

## Acceptance Criteria

- [x] Reusable `SkeletonCard` component in `components/ui/`
- [x] At least one dashboard uses the skeleton during loading (InstituteDashboard + TeacherDashboard inline)
- [x] Animation uses Tailwind `animate-pulse`
- [x] No existing functionality broken (build passes)

## Related Issue

Closes #305