### PR TITLE
Add feature: password strength indicator to the sign-up form

### DIFF
--- a/components/AuthForm.js
+++ b/components/AuthForm.js
@@ -235,6 +235,36 @@ export default function AuthForm({
                 Min 8 characters with upper, lower, number, and special character.
               </p>
             )}
+            {!isLogin && (
+              <div className="mt-3 space-y-2">
+                <div className="flex items-center justify-between text-xs">
+                  <span className="text-gray-400 font-medium">Password Strength</span>
+                  <span
+                    data-testid="password-strength-label"
+                    className={`font-semibold transition-colors duration-300 ${
+                      password.length > 0 ? passwordStrength.textClass : "text-gray-500"
+                    }`}
+                  >
+                    {password.length > 0 ? passwordStrength.label : "None"}
+                  </span>
+                </div>
+                <div className="grid grid-cols-4 gap-1.5 h-1.5 w-full bg-gray-700/30 rounded-full overflow-hidden">
+                  {[0, 1, 2, 3].map((index) => {
+                    const activeSegments = password.length > 0 ? Math.min(passwordStrength.score + 1, 4) : 0;
+                    const isFilled = index < activeSegments;
+                    return (
+                      <div
+                        key={index}
+                        data-testid={`password-strength-bar-${index}`}
+                        className={`h-full rounded-full transition-all duration-500 ease-out ${
+                          isFilled ? passwordStrength.barClass : "bg-gray-700/50"
+                        }`}
+                      />
+                    );
+                  })}
+                </div>
+              </div>
+            )}
           </div>
 
           {isLogin && (

--- a/components/_tests_/AuthForm.test.js
+++ b/components/_tests_/AuthForm.test.js
@@ -79,4 +79,53 @@ describe("AuthForm", () => {
 
     expect(onSubmit).toHaveBeenCalled();
   });
+
+  test("password strength indicator is not visible in login mode", () => {
+    render(<AuthForm {...props} isLogin={true} />);
+    expect(screen.queryByText(/password strength/i)).not.toBeInTheDocument();
+  });
+
+  test("password strength indicator is visible in sign-up mode", () => {
+    render(<AuthForm {...props} isLogin={false} />);
+    expect(screen.getByText(/password strength/i)).toBeInTheDocument();
+  });
+
+  test("updates password strength label and segments dynamically based on input", () => {
+    const { rerender } = render(<AuthForm {...props} isLogin={false} password="" />);
+    
+    // Empty password
+    expect(screen.getByTestId("password-strength-label")).toHaveTextContent("None");
+    for (let i = 0; i < 4; i++) {
+      expect(screen.getByTestId(`password-strength-bar-${i}`)).toHaveClass("bg-gray-700/50");
+    }
+
+    // Weak password
+    rerender(<AuthForm {...props} isLogin={false} password="hello" />);
+    expect(screen.getByTestId("password-strength-label")).toHaveTextContent("Weak");
+    expect(screen.getByTestId("password-strength-bar-0")).toHaveClass("bg-red-500");
+    expect(screen.getByTestId("password-strength-bar-1")).toHaveClass("bg-gray-700/50");
+
+    // Fair password (length < 8, uppercase)
+    rerender(<AuthForm {...props} isLogin={false} password="Hello" />);
+    expect(screen.getByTestId("password-strength-label")).toHaveTextContent("Fair");
+    expect(screen.getByTestId("password-strength-bar-0")).toHaveClass("bg-orange-500");
+    expect(screen.getByTestId("password-strength-bar-1")).toHaveClass("bg-orange-500");
+    expect(screen.getByTestId("password-strength-bar-2")).toHaveClass("bg-gray-700/50");
+
+    // Strong password (length < 8, uppercase, number)
+    rerender(<AuthForm {...props} isLogin={false} password="Hello1" />);
+    expect(screen.getByTestId("password-strength-label")).toHaveTextContent("Strong");
+    expect(screen.getByTestId("password-strength-bar-0")).toHaveClass("bg-yellow-500");
+    expect(screen.getByTestId("password-strength-bar-1")).toHaveClass("bg-yellow-500");
+    expect(screen.getByTestId("password-strength-bar-2")).toHaveClass("bg-yellow-500");
+    expect(screen.getByTestId("password-strength-bar-3")).toHaveClass("bg-gray-700/50");
+
+    // Very Strong password (length < 8, uppercase, number, symbol)
+    rerender(<AuthForm {...props} isLogin={false} password="Hello1!" />);
+    expect(screen.getByTestId("password-strength-label")).toHaveTextContent("Very Strong");
+    expect(screen.getByTestId("password-strength-bar-0")).toHaveClass("bg-green-500");
+    expect(screen.getByTestId("password-strength-bar-1")).toHaveClass("bg-green-500");
+    expect(screen.getByTestId("password-strength-bar-2")).toHaveClass("bg-green-500");
+    expect(screen.getByTestId("password-strength-bar-3")).toHaveClass("bg-green-500");
+  });
 });


### PR DESCRIPTION
## PR type
✨ New feature
🎨 UI/UX improvement

## Description
Below the password input (sign-up only), a 4 level strength bar is added for indicating password strength.

## Related Issues

Closes #307 

## Checked features
Indicator visible in sign-up mode only

Updates dynamically as the user types

At least 3 strength levels with distinct colours

Includes a text label alongside the colour bar

## Before
<img width="1423" height="1604" alt="Screenshot 2026-05-21 212126" src="https://github.com/user-attachments/assets/339f10f7-3123-481a-89e6-434f27729bff" />

## After
<img width="1391" height="1416" alt="Screenshot 2026-05-21 212207" src="https://github.com/user-attachments/assets/22f012ce-f301-4fa0-8858-06a9c3181bd8" />
<img width="1355" height="1422" alt="Screenshot 2026-05-21 212248" src="https://github.com/user-attachments/assets/ba88c7ad-76a2-494d-967f-73d5ce0fc092" />
