### PR TITLE
fix: replace unimported NextResponse.json() with jsonError() in 4 API auth handlers

### DIFF
--- a/app/api/conversations/route.js
+++ b/app/api/conversations/route.js
@@ -35,12 +35,9 @@ export async function POST(req) {
     const authResult = await verifyFirebaseToken(token);
 
     if (!authResult.valid) {
-      return NextResponse.json(
-        {
-          error: "Unauthorized",
-          reason: authResult.reason,
-        },
-        { status: 401 }
+      return jsonError(
+        { message: "Unauthorized", reason: authResult.reason },
+        401
       );
     }
 
@@ -102,12 +99,9 @@ export async function GET(request) {
     const authResult = await verifyFirebaseToken(token);
 
     if (!authResult.valid) {
-      return NextResponse.json(
-        {
-          error: "Unauthorized",
-          reason: authResult.reason,
-        },
-        { status: 401 }
+      return jsonError(
+        { message: "Unauthorized", reason: authResult.reason },
+        401
       );
     }
 

--- a/app/api/groq/route.js
+++ b/app/api/groq/route.js
@@ -91,12 +91,9 @@ export async function POST(request) {
     const authResult = await verifyFirebaseToken(token);
 
     if (!authResult.valid) {
-      return NextResponse.json(
-        {
-          error: "Unauthorized",
-          reason: authResult.reason,
-        },
-        { status: 401 }
+      return jsonError(
+        { message: "Unauthorized", reason: authResult.reason },
+        401
       );
     }
 

--- a/app/api/labels/route.js
+++ b/app/api/labels/route.js
@@ -36,12 +36,9 @@ export async function GET(request) {
     const authResult = await verifyFirebaseToken(token);
 
     if (!authResult.valid) {
-      return NextResponse.json(
-        {
-          error: "Unauthorized",
-          reason: authResult.reason,
-        },
-        { status: 401 }
+      return jsonError(
+        { message: "Unauthorized", reason: authResult.reason },
+        401
       );
     }
 

--- a/app/api/register/route.js
+++ b/app/api/register/route.js
@@ -41,12 +41,9 @@ export async function POST(req) {
     const authResult = await verifyFirebaseToken(token);
 
     if (!authResult.valid) {
-      return NextResponse.json(
-        {
-          error: "Unauthorized",
-          reason: authResult.reason,
-        },
-        { status: 401 }
+      return jsonError(
+        { message: "Unauthorized", reason: authResult.reason },
+        401
       );
     }
 


### PR DESCRIPTION
## Summary

Fixes a critical bug where 4 API routes use `NextResponse.json()` in auth-failure blocks **without importing `NextResponse`**, causing a `ReferenceError` (500) instead of the intended `401 Unauthorized` response.

Closes #377

## Problem

These files import `jsonError` / `jsonSuccess` from `@/lib/api-response` but directly call `NextResponse.json()` in their auth error paths — `NextResponse` is never imported.

This bug is **silent on the happy path** (authenticated users work fine) but crashes on every invalid or expired token.

## Files Changed

| File | Occurrences Fixed |
|------|:-:|
| `app/api/groq/route.js` | 1 |
| `app/api/conversations/route.js` | 2 (POST + GET) |
| `app/api/register/route.js` | 1 |
| `app/api/labels/route.js` | 1 |

**Total: 5 occurrences across 4 files**

## Fix

Replaced all `NextResponse.json()` calls with the already-imported `jsonError()` helper:

```diff
  if (!authResult.valid) {
-   return NextResponse.json(
-     { error: "Unauthorized", reason: authResult.reason },
-     { status: 401 }
-   );
+   return jsonError(
+     { message: "Unauthorized", reason: authResult.reason },
+     401
+   );
  }

