### PR TITLE
fix: prevent PWA from caching authenticated API responses (sensitive data leakage)

### DIFF
--- a/hooks/useAuth.js
+++ b/hooks/useAuth.js
@@ -63,6 +63,18 @@ export const useAuth = () => {
         } else {
           setUser(null);
           setUserProfile(null);
+
+          // Clear PWA caches on logout to prevent data leakage on shared devices
+          if (typeof window !== "undefined" && "caches" in window) {
+            try {
+              const cacheKeys = await caches.keys();
+              await Promise.all(
+                cacheKeys.map((key) => caches.delete(key))
+              );
+            } catch (cacheErr) {
+              console.warn("Failed to clear PWA caches on auth state change:", cacheErr);
+            }
+          }
         }
 
         setError(null);
@@ -88,6 +100,18 @@ export const useAuth = () => {
       await firebaseSignOut(auth);
       setUser(null);
       setUserProfile(null);
+
+      // Clear all PWA caches to prevent cached API responses from persisting after logout
+      if (typeof window !== "undefined" && "caches" in window) {
+        try {
+          const cacheKeys = await caches.keys();
+          await Promise.all(
+            cacheKeys.map((key) => caches.delete(key))
+          );
+        } catch (cacheErr) {
+          console.warn("Failed to clear PWA caches on sign out:", cacheErr);
+        }
+      }
     } catch (err) {
       console.error("Sign out error:", err);
       setError(err.message);

--- a/lib/api-response.js
+++ b/lib/api-response.js
@@ -10,7 +10,14 @@ import { NextResponse } from "next/server";
  * // Response body: { "error": "User not found" }
  */
 export function jsonError(error, status = 500) {
-  return NextResponse.json({ error }, { status });
+  return NextResponse.json({ error }, {
+    status,
+    headers: {
+      "Cache-Control": "no-store, no-cache, must-revalidate, proxy-revalidate",
+      Pragma: "no-cache",
+      Expires: "0",
+    },
+  });
 }
 
 /**
@@ -23,5 +30,12 @@ export function jsonError(error, status = 500) {
  * // Response body: { "success": true, "data": { "user": { ... } } }
  */
 export function jsonSuccess(data, status = 200) {
-  return NextResponse.json({ success: true, data }, { status });
+  return NextResponse.json({ success: true, data }, {
+    status,
+    headers: {
+      "Cache-Control": "no-store, no-cache, must-revalidate, proxy-revalidate",
+      Pragma: "no-cache",
+      Expires: "0",
+    },
+  });
 }

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -67,18 +67,6 @@ const withPWA = withPWAInit({
           },
         },
       },
-      {
-        urlPattern: /\/api\/.*$/i,
-        handler: "NetworkFirst",
-        options: {
-          cacheName: "apis",
-          expiration: {
-            maxEntries: 16,
-            maxAgeSeconds: 24 * 60 * 60,
-          },
-          networkTimeoutSeconds: 10,
-        },
-      },
     ],
   },
 });
@@ -105,6 +93,27 @@ const nextConfig = {
           {
             key: "Permissions-Policy",
             value: "camera=(), microphone=(), geolocation=()",
+          },
+        ],
+      },
+      {
+        source: "/api/:path*",
+        headers: [
+          {
+            key: "Cache-Control",
+            value: "no-store, no-cache, must-revalidate, proxy-revalidate",
+          },
+          {
+            key: "Pragma",
+            value: "no-cache",
+          },
+          {
+            key: "Expires",
+            value: "0",
+          },
+          {
+            key: "Surrogate-Control",
+            value: "no-store",
           },
         ],
       },


### PR DESCRIPTION
## Description

This PR addresses a critical privacy issue where the PWA service worker cached all `/api/*` responses — including authenticated ones — for up to 24 hours using a `NetworkFirst` strategy.

### Changes Made

**1. Removed API caching from PWA workbox config** (`next.config.mjs`)
- Deleted the `/api/.*` runtime caching rule
- Since all API routes verify Firebase auth tokens, no API response should be cached by the service worker

**2. Added Cache-Control headers at the Next.js config level** (`next.config.mjs`)
- All `/api/:path*` routes now return `Cache-Control: no-store, no-cache, must-revalidate, proxy-revalidate`
- Additional `Pragma: no-cache`, `Expires: 0`, and `Surrogate-Control: no-store` headers for maximum browser compliance

**3. Added Cache-Control headers to every API response helper** (`lib/api-response.js`)
- Both `jsonSuccess()` and `jsonError()` now include no-store headers
- Defense-in-depth: even if the Next.js config doesn't apply, individual responses still prevent caching

**4. Clear PWA caches on logout** (`hooks/useAuth.js`)
- `signOut()` now deletes all caches via the Cache Storage API after Firebase sign out
- `onAuthStateChanged` also clears caches when user becomes null (handles token expiry, session invalidation, external logout)

### Impact
- ✅ No API responses cached by the service worker
- ✅ Cache-Control headers prevent browser/proxy caching of API responses
- ✅ All caches cleared on logout — no stale data left behind on shared devices
- ✅ Backward compatible — all existing functionality preserved
- ✅ Defense-in-depth at multiple layers

Closes #314