### PR TITLE
fix: ProtectedRoute race condition — skeleton now tied to auth loading state

### DIFF
--- a/components/ProtectedRoute.js
+++ b/components/ProtectedRoute.js
@@ -4,9 +4,11 @@ import { useEffect, useState } from "react";
 import { useRouter, usePathname } from "next/navigation";
 import { useAuthContext } from "@/contexts/AuthContext";
 
+const AUTH_TIMEOUT = 15000;
+
 export default function ProtectedRoute({
   children,
-  allowedRoles = null, // null = all roles allowed
+  allowedRoles = null,
   requireEmailVerification = true,
 }) {
   const { user, userProfile, loading, isAuthenticated, hasProfile } =
@@ -14,36 +16,47 @@ export default function ProtectedRoute({
   const router = useRouter();
   const pathname = usePathname();
   const [redirecting, setRedirecting] = useState(false);
+  const [authTimedOut, setAuthTimedOut] = useState(false);
 
   useEffect(() => {
+    if (!loading) return;
+
+    const timer = setTimeout(() => {
+      setAuthTimedOut(true);
+    }, AUTH_TIMEOUT);
+
+    return () => clearTimeout(timer);
+  }, [loading]);
+
+  useEffect(() => {
+    if (authTimedOut) {
+      safeRedirect("/auth");
+      return;
+    }
+
     if (loading) return;
 
-    // Not logged in → go to auth
     if (!isAuthenticated) {
       safeRedirect("/auth");
       return;
     }
 
-    // Email not verified (if required) → go to verify page
     if (requireEmailVerification && user && !user.emailVerified) {
       safeRedirect("/verify");
       return;
     }
 
-    // No profile yet → force profile creation
     if (isAuthenticated && !hasProfile) {
       safeRedirect("/profile");
       return;
     }
 
-    // Role-based access control
     if (
-      allowedRoles && // only check if not null
+      allowedRoles &&
       userProfile &&
       !allowedRoles.includes(userProfile.role)
     ) {
-      // redirect user to their dashboard
-      let target = "/auth"; // fallback
+      let target = "/auth";
       switch (userProfile.role) {
         case "student":
           target = "/student/dashboard";
@@ -69,9 +82,9 @@ export default function ProtectedRoute({
     hasProfile,
     requireEmailVerification,
     allowedRoles,
+    authTimedOut,
   ]);
 
-  // Prevent infinite redirects by checking current pathname
   const safeRedirect = (target) => {
     if (pathname !== target) {
       setRedirecting(true);
@@ -79,28 +92,7 @@ export default function ProtectedRoute({
     }
   };
 
-  // // Loading spinner while auth state is resolving
-  // if (loading || redirecting) {
-  //   return (
-  //     <div className="min-h-screen flex items-center justify-center bg-gray-900">
-  //       <div className="text-center">
-  //         <div className="w-12 h-12 border-4 border-indigo-600 border-t-transparent rounded-full animate-spin mx-auto mb-4"></div>
-  //         <p className="text-gray-300">Loading...</p>
-  //       </div>
-  //     </div>
-  //   );
-  // }
-const [showSkeleton, setShowSkeleton] = useState(true);
-
-useEffect(() => {
-  const timer = setTimeout(() => {
-    setShowSkeleton(false);
-  }, 5000);
-
-  return () => clearTimeout(timer);
-}, []);
-
-if ((loading || redirecting) && showSkeleton) {
+if (loading || redirecting) {
   return (
     <div className="min-h-screen bg-[#050816] text-white p-6 animate-pulse">
       


### PR DESCRIPTION
## Description

Fixes a race condition where the ProtectedRoute component dismissed its skeleton loading screen after exactly 5 seconds regardless of whether Firebase authentication had actually resolved. On slow networks, this caused a brief window where protected content could fail to render correctly or flash before the redirect to /auth kicked in.

### The Problem

The component used a hardcoded `setTimeout` of 5 seconds to hide the skeleton:

```js
const [showSkeleton, setShowSkeleton] = useState(true);

useEffect(() => {
  const timer = setTimeout(() => {
    setShowSkeleton(false);
  }, 5000);
  return () => clearTimeout(timer);
}, []);
```

The skeleton was shown when `(loading || redirecting) && showSkeleton` — meaning after 5 seconds the skeleton vanished even if `loading` was still `true`. The component would then return `null` (since auth hadn't resolved), creating a blank flash before the eventual redirect.

### Changes Made

1. **Removed the `showSkeleton` state and its hardcoded 5-second timeout** — the skeleton now shows whenever `loading` or `redirecting` is true, without any artificial timeout

2. **Added 15-second fail-safe timeout** — if Firebase auth takes longer than 15 seconds, the component automatically redirects to `/auth` so users don't get stuck on an indefinite skeleton

3. **Cleaned up dead code** — removed a previously commented-out loading spinner that had been replaced by the skeleton approach

### Flow comparison

| Scenario | Before | After |
|---|---|---|
| Auth resolves in <5s | Skeleton → children (correct) | Skeleton → children (correct) |
| Auth resolves in >5s | Skeleton dismissed → blank screen → redirect | Skeleton stays → redirect (correct) |
| Firebase never responds | Skeleton dismissed after 5s → blank screen forever | Skeleton stays for 15s → redirect to /auth |

Closes #316