### PR TITLE
feat(ui): implement smooth noticeboard transitions and optimize mobil…

### DIFF
--- a/components/noticeBoard.js
+++ b/components/noticeBoard.js
@@ -405,7 +405,7 @@ const SmartNoticeBoard = () => {
 
           {/* Category Filters */}
           {isFilterOpen && (
-            <div className="mb-6 p-4 bg-black/40 border border-gray-600 rounded-xl backdrop-blur-sm">
+            <div className="mb-6 p-4 bg-black/40 border border-gray-600 rounded-xl backdrop-blur-sm transition-all duration-300">
               <h3 className="text-white font-semibold mb-3">Categories</h3>
               <div className="flex flex-wrap gap-2">
                 {categories.map((category) => {
@@ -415,10 +415,10 @@ const SmartNoticeBoard = () => {
                     <button
                       key={category.id}
                       onClick={() => setSelectedCategory(category.id)}
-                      className={`flex items-center space-x-2 px-3 py-2 rounded-lg transition-all duration-300 ${
+                      className={`flex items-center space-x-2 px-3 py-2 rounded-xl transition-all duration-300 hover:scale-105 active:scale-95 ${
                         isSelected
-                          ? "bg-accent text-white"
-                          : "bg-gray-700/50 text-gray-300 hover:bg-gray-600/50"
+                          ? "bg-gradient-to-r from-accent to-purple-600 text-white shadow-lg shadow-accent/25 border border-accent/20"
+                          : "bg-gray-800/30 text-gray-300 hover:bg-gray-700/50 hover:text-white border border-white/5"
                       }`}
                     >
                       <Icon className="w-4 h-4" />
@@ -483,8 +483,8 @@ const SmartNoticeBoard = () => {
 
       return (
         <div
-          key={notice.id}
-          className={`group relative bg-black/40 backdrop-blur-sm border rounded-2xl p-6 transition-all duration-300 hover:scale-[1.01] hover:shadow-2xl ${
+          key={`${notice.id}-${selectedCategory}-${showOnlyUnread}`}
+          className={`group relative bg-black/40 backdrop-blur-sm border rounded-2xl p-4 sm:p-6 transition-all duration-300 hover:scale-[1.01] hover:shadow-2xl animate-fade-in-up ${
             isRead
               ? "border-gray-600"
               : "border-accent/50 shadow-lg shadow-accent/10"
@@ -500,11 +500,11 @@ const SmartNoticeBoard = () => {
                       )}
 
                       {/* Header */}
-                      <div className="flex items-start justify-between mb-4">
+                      <div className="flex flex-col sm:flex-row sm:items-start justify-between gap-3 sm:gap-4 mb-4">
                         <div className="flex-1">
                           <div className="flex items-center space-x-3 mb-2">
                             <h3
-                              className={`text-lg font-semibold transition-colors duration-300 ${
+                              className={`text-base sm:text-lg font-semibold transition-colors duration-300 ${
                                 isRead ? "text-gray-300" : "text-white"
                               }`}
                             >
@@ -516,20 +516,20 @@ const SmartNoticeBoard = () => {
                           </div>
 
                           {/* Meta Info */}
-                          <div className="flex flex-wrap items-center gap-4 text-sm text-gray-400">
+                          <div className="flex flex-wrap items-center gap-2 sm:gap-4 text-xs sm:text-sm text-gray-400">
                             <div className="flex items-center space-x-1">
-                              <User className="w-4 h-4" />
+                              <User className="w-3.5 h-3.5 sm:w-4 h-4" />
                               <span>{notice.author}</span>
                             </div>
                             <div className="flex items-center space-x-1">
-                              <Clock className="w-4 h-4" />
+                              <Clock className="w-3.5 h-3.5 sm:w-4 h-4" />
                               <span>{getRelativeTime(notice.createdAt)}</span>
                             </div>
                             <div
-                              className={`flex items-center space-x-1 px-2 py-1 rounded-full ${priorityStyle.bg} ${priorityStyle.border} border`}
+                              className={`flex items-center space-x-1 px-2 py-0.5 sm:py-1 rounded-full text-[10px] sm:text-xs ${priorityStyle.bg} ${priorityStyle.border} border`}
                             >
                               <AlertCircle
-                                className={`w-3 h-3 ${priorityStyle.text}`}
+                                className={`w-2.5 h-2.5 sm:w-3 h-3 ${priorityStyle.text}`}
                               />
                               <span
                                 className={`capitalize ${priorityStyle.text}`}
@@ -547,7 +547,7 @@ const SmartNoticeBoard = () => {
                               ? markAsUnread(notice.id)
                               : markAsRead(notice.id)
                           }
-                          className={`p-2 rounded-lg transition-all duration-300 ${
+                          className={`self-end sm:self-start p-2 rounded-lg transition-all duration-300 ${
                             isRead
                               ? "text-gray-500 hover:text-gray-400 hover:bg-gray-700/50"
                               : "text-accent hover:text-accent/80 hover:bg-accent/10"
@@ -564,7 +564,7 @@ const SmartNoticeBoard = () => {
 
                       {/* Content */}
                       <p
-                        className={`leading-relaxed mb-4 ${
+                        className={`leading-relaxed mb-4 text-sm sm:text-base ${
                           isRead ? "text-gray-400" : "text-gray-300"
                         }`}
                       >
@@ -573,11 +573,11 @@ const SmartNoticeBoard = () => {
 
                       {/* Tags */}
                       {notice.tags && notice.tags.length > 0 && (
-                        <div className="flex flex-wrap gap-2">
+                        <div className="flex flex-wrap gap-1.5 sm:gap-2">
                           {notice.tags.map((tag) => (
                             <span
                               key={tag}
-                              className="px-3 py-1 bg-gray-700/50 text-gray-300 text-xs rounded-full border border-gray-600"
+                              className="px-2.5 py-0.5 sm:px-3 sm:py-1 bg-gray-700/50 text-gray-300 text-[10px] sm:text-xs rounded-full border border-gray-600"
                             >
                               #{tag}
                             </span>
@@ -587,7 +587,7 @@ const SmartNoticeBoard = () => {
 
                       {/* Glow effect for unread high priority */}
                       {!isRead && notice.priority === "high" && (
-                        <div className="absolute inset-0 bg-gradient-to-r from-red-500/10 to-pink-500/10 rounded-2xl -z-10 blur-xl" />
+                        <div className="absolute inset-0 bg-gradient-to-r from-red-500/10 to-pink-500/10 rounded-2xl -z-10 blur-xl pointer-events-none opacity-50 sm:opacity-100" />
                       )}
                     </div>
                   );
@@ -706,6 +706,22 @@ const SmartNoticeBoard = () => {
           </div>
         </div>
       )}
+
+      <style jsx>{`
+        @keyframes fadeInUp {
+          from {
+            opacity: 0;
+            transform: translateY(12px);
+          }
+          to {
+            opacity: 1;
+            transform: translateY(0);
+          }
+        }
+        .animate-fade-in-up {
+          animation: fadeInUp 0.4s cubic-bezier(0.16, 1, 0.3, 1) forwards;
+        }
+      `}</style>
     </div>
   );
 };


### PR DESCRIPTION
#394 

## Description
This Pull Request improves the UI responsiveness, active state styles, and layout transitions of the Learnova Smart Notice Board (`components/noticeBoard.js`). It eliminates abrupt list rendering jumps, provides dynamic interactive feedback on category buttons, and prevents layout overlapping on compact mobile viewports (320px–360px).

## Key Changes
- **Smooth Entry Transitions**: Integrated a custom cubic-bezier animation (`@keyframes fadeInUp` / `animate-fade-in-up`) coupled with a dynamic React key binding (`key={`${notice.id}-${selectedCategory}-${showOnlyUnread}`}`). This forces cards to re-mount and slide/fade elegantly into view when filters are updated, avoiding layout jarring.
- **Premium Category Filters**: Redesigned category filter buttons to use active styling and neon-glow highlights (`bg-gradient-to-r from-accent to-purple-600`) and added scaling micro-interactions on hover and click (`hover:scale-105 active:scale-95`).
- **No-Overlap Mobile Metadata**: Adjusted card padding (`p-4 sm:p-6`) and re-structured the card headers to adapt dynamically on mobile screens (`flex flex-col sm:flex-row gap-3 sm:gap-4`). Metadata layers now wrap cleanly (`flex flex-wrap items-center gap-2 sm:gap-4 text-xs sm:text-sm`), resolving text overlaps on compact widths like the iPhone SE (320px).
- **Scaled Priority Indicators**: Rescaled priority badges (`text-[10px] sm:text-xs px-2 py-0.5 sm:py-1`) and icons to fit mobile screens. Added `pointer-events-none` to absolute glows to prevent layout interference.

## How to Test and Verify
1. Navigate to the Smart Notice Board page.
2. Toggle categories or filter by "Unread" only.
3. Observe notices floating and sliding in smoothly from the bottom.
4. Resize the viewport to ~320px width (e.g. mobile simulator) and confirm that headers, dates, and badges do not overlap or wrap awkwardly.
