### PR TITLE
fix: prevent NoticeBoard crash on malformed localStorage data

### DIFF
--- a/components/noticeBoard.js
+++ b/components/noticeBoard.js
@@ -187,11 +187,22 @@ const SmartNoticeBoard = () => {
       setNotices(userRelevantNotices);
       setLoading(false);
 
-      // Load read notices from localStorage
+      // Load read notices from localStorage (defensive parsing)
       const userId = getUserId();
       const savedReadNotices = localStorage.getItem(`readNotices_${userId}`);
       if (savedReadNotices) {
-        setReadNotices(new Set(JSON.parse(savedReadNotices)));
+        try {
+          const parsed = JSON.parse(savedReadNotices);
+          if (Array.isArray(parsed)) {
+            setReadNotices(new Set(parsed));
+          } else {
+            // If stored value is malformed, remove it
+            localStorage.removeItem(`readNotices_${userId}`);
+          }
+        } catch (err) {
+          console.error("Failed to parse read notices from localStorage:", err);
+          localStorage.removeItem(`readNotices_${userId}`);
+        }
       }
     } else {
       setLoading(false);


### PR DESCRIPTION
## What type of PR is this?

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [ ] 🎨 UI/UX improvement
- [ ] ⚡ Performance improvement
- [ ] 🔒 Security fix

## Description

Added defensive error handling around `JSON.parse` usage in the `NoticeBoard` component's `localStorage` state restoration. This prevents the component from crashing when encountering malformed or corrupted data, allowing for a graceful recovery.

## Related Issues

Closes #414 

## Changes Made

- Wrapped `JSON.parse` in a `try-catch` block.
- Prevented component crash on malformed `localStorage` data.
- Added graceful recovery for corrupted `localStorage` state.

## Testing

How did you test these changes?
- [x] Tested locally
- [ ] Tested on mobile
- [ ] Tested different user roles
- [ ] All roles tested

## Screenshots (if applicable)

*N/A - Logic and error handling fix without UI changes.*

## Checklist

- [x] No hardcoded secrets or credentials
- [x] `.env.local` is not committed
- [x] Code follows project style
- [x] Changes are documented
- [x] Build passes locally (`npm run build`)
- [x] No console errors/warnings