### PR TITLE
fix: import onAuthStateChanged in useAuth.js to resolve global crash

### DIFF
--- a/hooks/useAuth.js
+++ b/hooks/useAuth.js
@@ -1,6 +1,6 @@
 import { useState, useEffect } from "react";
 import { auth, db } from "@/lib/firebaseConfig";
-import { onIdTokenChanged, signOut as firebaseSignOut } from "firebase/auth";
+import { onAuthStateChanged, onIdTokenChanged, signOut as firebaseSignOut } from "firebase/auth";
 import { doc, getDoc } from "firebase/firestore";
 
 /**


### PR DESCRIPTION
## What type of PR is this?

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [ ] 🎨 UI/UX improvement
- [ ] ⚡ Performance improvement
- [ ] 🔒 Security fix

## Description

This PR resolves a critical global runtime crash on client-side loading where the application fails with `ReferenceError: onAuthStateChanged is not defined`. The issue occurs because `onAuthStateChanged` was called within the `useAuth` hook but was never imported at the top of the file, completely blocking access to the platform since the `AuthContext` wraps the root layout.

## Related Issues

Closes #423 

## Changes Made

- Added the missing import for `onAuthStateChanged` from `"firebase/auth"` at the top of `hooks/useAuth.js`.
- Preserved existing imports (`onIdTokenChanged` and `signOut`) to ensure zero regression in auth-token tracking and session teardown.

## Testing

How did you test these changes?
- [x] Tested locally
- [ ] Tested on mobile
- [ ] Tested different user roles
- [ ] All roles tested

## Screenshots (if applicable)

*N/A - Non-UI runtime fix.*

## Checklist

- [x] No hardcoded secrets or credentials
- [x] `.env.local` is not committed
- [x] Code follows project style
- [x] Changes are documented
- [x] Build passes locally (`npm run build`)
- [x] No console errors/warnings