### PR TITLE
fix: clear notification timers on component unmount

### DIFF
--- a/contexts/NotificationContext.js
+++ b/contexts/NotificationContext.js
@@ -1,11 +1,13 @@
 "use client";
 
-import { createContext, useState } from "react";
+import { createContext, useState, useEffect, useRef } from "react";
 
 export const NotificationContext = createContext();
 
 export function NotificationProvider({ children }) {
   const [notifications, setNotifications] = useState([]);
+  // Keep timers so we can clear on unmount
+  const timersRef = useRef(new Map());
 
   const addNotification = (notification) => {
     const id = Date.now();
@@ -17,15 +19,28 @@ export function NotificationProvider({ children }) {
 
     setNotifications((prev) => [...prev, newNotification]);
 
-    setTimeout(() => {
+    // Auto-remove notification after 5s. Track timer so it can be cleared
+    // if the provider unmounts or the notification is removed early.
+    const timerId = setTimeout(() => {
       removeNotification(id);
+      // clean up timer map entry
+      timersRef.current.delete(id);
     }, 5000);
+
+    timersRef.current.set(id, timerId);
   };
 
   const removeNotification = (id) => {
     setNotifications((prev) =>
       prev.filter((notification) => notification.id !== id)
     );
+
+    // clear any pending timer for this notification
+    const t = timersRef.current.get(id);
+    if (t) {
+      clearTimeout(t);
+      timersRef.current.delete(id);
+    }
   };
 
   const clearNotifications = () => {
@@ -50,6 +65,13 @@ export function NotificationProvider({ children }) {
         }))
     );
   };
+  useEffect(() => {
+    return () => {
+      // clear any remaining timeouts when provider unmounts
+      timersRef.current.forEach((t) => clearTimeout(t));
+      timersRef.current.clear();
+    };
+  }, []);
 
   return (
     <NotificationContext.Provider


### PR DESCRIPTION
## What type of PR is this?

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [ ] 🎨 UI/UX improvement
- [x] ⚡ Performance improvement
- [ ] 🔒 Security fix

## Description

Improved `NotificationContext` timer management by tracking and cleaning up notification timeouts during component unmount. 

## Related Issues

Closes #424

## Changes Made

- Added timeout tracking using `useRef`
- Cleared active timers during component cleanup
- Prevented possible state updates after component unmount
- Reduced potential memory leak warnings in React

## Testing

How did you test these changes?
- [x] Tested locally
- [ ] Tested on mobile
- [ ] Tested different user roles
- [ ] All roles tested

## Screenshots (if applicable)

*Not applicable (logic/state management change).*

## Checklist

- [x] No hardcoded secrets or credentials
- [x] `.env.local` is not committed
- [x] Code follows project style
- [x] Changes are documented
- [x] Build passes locally (`npm run build`)
- [x] No console errors/warnings