### PR TITLE
fix: SignIn and SignUp silent failure fixed

### DIFF
--- a/app/auth/page.js
+++ b/app/auth/page.js
@@ -24,7 +24,7 @@ import { validateForm, redirectBasedOnRole } from "@/utils/authUtils";
 import { USER_ROLES } from "@/constants/userRoles";
 
 export default function AuthPage() {
-  const [showRoleSelection, setShowRoleSelection] = useState(false);
+  const [showRoleSelection, setShowRoleSelection] = useState(true);
   const [isLogin, setIsLogin] = useState(true);
   const [selectedRole, setSelectedRole] = useState("");
 


### PR DESCRIPTION
## What type of PR is this?

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [ ] 🎨 UI/UX improvement
- [ ] ⚡ Performance improvement
- [ ] 🔒 Security fix

## Description

This PR resolves a major UX block where clicking the login or signup buttons on the credential forms resulted in a completely static, unresponsive screen showing no changes. 

The root cause was that `showRoleSelection` was initialized to `false` by default on mount. This bypassed the beautiful "Choose Your Role" card interface, meaning the user filled in the form with `selectedRole = ""`. Upon submission, `validateForm` failed due to the missing role, but because `components/AuthForm.js` has no UI component designed to render `errors.role`, the validation failed completely silently.

Initializing `showRoleSelection` to `true` resolves this by forcing the user to pick a role first, ensuring `selectedRole` is populated and form validation succeeds.

## Related Issues

Closes #432 

## Changes Made

- Modified `app/auth/page.js` to initialize `showRoleSelection` to `true` by default:
  ```javascript
  const [showRoleSelection, setShowRoleSelection] = useState(true);
  ```
- This guarantees that a user landing on `/auth` must first select their role (Student, Teacher, Institute, Admin) before filling out the form, ensuring correct field validation and matching dashboard redirections.

## Testing

How did you test these changes?
- [x] Tested locally
- [ ] Tested on mobile
- [ ] Tested different user roles
- [ ] All roles tested

## Checklist

- [x] No hardcoded secrets or credentials
- [x] `.env.local` is not committed
- [x] Code follows project style
- [x] Changes are documented
- [x] Build passes locally (`npm run build`)
- [x] No console errors/warnings
