### PR TITLE
Fix/Standardize Exceptions List API formatting consistency

### DIFF
--- a/app/api/exceptions/all/route.js
+++ b/app/api/exceptions/all/route.js
@@ -10,12 +10,9 @@ export async function GET(request) {
     const authResult = await verifyFirebaseToken(token);
 
     if (!authResult.valid) {
-      return NextResponse.json(
-        {
-          error: "Unauthorized",
-          reason: authResult.reason,
-        },
-        { status: 401 }
+      return jsonError(
+        { message: "Unauthorized", reason: authResult.reason },
+        401
       );
     }
 

--- a/app/api/exceptions/create/route.js
+++ b/app/api/exceptions/create/route.js
@@ -10,12 +10,9 @@ export async function POST(request) {
     const authResult = await verifyFirebaseToken(token);
 
     if (!authResult.valid) {
-      return NextResponse.json(
-        {
-          error: "Unauthorized",
-          reason: authResult.reason,
-        },
-        { status: 401 }
+      return jsonError(
+        { message: "Unauthorized", reason: authResult.reason },
+        401
       );
     }
 

--- a/app/api/exceptions/list/route.js
+++ b/app/api/exceptions/list/route.js
@@ -1,4 +1,3 @@
-import { NextResponse } from "next/server";
 import { connectDb } from "@/lib/mongodb";
 import { verifyFirebaseToken, getUserProfile } from "@/lib/firebase-admin";
 import { jsonError, jsonSuccess } from "@/lib/api-response";
@@ -11,12 +10,9 @@ export async function GET(request) {
     const authResult = await verifyFirebaseToken(token);
 
     if (!authResult.valid) {
-      return NextResponse.json(
-        {
-          error: "Unauthorized",
-          reason: authResult.reason,
-        },
-        { status: 401 }
+      return jsonError(
+        { message: "Unauthorized", reason: authResult.reason },
+        401
       );
     }
 

--- a/app/api/exceptions/update/route.js
+++ b/app/api/exceptions/update/route.js
@@ -11,12 +11,9 @@ export async function PUT(request) {
     const authResult = await verifyFirebaseToken(token);
 
     if (!authResult.valid) {
-      return NextResponse.json(
-        {
-          error: "Unauthorized",
-          reason: authResult.reason,
-        },
-        { status: 401 }
+      return jsonError(
+        { message: "Unauthorized", reason: authResult.reason },
+        401
       );
     }
 


### PR DESCRIPTION
## What type of PR is this?

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [ ] 🎨 UI/UX improvement
- [ ] ⚡ Performance improvement
- [ ] 🔒 Security fix

## Description

Standardizes API error responses in the Exceptions API paths to conform to the project-wide `jsonError` structure exported from `@/lib/api-response` rather than raw `NextResponse.json` payloads.

While the codebase generally standardizes error payloads, `app/api/exceptions/list/route.js` returned an unauthorized response with a manually formatted JSON payload. Furthermore, all four Exceptions routes (`list`, `all`, `create`, and `update`) manually attempted to call `NextResponse.json` for unauthorized errors, but three of those files lacked a `NextResponse` import entirely, presenting active server-crash vulnerabilities during unauthorized flows. This PR replaces all four manual calls with the project's standard `jsonError` helper.

## Related Issues

Closes #454

## Changes Made

- Refactored `app/api/exceptions/list/route.js` to use `jsonError` helper formatting for unauthorized tokens and removed the unused `NextResponse` import.
- Modified `app/api/exceptions/all/route.js` to return consistent `jsonError` format and prevented hidden ReferenceErrors.
- Modified `app/api/exceptions/create/route.js` to return consistent `jsonError` format and prevented hidden ReferenceErrors.
- Modified `app/api/exceptions/update/route.js` to return consistent `jsonError` format and prevented hidden ReferenceErrors.

## Testing

How did you test these changes?
- [x] Tested locally
- [ ] Tested on mobile
- [ ] Tested different user roles
- [ ] All roles tested

## Checklist

- [x] No hardcoded secrets or credentials
- [x] `.env.local` is not committed
- [x] Code follows project style
- [x] Changes are documented
- [x] Build passes locally (`npm run build`)
- [x] No console errors/warnings