### PR TITLE
feat(ui): redesign PWA install banner with premium glassmorphism and …

### DIFF
--- a/components/InstallPWA.js
+++ b/components/InstallPWA.js
@@ -81,45 +81,54 @@ export default function InstallPWA() {
   };
 
   if (!isMounted) return null;
-
-  if (isInstalled || !isVisible || !installPrompt) {
-    return null;
-  }
+  if (isInstalled || !installPrompt) return null;
 
   return (
-    <div className="fixed bottom-4 right-4 z-50 animate-slide-up">
-      <div className="bg-gradient-to-br from-purple-900/95 to-accent/95 backdrop-blur-xl border border-purple-500/30 rounded-2xl shadow-2xl p-6 max-w-sm">
+    <div
+      className={`fixed bottom-4 right-4 z-50 transition-all duration-500 ease-out transform ${
+        isVisible
+          ? "opacity-100 scale-100 translate-y-0"
+          : "opacity-0 scale-95 translate-y-8 pointer-events-none"
+      }`}
+    >
+      <div className="relative w-full max-w-sm sm:max-w-[360px] mx-auto bg-slate-900/90 backdrop-blur-xl border border-purple-500/20 rounded-2xl shadow-2xl p-5 sm:p-6 overflow-hidden transition-all duration-300 hover:border-purple-500/40 hover:shadow-purple-500/10">
+        {/* Ambient Background Glows */}
+        <div className="absolute -top-12 -left-12 h-24 w-24 rounded-full bg-purple-500/10 blur-2xl pointer-events-none" />
+        <div className="absolute -bottom-12 -right-12 h-24 w-24 rounded-full bg-blue-500/10 blur-2xl pointer-events-none" />
+
+        {/* Close Button */}
         <button
           onClick={handleDismiss}
-          className="absolute top-3 right-3 text-white/70 hover:text-white transition-colors"
-          aria-label="Dismiss"
+          className="absolute top-3 right-3 text-slate-400 hover:text-white transition-colors duration-200 cursor-pointer"
+          aria-label="Dismiss banner"
         >
-          <X className="w-5 h-5" />
+          <X className="w-4 h-4" />
         </button>
 
-        <div className="flex items-start gap-4">
-          <div className="bg-white/10 rounded-xl p-3">
-            <Download className="w-8 h-8 text-white" />
+        <div className="flex items-start gap-4 relative z-10">
+          <div className="inline-flex h-11 w-11 items-center justify-center rounded-xl bg-purple-500/10 ring-1 ring-purple-500/30 flex-shrink-0">
+            <Download className="h-5 w-5 text-purple-400" />
           </div>
 
-          <div className="flex-1">
-            <h3 className="text-white font-bold text-lg mb-2">
+          <div className="flex-1 min-w-0">
+            <h3 className="text-white font-extrabold text-base tracking-tight mb-1">
               Install Learnova
             </h3>
-            <p className="text-white/80 text-sm mb-4">
-              Install our app for quick access and offline use!
+            <p className="text-slate-300 text-xs sm:text-sm leading-normal">
+              Install our premium app for quick access and offline use!
             </p>
 
-            <div className="flex gap-3">
+            {/* Action Buttons */}
+            <div className="flex gap-2.5 mt-4">
               <button
                 onClick={handleInstall}
-                className="flex-1 bg-white text-purple-900 font-semibold py-2.5 px-4 rounded-lg hover:bg-white/90 transition-all duration-300 hover:scale-105"
+                className="flex-1 inline-flex items-center justify-center px-4 py-2 rounded-xl bg-gradient-to-r from-purple-600 to-indigo-600 text-white font-semibold text-xs hover:scale-[1.03] active:scale-[0.97] transition-all duration-300 cursor-pointer shadow-lg shadow-purple-600/20"
               >
                 Install
               </button>
               <button
                 onClick={handleDismiss}
-                className="px-4 text-white/80 hover:text-white transition-colors"
+                className="px-4 py-2 rounded-xl bg-slate-800/80 border border-white/5 text-slate-300 font-semibold text-xs hover:bg-slate-700/80 hover:text-white hover:scale-[1.03] active:scale-[0.97] transition-all duration-300 cursor-pointer"
               >
                 Not now
               </button>
@@ -127,21 +136,22 @@ export default function InstallPWA() {
           </div>
         </div>
 
-        <div className="mt-4 pt-4 border-t border-white/10">
-          <ul className="space-y-2 text-white/70 text-xs">
-            <li className="flex items-center gap-2">
-              <span className="w-1.5 h-1.5 bg-accent rounded-full"></span>
+        {/* Benefits Section */}
+        <div className="mt-4 pt-4 border-t border-white/5 relative z-10">
+          <div className="flex flex-wrap gap-x-4 gap-y-2 text-slate-400 text-[11px] font-medium">
+            <div className="flex items-center gap-1.5">
+              <span className="w-1.5 h-1.5 bg-purple-500 rounded-full animate-pulse"></span>
               Works offline
-            </li>
-            <li className="flex items-center gap-2">
-              <span className="w-1.5 h-1.5 bg-accent rounded-full"></span>
+            </div>
+            <div className="flex items-center gap-1.5">
+              <span className="w-1.5 h-1.5 bg-purple-500 rounded-full animate-pulse"></span>
               Fast & reliable
-            </li>
-            <li className="flex items-center gap-2">
-              <span className="w-1.5 h-1.5 bg-accent rounded-full"></span>
+            </div>
+            <div className="flex items-center gap-1.5">
+              <span className="w-1.5 h-1.5 bg-purple-500 rounded-full animate-pulse"></span>
               Home screen access
-            </li>
-          </ul>
+            </div>
+          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Closes #407 

## Description
This Pull Request transforms the PWA installation prompt (`components/InstallPWA.js`) from a flat, abrupt overlay into a premium glassmorphic floating toast with fluid entrance and exit transitions. It aligns the installation banner with Learnova’s high-fidelity dark-mode design system.

## Key Changes
- **Continuous Transition Architecture**: Eliminated the sudden `return null` mounting checks for `!isVisible`. Once the service worker is active and the installation prompt is captured, the component remains mounted, utilizing CSS opacity, scaling, and vertical translation to execute smooth animations (`transition-all duration-500 ease-out transform`).
- **Premium Glassmorphic Toast Layout**: Overhauled the card using translucent HSL containers (`backdrop-blur-xl bg-slate-900/90 border-purple-500/20 shadow-2xl`). 
- **Ambient Glow Overlays**: Injected soft neon glowing background spots (`bg-purple-500/10` and `bg-blue-500/10` with `blur-2xl`) behind the card to create layout depth.
- **Interactive Button Polish**: Upgraded the action controls with high-end purple/indigo linear gradients (`from-purple-600 to-indigo-600`) and outline button formats, complete with hardware-accelerated interactive scaling (`hover:scale-[1.03] active:scale-[0.97]`).
- **Responsive Mobile Optimizations**: Restructured the bottom features section into wrapped flex blocks (`flex flex-wrap gap-x-4 gap-y-2`) and adjusted dimensions (`sm:max-w-[360px]`). This prevents text overlapping or squishing, ensuring perfect legibility on narrow viewports down to 320px width.

## How to Test and Verify
1. Open the dev tools, emulate a mobile device, and configure standard PWA display triggers.
2. Confirm the floating install banner enters smoothly from the bottom right with a slide-and-fade animation.
3. Hover over the **"Install"** and **"Not Now"** buttons to verify the scale-up feedback, and click to confirm the downscale active state triggers correctly.
4. Click **"Not Now"** or close the prompt and confirm the toast slides down and fades out cleanly.
5. Verify on narrow viewport sizes (320px–360px) that the benefits row wraps fluidly without layout breakage.
