### PR TITLE
fix: save firebaseUid during registration to fix gamification API 404 errors

### DIFF
--- a/app/api/register/route.js
+++ b/app/api/register/route.js
@@ -182,6 +182,7 @@ export async function POST(req) {
       rollNo,
       email,
       image: blob.url,
+      firebaseUid: decodedToken.uid,
     };
     const result = await users.insertOne(user);
 


### PR DESCRIPTION
## What type of PR is this?

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [ ] 🎨 UI/UX improvement
- [ ] ⚡ Performance improvement
- [x] 🔒 Security fix

## Description

This PR fixes a bug where the newly added gamification API (/api/student/gamification) always returned a 404 Student not found error. The gamification route attempts to query the MongoDB users collection using { firebaseUid: userId }, but the /api/register route was previously omitting the firebaseUid field when inserting the user.This PR fixes a bug where the newly added gamification API (/api/student/gamification) always returned a 404 Student not found error. The gamification route attempts to query the MongoDB users collection using { firebaseUid: userId }, but the /api/register route was previously omitting the firebaseUid field when inserting the user.

## Related Issues

Closes #466 

## Changes Made
1. Updated app/api/register/route.js to explicitly include firebaseUid: decodedToken.uid in the user object before inserting it into MongoDB.
2. This effectively links the Firebase Auth record to the MongoDB profile, ensuring the gamification API can correctly query, initialize, and return the student's XP, current streak, and unlocked badges.

## Testing

How did you test these changes?
- [x] Tested locally
- [ ] Tested on mobile
- [ ] Tested different user roles
- [ ] All roles tested

## Screenshots (if applicable)


## Checklist

- [x] No hardcoded secrets or credentials
- [x] `.env.local` is not committed
- [x] Code follows project style
- [ ] Changes are documented
- [x] Build passes locally (`npm run build`)
- [x] No console errors/warnings
