### PR TITLE
fix: calculate attendance rate from user enrollment date to prevent unfair penalties

### DIFF
--- a/services/statsService.js
+++ b/services/statsService.js
@@ -11,8 +11,8 @@ import {
   where,
 } from "firebase/firestore";
 
-export function getWeekdaysSinceYearStart() {
-  const start = new Date(new Date().getFullYear(), 0, 1);
+export function getWeekdaysSince(startDate) {
+  const start = startDate ? new Date(startDate) : new Date(new Date().getFullYear(), 0, 1);
   const end = new Date();
   let weekdays = 0;
 
@@ -113,7 +113,16 @@ export const recalculateAttendanceRate = async (userId) => {
 
     const countSnapshot = await getCountFromServer(attendanceQuery);
     const presentDays = countSnapshot.data().count;
-    const totalDays = getWeekdaysSinceYearStart();
+
+    const userSnap = await getDoc(doc(db, "users", userId));
+    let startDate = new Date(new Date().getFullYear(), 0, 1);
+    if (userSnap.exists() && userSnap.data().createdAt) {
+      // createdAt might be a Firestore Timestamp or a string
+      const createdAt = userSnap.data().createdAt;
+      startDate = createdAt.toDate ? createdAt.toDate() : new Date(createdAt);
+    }
+
+    const totalDays = getWeekdaysSince(startDate);
     const rate = Math.min(100, Math.round((presentDays / totalDays) * 100));
 
     await updateDoc(statsRef, {


### PR DESCRIPTION
## What type of PR is this?

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [ ] 🎨 UI/UX improvement
- [ ] ⚡ Performance improvement
- [ ] 🔒 Security fix

## Description
This PR fixes a severe logical bug in services/statsService.js where the attendance rate calculation unfairly penalized students who enrolled mid-year. Previously, the totalDays required for perfect attendance was hardcoded to start from January 1st of the current year, regardless of when the user actually joined the platform.

## Related Issues

Closes #467 

## Changes Made
1. Refactored the getWeekdaysSinceYearStart helper to getWeekdaysSince(startDate).
2. Modified recalculateAttendanceRate to dynamically fetch the student's createdAt timestamp from the Firestore users collection.
3. The denominator (totalDays) is now accurately calculated starting from the day the student created their account.
4. If a user record is missing a createdAt date for any reason, it safely falls back to January 1st to prevent calculation errors.


## Testing

How did you test these changes?
- [x] Tested locally
- [ ] Tested on mobile
- [ ] Tested different user roles
- [ ] All roles tested

## Screenshots (if applicable)

## Checklist

- [x] No hardcoded secrets or credentials
- [x] `.env.local` is not committed
- [x] Code follows project style
- [ ] Changes are documented
- [x] Build passes locally (`npm run build`)
- [x] No console errors/warnings
