### PR TITLE
fix: add accessible labels to StudentDashboard icon buttons

### DIFF
--- a/components/StudentDashboard.js
+++ b/components/StudentDashboard.js
@@ -371,7 +371,10 @@ const StudentDashboard = () => {
                   Attendance Overview
                 </h2>
 
-                <button className="text-accent hover:text-accent/80 transition-colors">
+                <button
+                  className="text-accent hover:text-accent/80 transition-colors"
+                  aria-label="Refresh attendance overview"
+                >
                   <RefreshCw className="w-5 h-5" />
                 </button>
               </div>
@@ -435,7 +438,10 @@ const StudentDashboard = () => {
                   Recent Activity
                 </h2>
 
-                <button className="text-accent hover:text-accent/80 transition-colors">
+                <button
+                  className="text-accent hover:text-accent/80 transition-colors"
+                  aria-label="Download recent activity"
+                >
                   <Download className="w-5 h-5" />
                 </button>
               </div>


### PR DESCRIPTION
## Summary

Improves accessibility in `StudentDashboard.js` by adding accessible labels to icon-only buttons.

Closes #497

### Problem

Several icon-only buttons inside `StudentDashboard.js` rendered visual icons without accessible names.

Examples:

* `RefreshCw`
* `Download`

Since these buttons had no `aria-label` or visible text, screen readers could announce them as unnamed buttons.

### Fix

Added meaningful `aria-label` attributes to icon-only buttons:

* `Refresh attendance overview`
* `Download recent activity`

### Changes Made

* Updated `components/StudentDashboard.js`
* Added descriptive `aria-label` attributes to icon-only buttons
* Preserved UI and existing behavior

### Testing Checklist

* [x] Icon-only buttons include meaningful `aria-label`
* [x] Screen readers can identify button purpose
* [x] UI and behavior remain unchanged
* [x] No unrelated files modified
