### PR TITLE
UI improvement: Fix low contrast activity tag

### DIFF
--- a/app/activity/page.js
+++ b/app/activity/page.js
@@ -618,9 +618,9 @@ export default function ActivityPage() {
                           <span
                             className={`text-xs px-2 py-1 rounded-full font-medium ${
                               activity.type === "quiz"
-                                ? "bg-blue-500/20 text-blue-300"
-                                : "bg-green-500/20 text-green-300"
-                            }`}
+                                ? "bg-blue-600 text-white"
+                                : "bg-green-600 text-white"
+                          }`}
                           >
                             {activity.type}
                           </span>


### PR DESCRIPTION
## What type of PR is this?

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [X] 🎨 UI/UX improvement
- [ ] ⚡ Performance improvement
- [ ] 🔒 Security fix

## Description

The activity cards use low-contrast tag styling for quiz and game labels in light mode. Light text colors made them difficult to read against the light page background.

## Related Issues

Closes #498 

## Changes Made

- Updated activity.type styling in page.js
- Replaced the low contrast classes for quizzes and games

## Testing

How did you test these changes?
- [X] Tested locally
- [X] Tested on mobile
- [X] Tested different user roles
- [X] All roles tested

## Screenshots
Before
<img width="1258" height="492" alt="image" src="https://github.com/user-attachments/assets/6657eac0-3f2c-4661-a4de-294ebe6bb446" />

After
<img width="1250" height="497" alt="image" src="https://github.com/user-attachments/assets/f9b999bc-0f3b-4697-8503-a44095ad5514" />


## Checklist

- [X] No hardcoded secrets or credentials
- [X] `.env.local` is not committed
- [X] Code follows project style
- [X] Changes are documented
- [X] Build passes locally (`npm run build`)
- [X] No console errors/warnings
