### PR TITLE
perf: cache face descriptors in FaceRecognizer to prevent redundant API calls

### DIFF
--- a/components/FaceRecognizer.js
+++ b/components/FaceRecognizer.js
@@ -18,6 +18,10 @@ export default function FaceRecognizer({ authUser }) {
   const retryStreamRef = useRef(null);
   const videoRef = useRef(null);
   const canvasRef = useRef(null);
+  
+  // FIX: Added ref to cache descriptors and prevent massive re-fetching on retries
+  const cachedDescriptorsRef = useRef(null); 
+
   const {
     labels: fetchedLabels,
     loading: labelsLoading,
@@ -139,40 +143,49 @@ export default function FaceRecognizer({ authUser }) {
     )
       return;
 
-    const labeledFaceDescriptors = (
-      await Promise.all(
-        labels.map(async (student) => {
-          try {
-            const token = await authUser?.getIdToken();
-            const res = await fetch(`/api/images?id=${student._id}`, {
-              headers: token ? { Authorization: `Bearer ${token}` } : {},
-            });
+    // FIX: Check if descriptors are already cached in memory
+    let labeledFaceDescriptors = cachedDescriptorsRef.current;
 
-            if (!res.ok) {
-              console.warn(`Could not load image for ${student.name}: ${res.status}`);
-              return null;
+    // FIX: Only fetch and compute ML models if they haven't been processed yet
+    if (!labeledFaceDescriptors) {
+      labeledFaceDescriptors = (
+        await Promise.all(
+          labels.map(async (student) => {
+            try {
+              const token = await authUser?.getIdToken();
+              const res = await fetch(`/api/images?id=${student._id}`, {
+                headers: token ? { Authorization: `Bearer ${token}` } : {},
+              });
+
+              if (!res.ok) {
+                console.warn(`Could not load image for ${student.name}: ${res.status}`);
+                return null;
+              }
+
+              const blob = await res.blob();
+              const img = await faceapi.env.getEnv().createImageFromBlob(blob);
+
+              const detection = await faceapi
+                .detectSingleFace(img, new faceapi.TinyFaceDetectorOptions())
+                .withFaceLandmarks()
+                .withFaceDescriptor();
+
+              if (detection) {
+                return new faceapi.LabeledFaceDescriptors(student.name, [
+                  detection.descriptor,
+                ]);
+              }
+            } catch {
+              // Image not found for student
             }
+            return null;
+          }),
+        )
+      ).filter(Boolean);
 
-            const blob = await res.blob();
-            const img = await faceapi.env.getEnv().createImageFromBlob(blob);
-
-            const detection = await faceapi
-              .detectSingleFace(img, new faceapi.TinyFaceDetectorOptions())
-              .withFaceLandmarks()
-              .withFaceDescriptor();
-
-            if (detection) {
-              return new faceapi.LabeledFaceDescriptors(student.name, [
-                detection.descriptor,
-              ]);
-            }
-          } catch {
-            // Image not found for student
-          }
-          return null;
-        }),
-      )
-    ).filter(Boolean);
+      // FIX: Save the computed descriptors to the ref to avoid N+1 API calls on retry
+      cachedDescriptorsRef.current = labeledFaceDescriptors;
+    }
 
     if (!labeledFaceDescriptors.length) {
       if (isMounted.current) {


### PR DESCRIPTION
## What type of PR is this?
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [ ] 🎨 UI/UX improvement
- [x] ⚡ Performance improvement
- [ ] 🔒 Security fix

## Description
Optimized the `FaceRecognizer` component by caching computed `LabeledFaceDescriptors`. Previously, clicking "Scan Again" forced the component to re-execute the entire pipeline, fetching all student images and running heavy ML detection repeatedly. This PR introduces cache memorization to eliminate unnecessary network traffic and CPU load during scan retries.

## Related Issues
Closes #542

## Changes Made
- Introduced `cachedDescriptorsRef` using `useRef` to store processed face descriptors in memory across retries.
- Added a conditional check inside `runDetection` to safely bypass network hits to `/api/images` and redundant `faceapi` calculations if descriptors are already loaded.
- Kept all original file layouts, comment tracks, and internal dependencies untouched to prevent linting or structural errors.

## Testing
How did you test these changes?
- [x] Tested locally
- [ ] Tested on mobile
- [ ] Tested different user roles
- [ ] All roles tested

## Screenshots (if applicable)
N/A (Backend data optimization, no visual UI structure changes)

## Checklist
- [x] No hardcoded secrets or credentials
- [x] `.env.local` is not committed
- [x] Code follows project style
- [x] Changes are documented
- [x] Build passes locally (`npm run build`)
- [x] No console errors/warnings

**GSSoC 2026** Contributor!
/gssoc-page-status