### PR TITLE
fix: resolve AttendanceAnalytics import error

### DIFF
--- a/components/dashboard/AttendanceAnalytics.js
+++ b/components/dashboard/AttendanceAnalytics.js
@@ -18,7 +18,7 @@ import {
   Legend,
   Filler,
 } from "chart.js";
-import { getWeekdaysSinceYearStart } from "@/services/statsService";
+import { getWeekdaysSince } from "@/services/statsService";
 
 ChartJS.register(
   CategoryScale,
@@ -113,7 +113,7 @@ const AttendanceAnalytics = ({ userId, recentActivity = [] }) => {
         const snapshot = await getDocs(attendanceQuery);
         const records = snapshot.docs.map((doc) => doc.data() || {});
         const totalPresent = records.length;
-        const totalClasses = getWeekdaysSinceYearStart();
+        const totalClasses = getWeekdaysSince();
 
         const safeTotalClasses = totalClasses > 0 ? totalClasses : 1;
         let totalAbsent = safeTotalClasses - totalPresent;


### PR DESCRIPTION
## Summary

Fixed AttendanceAnalytics runtime failure caused by importing a non-existent function from `statsService`.

## Changes Made

* Replaced invalid `getWeekdaysSinceYearStart` import with `getWeekdaysSince`
* Updated corresponding function call in `AttendanceAnalytics.js`

## Result

* Attendance analytics now renders successfully
* Removed runtime `TypeError`
* Dashboard attendance data loads normally

Fixes #534
