### PR TITLE
fix: add missing useEffect import in AdminDashboard (#289)

### DIFF
--- a/components/AdminDashboard.js
+++ b/components/AdminDashboard.js
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import {
   Building2,
   Users,


### PR DESCRIPTION
Closes #289

the AdminDashboard component was crashing with a ReferenceError because useEffect was used on line 46 but only useState was imported from React on line 3. this meant the entire admin dashboard was broken for all admin users.

fix: added useEffect to the import statement. the existing useEffect already has proper cleanup (clearTimeout on unmount) so no other changes needed.

also checked StudentDashboard, TeacherDashboardComponent, and InstituteDashboard — they all import useEffect correctly, this bug was unique to AdminDashboard.

happy to make changes if needed!