### PR TITLE
fix: utilize Next.js data cache to prevent JWKS rate limiting in middleware

### DIFF
--- a/middleware.js
+++ b/middleware.js
@@ -18,9 +18,16 @@ let _cacheExpiry = 0;
  */
 async function fetchPublicKeys() {
   const now = Date.now();
+  
+  // L1 Cache: Fast in-memory return if the current Edge isolate is still alive
   if (_cachedKeys && now < _cacheExpiry) return _cachedKeys;
 
-  const res = await fetch(JWKS_URL);
+  // L2 Cache: Next.js Data Cache to prevent 429 Rate Limit errors across new Edge isolates
+  const res = await fetch(JWKS_URL, {
+    cache: "force-cache",
+    next: { revalidate: 21600 } // Cache response at the edge for 6 hours (21600 seconds)
+  });
+  
   if (!res.ok) {
     throw new Error(`JWKS fetch failed: ${res.status}`);
   }


### PR DESCRIPTION
## What type of PR is this?
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [ ] 🎨 UI/UX improvement
- [x] ⚡ Performance improvement
- [ ] 🔒 Security fix

## Description
This PR resolves a critical architectural flaw where Firebase RS256 public keys were only cached using in-memory variables (`_cachedKeys`) within the Edge runtime. Because Edge isolates are ephemeral, this caused redundant network requests to Google's JWKS endpoint on worker restarts, creating a high risk of triggering **HTTP 429 (Too Many Requests)** rate limits and locking users out.

## Related Issues
Closes #559 

## Changes Made
- Upgraded the `fetchPublicKeys` function to use Next.js native Data Cache (`force-cache` with `revalidate: 21600`) as a robust L2 cache.
- Preserved the L1 in-memory cache for ultra-fast returns if the current Edge isolate is still alive.
- Ensured all original error handling and cryptographic Web Crypto API logic remained completely untouched.

## Testing
How did you test these changes?
- [x] Tested locally
- [ ] Tested on mobile
- [ ] Tested different user roles
- [ ] All roles tested

## Checklist
- [x] No hardcoded secrets or credentials
- [x] `.env.local` is not committed
- [x] Code follows project style
- [x] Build passes locally (`npm run build`)
- [x] No console errors/warnings

**GSSoC 2026** Contributor!
/gssoc-page-status