### PR TITLE
fix: use centralized MongoDB rate limiting in registration API

### DIFF
--- a/app/api/register/route.js
+++ b/app/api/register/route.js
@@ -21,6 +21,8 @@ import {
 
 import { z } from "zod";
 
+import { checkRateLimit } from "@/lib/rateLimit";
+
 if (
   typeof global !== "undefined" &&
   !global.mockFile
@@ -33,13 +35,7 @@ if (
   };
 }
 
-export const rateLimitMap =
-  new Map();
 
-const RATE_LIMIT_WINDOW =
-  60 * 1000;
-
-const MAX_ATTEMPTS = 5;
 
 const MAX_FILE_SIZE =
   5 * 1024 * 1024;
@@ -197,49 +193,11 @@ export const POST =
   withErrorHandler(
     async (req) => {
       // Rate limiting
-      const ip =
-        req.headers.get(
-          "x-forwarded-for"
-        ) || "127.0.0.1";
+      const ip = req.headers.get("x-forwarded-for") || "127.0.0.1";
+      const rateLimitResult = await checkRateLimit(`register_ip_${ip}`);
 
-      const now = Date.now();
-
-      if (
-        !rateLimitMap.has(ip)
-      ) {
-        rateLimitMap.set(
-          ip,
-          []
-        );
-      }
-
-      const attempts =
-        rateLimitMap
-          .get(ip)
-          .filter(
-            (
-              timestamp
-            ) =>
-              now -
-                timestamp <
-              RATE_LIMIT_WINDOW
-          );
-
-      attempts.push(now);
-
-      rateLimitMap.set(
-        ip,
-        attempts
-      );
-
-      if (
-        attempts.length >
-        MAX_ATTEMPTS
-      ) {
-        throw new AppError(
-          "Too many registration attempts. Please try again later.",
-          429
-        );
+      if (!rateLimitResult.allowed) {
+        throw new AppError("Too many registration attempts. Please try again later.", 429);
       }
 
       // Authenticate


### PR DESCRIPTION
## Description
This pull request addresses an issue where the registration API's rate limiting was easily bypassable in production. The original implementation used a global JavaScript `Map` to track request attempts. Because the Next.js API routes run in a stateless serverless environment, this in-memory `Map` was isolated to individual instances and frequently reset during cold starts, rendering the rate limit ineffective.

This update migrates the rate limiting logic in `app/api/register/route.js` to use the centralized, MongoDB-backed `checkRateLimit` utility. Now, request limits are accurately enforced across all serverless instances.

## Changes Made
- Removed the local in-memory `Map` and static limit variables from `app/api/register/route.js`.
- Imported the `checkRateLimit` function from `lib/rateLimit.js`.
- Updated the rate-limiting validation step to call `checkRateLimit("register_ip_" + ip)`, which persists rate-limiting data in the database.

## Related Issues
- Fixes #552

## Testing Instructions
1. Deploy the changes to your serverless environment (or test locally).
2. Attempt to submit multiple registration requests rapidly from the same IP address.
3. Verify that the API correctly returns a `429 Too Many Requests` error once the maximum attempt threshold is reached, and that this state persists across requests.
