### PR TITLE
fix: resolve decodedToken ReferenceError in settings PATCH handler

### DIFF
--- a/components/_tests_/settingsRoute.test.js
+++ b/components/_tests_/settingsRoute.test.js
@@ -179,4 +179,19 @@ describe("PATCH /api/settings - Security, Role-Based Access and Audit Logging Te
       expect.stringContaining("[Audit Log] Settings updated successfully for target user: victim-user-123 by operator: admin-789 (Role: admin)")
     );
   });
+
+  test("rejects request with unrecognized fields with 400 Bad Request", async () => {
+    verifyFirebaseToken.mockResolvedValue({ uid: "user-123", email: "user@example.com" });
+
+    const req = createMockRequest(
+      { authorization: "Bearer valid-token" },
+      { nonexistentField: "should not be allowed" }
+    );
+    const response = await PATCH(req);
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.error).toContain("Bad Request");
+    expect(mockUpdateOne).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
Summary: The PATCH /api/settings handler referenced decodedToken before it was assigned. Fixed by commits 837e573 and eaa33ab which extracted the token from authResult and migrated to authenticateRequest(). This PR adds test coverage for Zod schema validation when the body contains unrecognized fields.

Closes #485