### PR TITLE
Fixed low-contrast text in login page

### DIFF
--- a/components/RoleSelection.js
+++ b/components/RoleSelection.js
@@ -76,21 +76,21 @@ export default function RoleSelection({ onRoleSelect }) {
         <div className="p-6 bg-slate-900/40 backdrop-blur-xl rounded-2xl border border-white/5 hover:border-white/10 transition-all duration-300">
           <Shield className="w-10 h-10 text-indigo-400 mx-auto mb-4" />
           <h4 className="font-bold text-white mb-2 text-base">Secure Access</h4>
-          <p className="text-slate-400 text-sm leading-relaxed">
+          <p className="text-slate-100 text-sm leading-relaxed">
             Role-based permissions and high-security compliance standards
           </p>
         </div>
         <div className="p-6 bg-slate-900/40 backdrop-blur-xl rounded-2xl border border-white/5 hover:border-white/10 transition-all duration-300">
           <Zap className="w-10 h-10 text-purple-400 mx-auto mb-4" />
           <h4 className="font-bold text-white mb-2 text-base">Real-time Sync</h4>
-          <p className="text-slate-400 text-sm leading-relaxed">
+          <p className="text-slate-100 text-sm leading-relaxed">
             Instant database updates synced seamlessly across all devices
           </p>
         </div>
         <div className="p-6 sm:col-span-2 lg:col-span-1 bg-slate-900/40 backdrop-blur-xl rounded-2xl border border-white/5 hover:border-white/10 transition-all duration-300">
           <Sparkles className="w-10 h-10 text-pink-400 mx-auto mb-4" />
           <h4 className="font-bold text-white mb-2 text-base">Custom Dashboard</h4>
-          <p className="text-slate-400 text-sm leading-relaxed">
+          <p className="text-slate-100 text-sm leading-relaxed">
             Tailored layouts built for your specialized platform activities
           </p>
         </div>


### PR DESCRIPTION
## What type of PR is this?

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [X] 🎨 UI/UX improvement
- [ ] ⚡ Performance improvement
- [ ] 🔒 Security fix

## Description

The choose your role page's cards had text that was low-contrast. The text paired with the background in light mode makes it  difficult to read at first glance.

## Related Issues

Closes #545 

## Changes Made

- Changed the RoleSelection.js page card text to a higher contrast 
- Ensured that the text is readable in both light and dark modes.

## Testing

How did you test these changes?
- [X] Tested locally
- [X] Tested on mobile
- [X] Tested different user roles
- [X] All roles tested

## Screenshots (if applicable)
Before
<img width="1590" height="420" alt="image" src="https://github.com/user-attachments/assets/33c91af5-51d8-44d5-a096-fa6dfe8c13cb" />

After
<img width="1444" height="353" alt="image" src="https://github.com/user-attachments/assets/60a2a912-707e-421e-94a7-04067e8790d6" />


## Checklist

- [X] No hardcoded secrets or credentials
- [X] `.env.local` is not committed
- [X] Code follows project style
- [X] Changes are documented
- [X] Build passes locally (`npm run build`)
- [X] No console errors/warnings
