### PR TITLE
fix: declare stats state and fetch from Firestore to prevent Referenc…

### DIFF
--- a/components/universal-profile.js
+++ b/components/universal-profile.js
@@ -59,6 +59,7 @@ export default function UniversalProfile() {
   // Role state fetched from Firestore
   const [role, setRole] = useState("student");
   const [userData, setUserData] = useState(null);
+  const [stats, setStats] = useState(null);
 
   useEffect(() => {
     const fetchUserData = async () => {
@@ -71,8 +72,15 @@ export default function UniversalProfile() {
           setUserData(data); //to save the full profile data
           setRole(data.role || "student");
         }
+
+        // Fetch dashboard statistics from the userStats collection
+        const statsRef = doc(db, "userStats", user.uid);
+        const statsSnap = await getDoc(statsRef);
+        if (statsSnap.exists()) {
+          setStats(statsSnap.data());
+        }
       } catch (error) {
-        // Silently handle error fetching user role
+        // Silently handle error fetching user data / stats
       }
     };
     fetchUserData();


### PR DESCRIPTION
Closes #504

## Summary

Fixes a fatal runtime crash affecting all profile dashboards caused by an undefined `stats` reference inside `components/universal-profile.js`.

The profile UI was crashing immediately for:

* students
* teachers
* admins
* institutes
* parents

This patch safely initializes statistics state, fetches dashboard stats from Firestore, and preserves graceful fallback rendering when metrics are unavailable.

---

## Root Cause

The statistics rendering logic referenced:

```js
const realValue =
  stats && stats[stat.label] !== undefined
    ? stats[stat.label]
    : "0";
```

However:

* `stats` was never declared
* no state/prop/helper initialized it
* React rendering triggered:

  ```text
  ReferenceError: stats is not defined
  ```

This caused the entire profile dashboard to crash at runtime.

---

## Changes

### Updated

```text
components/universal-profile.js
```

### Implemented

* Added:

  ```js
  const [stats, setStats] = useState(null);
  ```

* Added Firestore stats retrieval inside the existing `fetchUserData` flow

* Reads statistics from:

  ```text
  userStats/{uid}
  ```

* Populates the local `stats` state safely

* Preserved existing fallback rendering behavior

---

## Fallback Behavior

| Scenario                    | Displayed Value      | Change Indicator    |
| --------------------------- | -------------------- | ------------------- |
| Stats not loaded yet        | `"0"`                | `"New"`             |
| Metric missing in Firestore | `"0"`                | `"New"`             |
| Metric exists               | Real Firestore value | Actual change value |

---

## Verification

✅ Profile dashboards render successfully for all roles
✅ Runtime crash eliminated
✅ Missing stats now fallback safely
✅ Existing UI/stat card behavior preserved
✅ No new runtime warnings/errors introduced
✅ `npm run build` succeeds

---

## Files Changed

* `components/universal-profile.js`
