### PR TITLE
fix: correct chronological database search order assertion in conversationsRoute tests

### DIFF
--- a/components/_tests_/conversationsRoute.test.js
+++ b/components/_tests_/conversationsRoute.test.js
@@ -298,7 +298,7 @@ describe("GET /api/conversations - History Retrieval Security and Performance Te
     expect(body.data).toEqual(dummyConversations);
 
     expect(mockFind).toHaveBeenCalledWith({ userId: "user-123" });
-    expect(mockSort).toHaveBeenCalledWith({ timestamp: 1 });
+    expect(mockSort).toHaveBeenCalledWith({ timestamp: -1 });
     expect(mockLimit).toHaveBeenCalledWith(50);
   });
 


### PR DESCRIPTION
Fixes #641

This PR corrects the conversation history retrieval sort order assertion in `conversationsRoute.test.js`.

### Proposed Changes
- Changed expected sort parameter from `{ timestamp: 1 }` to `{ timestamp: -1 }` to match the actual API implementation.

Requesting `gssoc`, `gssoc:approved` point labels!