### PR TITLE
fix: specify descriptive validation messages on exceptions update route

### DIFF
--- a/app/api/exceptions/update/route.js
+++ b/app/api/exceptions/update/route.js
@@ -15,8 +15,12 @@ export const PUT = withErrorHandler(async (request) => {
   const body = await request.json();
   const { exceptionId, status, comments } = body;
 
-  if (!exceptionId || !ObjectId.isValid(exceptionId)) {
-    throw new ValidationError("Invalid or missing exception ID");
+  if (!exceptionId) {
+    throw new ValidationError("exceptionId is required");
+  }
+
+  if (!ObjectId.isValid(exceptionId)) {
+    throw new ValidationError("Invalid exception ID");
   }
 
   const trimmedStatus = typeof status === "string" ? status.trim() : "";


### PR DESCRIPTION
Fixes #643

This PR improves exceptions update validation error messages to be more specific and clear.

Requesting `gssoc`, `gssoc:approved` point labels!