### PR TITLE
test: mock mongodb module in exceptionsUpdateRoute test to resolve ESM parsing issues

### DIFF
--- a/components/_tests_/exceptionsUpdateRoute.test.js
+++ b/components/_tests_/exceptionsUpdateRoute.test.js
@@ -1,6 +1,6 @@
-import { PUT } from "@/app/api/exceptions/update/route";
 import { connectDb } from "@/lib/mongodb";
 import { verifyFirebaseToken, getUserProfile, getUserProfileByEmail } from "@/lib/firebase-admin";
+
 class ObjectId {
   constructor(id) {
     this.id = id;
@@ -8,7 +8,26 @@ class ObjectId {
   toString() {
     return this.id;
   }
+  static isValid(id) {
+    return typeof id === "string" && id.length === 24;
+  }
 }
+
+jest.mock("mongodb", () => ({
+  ObjectId: class {
+    constructor(id) {
+      this.id = id;
+    }
+    toString() {
+      return this.id;
+    }
+    static isValid(id) {
+      return typeof id === "string" && id.length === 24;
+    }
+  }
+}));
+
+import { PUT } from "@/app/api/exceptions/update/route";
 jest.mock("next/server", () => ({
   NextResponse: {
     json: jest.fn().mockImplementation((body, init) => {


### PR DESCRIPTION
Fixes #645

This PR mocks the `mongodb` package in `exceptionsUpdateRoute.test.js` to resolve ESM parsing syntax errors during Jest test execution.

Requesting `gssoc`, `gssoc:approved` point labels!