### PR TITLE
security: add http security headers to next config

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -83,6 +83,8 @@ const nextConfig = {
           { key: "X-Content-Type-Options", value: "nosniff" },
           { key: "Referrer-Policy", value: "strict-origin-when-cross-origin" },
           { key: "Permissions-Policy", value: "camera=(self), microphone=(self), geolocation=(self)" },
+          { key: "X-XSS-Protection", value: "1; mode=block" },
+          { key: "Strict-Transport-Security", value: "max-age=31536000; includeSubDomains; preload" },
         ],
       },
       {


### PR DESCRIPTION
Fixes #649

This PR adds `X-XSS-Protection` and top-level `Strict-Transport-Security` headers to Next.js configuration.

Requesting `gssoc`, `gssoc:approved` point labels!