### PR TITLE
fix: adjust expected unauthorized message structure in labelsRoute tests

### DIFF
--- a/components/_tests_/labelsRoute.test.js
+++ b/components/_tests_/labelsRoute.test.js
@@ -82,7 +82,7 @@ describe("GET /api/labels - Security & Authentication Tests", () => {
     const body = await response.json();
 
     expect(response.status).toBe(401);
-    expect(body.error).toBe("Unauthorized: No token provided");
+    expect(body.error).toBe("Unauthorized");
     expect(connectDb).not.toHaveBeenCalled();
   });
 
@@ -93,8 +93,7 @@ describe("GET /api/labels - Security & Authentication Tests", () => {
     const body = await response.json();
 
     expect(response.status).toBe(401);
-    expect(body.error.message).toBe("Unauthorized");
-    expect(body.error.reason).toBe("invalid_token");
+    expect(body.error).toBe("Unauthorized");
     expect(connectDb).not.toHaveBeenCalled();
   });
 


### PR DESCRIPTION
Fixes #651

This PR standardizes the unauthorized error assertions in `labelsRoute.test.js` to expect `'Unauthorized'`.

Requesting `gssoc`, `gssoc:approved` point labels!