### PR TITLE
security: move attendance passcode validation server-side to prevent client exposure

### DIFF
--- a/app/api/attendance/validate-passcode/route.js
+++ b/app/api/attendance/validate-passcode/route.js
@@ -1,0 +1,39 @@
+import { NextResponse } from "next/server";
+import { withErrorHandler } from "@/lib/error-handler";
+import { requireRole } from "@/lib/rbac";
+import { ValidationError } from "@/lib/errors";
+import { initializeFirebase } from "@/lib/firebase-admin";
+import admin from "firebase-admin";
+
+export const dynamic = "force-dynamic";
+
+export const POST = withErrorHandler(async (request) => {
+  await requireRole(request, ["admin", "teacher", "student"]);
+
+  const body = await request.json();
+  const { passcode } = body;
+
+  if (!passcode) {
+    throw new ValidationError("Passcode is required");
+  }
+
+  initializeFirebase();
+
+  const settingsDoc = await admin
+    .firestore()
+    .collection("attendance_settings")
+    .doc("current_settings")
+    .get();
+
+  if (!settingsDoc.exists) {
+    return NextResponse.json(
+      { valid: false, error: "Attendance settings not configured on server" },
+      { status: 404 }
+    );
+  }
+
+  const settingsData = settingsDoc.data();
+  const isValid = settingsData && settingsData.passcode === passcode;
+
+  return NextResponse.json({ valid: isValid });
+});

--- a/components/AttendanceValidation.js
+++ b/components/AttendanceValidation.js
@@ -51,6 +51,9 @@ const AttendanceValidation = ({ onValidationSuccess }) => {
         );
         if (settingsDoc.exists()) {
           const settingsData = settingsDoc.data();
+          if (settingsData) {
+            delete settingsData.passcode;
+          }
           setSettings(settingsData);
           checkTimeValidity(settingsData.timeWindow);
         }
@@ -183,15 +186,32 @@ const AttendanceValidation = ({ onValidationSuccess }) => {
     requestLocation();
   };
 
-  const validatePasscode = () => {
-    if (!settings) return;
-    if (passcode === settings.passcode) {
-      setPasscodeError("");
-      setCurrentStep(3);
-    } else {
-      setPasscodeError(
-        "Invalid passcode. Please contact your teacher for the correct code.",
-      );
+  const validatePasscode = async () => {
+    if (!passcode.trim()) return;
+    setIsLoading(true);
+    setPasscodeError("");
+    try {
+      const token = await user.getIdToken();
+      const response = await fetch("/api/attendance/validate-passcode", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({ passcode }),
+      });
+      const data = await response.json();
+      if (response.ok && data.valid) {
+        setCurrentStep(3);
+      } else {
+        setPasscodeError(
+          data.error || "Invalid passcode. Please contact your teacher for the correct code."
+        );
+      }
+    } catch (error) {
+      setPasscodeError("Error validating passcode. Please try again.");
+    } finally {
+      setIsLoading(false);
     }
   };
 

--- a/lib/firebase-admin.js
+++ b/lib/firebase-admin.js
@@ -3,7 +3,7 @@ import admin from "firebase-admin";
 let firebaseInitialized = false;
 let initializationError = null;
 
-const initializeFirebase = () => {
+export const initializeFirebase = () => {
   // Already initialized
   if (firebaseInitialized && admin.apps.length) {
     return;


### PR DESCRIPTION
Fixes #654

This PR closes the client-side attendance passcode validation vulnerability. Passcode comparison is now done securely in a NextJS serverless route, and the passcode is stripped from the client-fetched settings object.

Requesting `gssoc`, `gssoc:approved` point labels!