### PR TITLE
fix: replace native alert() with toast notification in TeacherDashboard

### DIFF
--- a/components/TeacherDashboardComponent.js
+++ b/components/TeacherDashboardComponent.js
@@ -1,3 +1,4 @@
+import { toast } from "react-hot-toast";
 import React, { useState, useEffect } from "react";
 import { Navbar } from "./Navbar";
 import Image from "next/image";
@@ -417,7 +418,7 @@ const TeacherDashboard = () => {
         ),
       );
     } catch (error) {
-      alert("Failed to update request. Please try again.");
+      toast.error("Failed to update request. Please try again.");
     }
   };
 


### PR DESCRIPTION
Fixes #662

This PR imports `toast` and replaces the native browser alert window inside the exception handler with a styled toast notification.

Requesting `gssoc`, `gssoc:approved` point labels!