### PR TITLE
a11y: improve alt text descriptiveness on profile avatar images

### DIFF
--- a/components/Navbar.js
+++ b/components/Navbar.js
@@ -468,7 +468,7 @@ export function Navbar() {
                       {getUserPhoto() && (
                         <Image
                           src={getUserPhoto()}
-                          alt="Profile"
+                          alt="User profile avatar"
                           width={56}
                           height={56}
                           className="rounded-full border-2 border-accent/50 object-cover shadow-lg"


### PR DESCRIPTION
Fixes #668

This PR replaces generic alt labels with standard descriptive terms for screen-readers.

Requesting `gssoc`, `gssoc:approved` point labels!