### PR TITLE
fix(security): remove spoofable userRole cookie fallback in middleware

### DIFF
--- a/middleware.js
+++ b/middleware.js
@@ -135,17 +135,39 @@ export async function middleware(request) {
     authToken = request.cookies.get("authToken")?.value;
   }
   
-  const userRole = request.cookies.get("userRole")?.value;
-
   // Cryptographically verify the token — decoding alone is not sufficient
   let isTokenValid = false;
   let isEmailVerified = false;
+  let userRole = null;
 
   if (authToken) {
     const payload = await verifyIdToken(authToken);
     if (payload) {
       isTokenValid = true;
       isEmailVerified = !!payload.email_verified;
+      
+      // Prioritize securely signed custom claim
+      if (payload.role) {
+        userRole = payload.role;
+      } else if (FIREBASE_PROJECT_ID) {
+        // Fallback: securely fetch the user's role from Firestore REST API
+        try {
+          const res = await fetch(
+            `https://firestore.googleapis.com/v1/projects/${FIREBASE_PROJECT_ID}/databases/(default)/documents/users/${payload.sub}`,
+            {
+              headers: { Authorization: `Bearer ${authToken}` },
+              cache: "force-cache",
+              next: { revalidate: 300 } // Cache securely at the edge for 5 minutes
+            }
+          );
+          if (res.ok) {
+            const data = await res.json();
+            userRole = data.fields?.role?.stringValue || null;
+          }
+        } catch (err) {
+          console.error("Middleware Edge fetch failed:", err);
+        }
+      }
     }
   }
 


### PR DESCRIPTION
## What type of PR is this?

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [ ] 🎨 UI/UX improvement
- [ ] ⚡ Performance improvement
- [x] 🔒 Security fix

## Description

Resolves a critical security vulnerability where the Edge middleware was falling back to the client-controlled `userRole` cookie if Firebase custom claims were undefined. This allowed any registered user to bypass dashboard route protections and access `/admin/dashboard` simply by modifying their local cookies.

## Related Issues

Closes #673 

## Changes Made

* **Removed Cookie Fallback:** The middleware no longer reads or trusts `request.cookies.get("userRole")`.
* **Implemented Secure REST Verification:** Added a fallback branch that securely queries the Firestore REST API using the verified user's `authToken` as a Bearer token.
* **Edge Caching:** Wrapped the REST call with Next.js Data Cache (`cache: "force-cache", next: { revalidate: 300 }`) to ensure the role is cached for 5 minutes per user, minimizing latency and Firestore read operations.

## Testing

How did you test these changes?
- [x] Tested locally
- [ ] Tested on mobile
- [ ] Tested different user roles
- [ ] All roles tested

## Screenshots (if applicable)

## Checklist

- [x] No hardcoded secrets or credentials
- [x] `.env.local` is not committed
- [x] Code follows project style
- [ ] Changes are documented
- [x] Build passes locally (`npm run build`)
- [x] No console errors/warnings
