### PR TITLE
fix: resolve infinite redirection loop by syncing auth cookies (#670)

### DIFF
--- a/hooks/useAuth.js
+++ b/hooks/useAuth.js
@@ -54,14 +54,27 @@ export const useAuth = () => {
             const profileData = userDoc.data();
             setUser(firebaseUser);
             setUserProfile(profileData);
+
+            // Sync auth token and role in cookies
+            const token = await firebaseUser.getIdToken();
+            setCookie("authToken", token, 7);
+            setCookie("userRole", profileData.role, 7);
           } else {
             // User exists in Auth but no profile in Firestore
             setUser(firebaseUser);
             setUserProfile(null);
+
+            // Clean up cookies if profile is missing
+            deleteCookie("authToken");
+            deleteCookie("userRole");
           }
         } else {
           setUser(null);
           setUserProfile(null);
+
+          // Clear auth cookies
+          deleteCookie("authToken");
+          deleteCookie("userRole");
 
           // Clear PWA caches on logout to prevent data leakage on shared devices
           if (typeof window !== "undefined" && "caches" in window) {
@@ -81,6 +94,8 @@ export const useAuth = () => {
         setError(err.message);
         setUser(null);
         setUserProfile(null);
+        deleteCookie("authToken");
+        deleteCookie("userRole");
       } finally {
         setLoading(false);
       }
@@ -98,6 +113,10 @@ export const useAuth = () => {
       await firebaseSignOut(auth);
       setUser(null);
       setUserProfile(null);
+
+      // Clear auth cookies
+      deleteCookie("authToken");
+      deleteCookie("userRole");
 
       // Clear all PWA caches to prevent cached API responses from persisting after logout
       if (typeof window !== "undefined" && "caches" in window) {

--- a/lib/firebase-admin.js
+++ b/lib/firebase-admin.js
@@ -47,6 +47,8 @@ const initializeFirebase = () => {
   }
 };
 
+export const initFirebaseAdmin = initializeFirebase;
+
 /**
  * Verifies a Firebase ID token using the Firebase Admin SDK.
  * @param {string} token - The Firebase ID token string to verify.


### PR DESCRIPTION
## 🛠️ Related Issue
Closes: #670

## 📌 Description
This PR addresses and resolves two key bugs:
1. **Infinite Auth Redirection Loop:** The Edge middleware relies on `authToken` and `userRole` cookies to authorize pages. However, these cookies were never set upon login, causing authenticated users to get stuck in a redirect loop back to `/auth`. This fix syncs cookies with the central Firebase auth listener.
2. **Missing Sync Initialization Export:** Resolves a runtime `TypeError` in the offline synchronization route where `initFirebaseAdmin` was called but not exported from `lib/firebase-admin.js`.

## ✨ Changes Made
- Integrated `setCookie` and `deleteCookie` helpers into `onAuthStateChanged` inside `hooks/useAuth.js` to sync cookies on successful login/logout.
- Added clean-up `deleteCookie` calls inside `signOut` to clear all auth cookies on user sign-out.
- Exported `initFirebaseAdmin` as an alias to `initializeFirebase` in `lib/firebase-admin.js` to ensure the offline attendance sync route compiles and runs successfully.

## 🧪 Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] UI/UX improvement
- [ ] Documentation update

## ✔️ Checklist
- [x] My code follows project style guidelines
- [x] I have tested my changes
- [x] I have linked the related issue
- [x] No unnecessary files are included