### PR TITLE
Fix 1-second interval never cleared in TeacherDashboard

### DIFF
--- a/components/TeacherDashboardComponent.js
+++ b/components/TeacherDashboardComponent.js
@@ -420,9 +420,9 @@ const TeacherDashboard = () => {
     }, 1000);
 
     return () => {
-  clearInterval(timer);
-  clearTimeout(loadingTimer);
-};
+      clearInterval(interval);
+      clearTimeout(loadingTimer);
+    };
   }, []);
 
   const generatePasscode = () => {


### PR DESCRIPTION
## What was the bottleneck

`TeacherDashboardComponent` sets up a 1-second `setInterval` to keep the live clock and attendance-window status up to date. The `useEffect` cleanup returned `clearInterval(timer)` — but `timer` is undefined. The actual interval was stored in the variable named `interval`. Passing `undefined` to `clearInterval` is a silent no-op, so the 1-second tick kept running after every navigation away from the teacher dashboard, accumulating one new orphaned interval per visit.

## Root cause

Variable name mismatch in the cleanup function: the interval was assigned to `const interval = setInterval(...)` on line 394 but cleared with `clearInterval(timer)` — a name that was never declared in that scope.

## Files changed

- `components/TeacherDashboardComponent.js` — Changed `clearInterval(timer)` to `clearInterval(interval)` in the useEffect return function.

## Why this eliminates the root cause

`clearInterval(interval)` now passes the actual `intervalID` returned by `setInterval`, correctly cancelling the tick.

## Before / after

| Scenario | Before | After |
|---|---|---|
| Navigate to teacher dashboard 5 times | 5 concurrent 1-second intervals running | 1 interval, cleaned up on each navigation |
| Memory / CPU after extended session | Accumulates with each visit | Flat |

## Steps to verify

1. Open browser DevTools → Performance tab → start recording.
2. Navigate to teacher dashboard, then away, then back three times.
3. Verify no stacking of `setCurrentTime`/`setAttendanceWindow` calls in the flame chart.

Please review and merge this under GSSoC 2026.