### PR TITLE
Skip mousemove tracking on touch-only devices

### DIFF
--- a/app/activity/page.js
+++ b/app/activity/page.js
@@ -91,11 +91,17 @@ export default function ActivityPage() {
     };
 
     window.addEventListener("scroll", handleScroll, { passive: true });
-    window.addEventListener("mousemove", handleMouseMove, { passive: true });
+
+    const isTouchOnly = window.matchMedia("(pointer: coarse)").matches;
+    if (!isTouchOnly) {
+      window.addEventListener("mousemove", handleMouseMove, { passive: true });
+    }
 
     return () => {
       window.removeEventListener("scroll", handleScroll);
-      window.removeEventListener("mousemove", handleMouseMove);
+      if (!isTouchOnly) {
+        window.removeEventListener("mousemove", handleMouseMove);
+      }
     };
   }, []);
 

--- a/app/not-found.js
+++ b/app/not-found.js
@@ -36,8 +36,10 @@ export default function NotFound() {
       y: window.innerHeight / 2,
     });
 
-    let timeout;
+    const isTouchOnly = window.matchMedia("(pointer: coarse)").matches;
+    if (isTouchOnly) return;
 
+    let timeout;
     const throttledMouseMove = (event) => {
       if (!timeout) {
         timeout = setTimeout(() => {

--- a/app/page.js
+++ b/app/page.js
@@ -251,12 +251,18 @@ export default function AboutPage() {
       }
     };
 
+    const isTouchOnly = window.matchMedia("(pointer: coarse)").matches;
+
     window.addEventListener("scroll", throttledScroll, { passive: true });
-    window.addEventListener("mousemove", throttledMouseMove, { passive: true });
+    if (!isTouchOnly) {
+      window.addEventListener("mousemove", throttledMouseMove, { passive: true });
+    }
 
     return () => {
       window.removeEventListener("scroll", throttledScroll);
-      window.removeEventListener("mousemove", throttledMouseMove);
+      if (!isTouchOnly) {
+        window.removeEventListener("mousemove", throttledMouseMove);
+      }
       if (scrollTimeout) clearTimeout(scrollTimeout);
       if (mouseTimeout) clearTimeout(mouseTimeout);
     };


### PR DESCRIPTION
## What was the bottleneck

Three pages (`app/page.js`, `app/activity/page.js`, `app/not-found.js`) registered `window.addEventListener('mousemove', ...)` unconditionally. On touch-only devices (phones, tablets), every touch gesture triggers synthesised `mousemove` events. At 120 Hz the browser can fire hundreds of position updates per second, each causing a `setMousePosition` state update and a full React re-render of the component — for a visual cursor-glow effect that is completely invisible on touch screens.

## Root cause

No pointer-capability check before adding the listener. `mousemove` tracking is only meaningful when the primary input device is a precise pointer (mouse/trackpad). Touch-primary devices use `pointer: coarse` media feature.

## Files changed

- `app/page.js` — Check `window.matchMedia('(pointer: coarse)').matches` before adding `mousemove` listener and conditionally remove it in cleanup.
- `app/activity/page.js` — Same guard added.
- `app/not-found.js` — Same guard; early return from the effect on touch-only devices.

## Why this eliminates the root cause

`pointer: coarse` is true on all touch-primary devices and false on mouse/trackpad devices. The check runs once at mount — zero overhead for mouse users, zero `mousemove` listener overhead for touch users.

## Before / after

| Device | Before | After |
|---|---|---|
| Touch phone | mousemove fires on every touch → setState per event | Listener never registered |
| Mouse desktop | Unchanged | Unchanged (pointer: coarse is false) |
| iPad with keyboard + trackpad | Trackpad is coarse+fine → listener skips | No regression, cursor glow still works if pointer is fine |

## Steps to verify

1. Open Chrome DevTools → toggle device mode to a mobile viewport.
2. Check Performance tab — no `setMousePosition` calls while touching the screen.
3. On desktop: cursor glow still follows the mouse normally.

Please review and merge this under GSSoC 2026.