### PR TITLE
Abort in-flight gamification fetch on StudentDashboard unmount

### DIFF
--- a/components/StudentDashboard.js
+++ b/components/StudentDashboard.js
@@ -59,23 +59,31 @@ const StudentDashboard = () => {
   const [gamificationData, setGamificationData] = useState(null);
 
   useEffect(() => {
+    if (!user) return;
+
+    const controller = new AbortController();
+
     const fetchGamification = async () => {
       try {
         const token = await user.getIdToken();
         const res = await fetch("/api/student/gamification", {
-          headers: { Authorization: `Bearer ${token}` }
+          headers: { Authorization: `Bearer ${token}` },
+          signal: controller.signal,
         });
         if (res.ok) {
           const data = await res.json();
           setGamificationData(data);
         }
       } catch (err) {
-        console.error("Failed to load gamification data", err);
+        if (err.name !== "AbortError") {
+          console.error("Failed to load gamification data", err);
+        }
       }
     };
-    if (user) {
-      fetchGamification();
-    }
+
+    fetchGamification();
+
+    return () => controller.abort();
   }, [user]);
 
   // Mock schedule data is now imported from @/constants/mockData


### PR DESCRIPTION
## What was the bottleneck

`StudentDashboard` fetched `/api/student/gamification` inside a `useEffect([user])` with no cleanup. If the user navigated away before the response arrived, the fetch resolved after unmount and called `setGamificationData` on a detached component — producing a React warning and wasting the full network round-trip. Additionally, if the `user` object reference changed (common during Firebase token refresh), a new fetch started while the old one was still in flight, leading to a race where the older, slower response could overwrite the newer one's state.

## Root cause

No `AbortController` wired to the fetch, and no cleanup function in the `useEffect`.

## Files changed

- `components/StudentDashboard.js` — Create an `AbortController` at the top of the effect, pass its `signal` to `fetch`, abort in the cleanup return, and swallow `AbortError` (expected on cleanup — not a real error).

## Why this eliminates the root cause

When the component unmounts or `user` changes, the cleanup fires before the new effect, aborting any in-flight request. The `AbortError` is caught and ignored. Only the most recent fetch can succeed.

## Before / after

| Scenario | Before | After |
|---|---|---|
| Navigate away before response | setState on unmounted component, React warning | Request cancelled, no state update |
| Rapid user reference changes | Race between stale and fresh responses | Only latest request wins |

## Steps to verify

1. Sign in as student, open dashboard, immediately navigate away.
2. No React "setState on unmounted component" warning in console.
3. Return to dashboard — gamification data loads correctly.

Please review and merge this under GSSoC 2026.