### PR TITLE
Clear deferred timer and remove appinstalled listener on PWA unmount

### DIFF
--- a/components/InstallPWA.js
+++ b/components/InstallPWA.js
@@ -36,21 +36,26 @@ export default function InstallPWA() {
       console.error("Failed to read localStorage:", error);
     }
 
+    let visibilityTimer;
+
     const handler = (e) => {
       e.preventDefault();
       setInstallPrompt(e);
-      setTimeout(() => setIsVisible(true), 5000);
+      visibilityTimer = setTimeout(() => setIsVisible(true), 5000);
+    };
+
+    const installedHandler = () => {
+      setIsInstalled(true);
+      setIsVisible(false);
     };
 
     window.addEventListener("beforeinstallprompt", handler);
-
-    window.addEventListener("appinstalled", () => {
-      setIsInstalled(true);
-      setIsVisible(false);
-    });
+    window.addEventListener("appinstalled", installedHandler);
 
     return () => {
       window.removeEventListener("beforeinstallprompt", handler);
+      window.removeEventListener("appinstalled", installedHandler);
+      if (visibilityTimer) clearTimeout(visibilityTimer);
     };
   }, []);
 


### PR DESCRIPTION
## What was the bottleneck

`InstallPWA` had two resource leaks in its `useEffect`:

1. A 5-second `setTimeout` that showed the install prompt was never stored or cleared. If the component unmounted during those 5 seconds (e.g., the user navigated), `setIsVisible(true)` called state on a detached component.
2. The `appinstalled` event listener was added to `window` but never removed in the cleanup return. A stale closure remained attached to `window` indefinitely after the first mount, leaking memory and calling `setIsInstalled`/`setIsVisible` on detached instances.

## Root cause

The cleanup function only removed `beforeinstallprompt` but left out the `appinstalled` listener and did not hold a reference to the timer ID.

## Files changed

- `components/InstallPWA.js` — Store `setTimeout` ID in `visibilityTimer`, call `clearTimeout(visibilityTimer)` in cleanup. Move `appinstalled` handler to a named function, add `window.removeEventListener('appinstalled', installedHandler)` in cleanup.

## Before / after

| Scenario | Before | After |
|---|---|---|
| Unmount during 5-second delay | setState on unmounted component | Timer cancelled, no state update |
| Install prompt shown then unmounted | appinstalled handler stays on window | Handler removed on cleanup |

## Steps to verify

1. Trigger `beforeinstallprompt`, navigate away within 5 seconds.
2. No console warning about unmounted component state updates.
3. Install flow still works when user stays on the page.

Please review and merge this under GSSoC 2026.