### PR TITLE
Read user role from Firestore profile in noticeBoard

### DIFF
--- a/components/noticeBoard.js
+++ b/components/noticeBoard.js
@@ -22,8 +22,7 @@ const CATEGORIES = [
 ];
 
 const SmartNoticeBoard = () => {
-  const { user, loading: authLoading } = useAuth();
-
+  const { user, userProfile, loading: authLoading } = useAuth();
   const [notices, setNotices] = useState([]);
   const [loading, setLoading] = useState(true);
 
@@ -38,6 +37,10 @@ const SmartNoticeBoard = () => {
   const [readNotices, setReadNotices] = useState(new Set());
 
   const userId = user?.uid || user?.id || "anonymous";
+
+  const getUserRole = () => {
+    return userProfile?.role || user?.role || "student";
+  };
 
   // Load notices + SSE
   useEffect(() => {


### PR DESCRIPTION
## What was the bottleneck

`noticeBoard.js` filtered notices by `targetAudience` using a role obtained from `user?.role`. Firebase Auth objects do not carry a `.role` field — that field lives in the Firestore `users` collection. `user?.role` evaluated to `undefined` on every request, and the fallback `|| "student"` silently treated every user — teachers, admins, institute staff — as a student. Teachers never saw notices scoped to `["teacher", "admin"]` and admins never saw admin-only notices.

## Root cause

`useAuth` already fetches the Firestore profile into a separate `userProfile` return value, but `noticeBoard.js` only destructured `user` and ignored `userProfile`.

## Files changed

- `components/noticeBoard.js` — Destructure `userProfile` alongside `user` from `useAuth()`. Change `getUserRole()` to return `userProfile?.role || user?.role || "student"`, reading from the Firestore-backed profile first.

## Why this eliminates the root cause

`userProfile` is populated directly from `getDoc(doc(db, 'users', uid))` inside `useAuth`, which is where role is stored. Reading `userProfile.role` gives the correct value for all role types without any extra fetch.

## Before / after

| User role | Before | After |
|---|---|---|
| teacher | Shown student notices only | Shown teacher-targeted notices |
| admin | Shown student notices only | Shown admin + teacher + student notices (if targetAudience allows) |
| student | Correct (coincidental) | Unchanged |

## Steps to verify

1. Sign in as teacher account.
2. Open /notices — "Faculty Meeting Rescheduled" (targetAudience: ["teacher","admin"]) should now appear.
3. Sign in as student — that notice should not appear.

Please review and merge this under GSSoC 2026.