### PR TITLE
Abort stale exception-list fetches in TeacherDashboard polling loop

### DIFF
--- a/components/TeacherDashboardComponent.js
+++ b/components/TeacherDashboardComponent.js
@@ -329,8 +329,13 @@ const TeacherDashboard = () => {
 
   // Fetch exception requests
   useEffect(() => {
+    if (!user) return;
+
+    let controller = new AbortController();
+
     const fetchExceptionRequests = async () => {
-      if (!user) return;
+      controller.abort();
+      controller = new AbortController();
 
       setIsLoadingRequests(true);
       setRequestsError(null);
@@ -338,9 +343,8 @@ const TeacherDashboard = () => {
       try {
         const token = await user.getIdToken();
         const response = await fetch("/api/exceptions/list", {
-          headers: {
-            Authorization: `Bearer ${token}`,
-          },
+          headers: { Authorization: `Bearer ${token}` },
+          signal: controller.signal,
         });
 
         if (!response.ok) {
@@ -350,7 +354,6 @@ const TeacherDashboard = () => {
         const data = await response.json();
         const payload = data.data ?? data;
 
-        // Normalize data structure
         const normalizedRequests = (payload.exceptions || []).map((req) => ({
           id: req._id || req.id,
           studentName: req.studentName || req.student || "Unknown Student",
@@ -368,7 +371,10 @@ const TeacherDashboard = () => {
 
         setExceptionRequests(normalizedRequests);
       } catch (error) {
-        setRequestsError(error.message);
+        if (error.name !== "AbortError") {
+          console.error("Failed to fetch exception requests:", error);
+          setRequestsError(error.message);
+        }
       } finally {
         setIsLoadingRequests(false);
       }
@@ -376,9 +382,11 @@ const TeacherDashboard = () => {
 
     fetchExceptionRequests();
 
-    // Poll for updates every 30 seconds
     const interval = setInterval(fetchExceptionRequests, 30000);
-    return () => clearInterval(interval);
+    return () => {
+      clearInterval(interval);
+      controller.abort();
+    };
   }, [user]);
 
   const handleExceptionRequest = async (id, action) => {


### PR DESCRIPTION
## What was the bottleneck

`TeacherDashboardComponent` polled `/api/exceptions/list` every 30 seconds via a `setInterval`. Each fetch had no `AbortController`, so:

1. On component unmount, in-flight requests completed and called `setExceptionRequests` on a detached component.
2. If a slow poll response (e.g. under MongoDB pressure) resolved after the next 30-second tick had already fired and received a faster response, the stale response overwrote the fresh one — showing teachers outdated exception data.

## Root cause

No cancellation mechanism on the fetch, and no abort in the useEffect cleanup.

## Files changed

- `components/TeacherDashboardComponent.js` — Added an `AbortController` reference. At the start of each `fetchExceptionRequests` call, the previous controller is aborted and a fresh one is created. The cleanup aborts the in-flight request and clears the interval. `AbortError` is caught and silently ignored.

## Why this eliminates the root cause

Each fetch tick aborts the previous one before starting, so only the most recent response ever updates state. On unmount, both the interval and the current in-flight request are cancelled.

## Before / after

| Scenario | Before | After |
|---|---|---|
| Unmount during active poll | setState on unmounted component | Request aborted, no state update |
| Slow network causes response order inversion | Stale response overwrites fresh state | Previous request aborted on next tick |
| Normal poll cycle | Unchanged | Unchanged |

## Steps to verify

1. Open teacher dashboard, wait for exceptions to load.
2. Navigate away immediately — no React warning in console.
3. Return — data loads fresh on remount.

Please review and merge this under GSSoC 2026.