### PR TITLE
fix: apply object-cover class to FaceRecognizer overlay canvas

### DIFF
--- a/components/FaceRecognizer.js
+++ b/components/FaceRecognizer.js
@@ -422,7 +422,7 @@ export default function FaceRecognizer({ authUser }) {
 
         <canvas
           ref={canvasRef}
-          className="absolute top-0 left-0 w-full h-full pointer-events-none z-20"
+          className="absolute top-0 left-0 w-full h-full pointer-events-none z-20 object-cover"
         />
 
         {/* Liveness Overlay */}


### PR DESCRIPTION
Fixes #732

This PR adds `object-cover` to the `<canvas>` overlay in the FaceRecognizer layout, ensuring that its dimensions and scaling behavior match the underlying `<video>` tag exactly to prevent viewport offsets on mobile devices.

Requesting `gssoc`, `gssoc:approved` point labels!