### PR TITLE
security: enforce fresh GPS coordinates for attendance

### DIFF
--- a/components/AttendanceValidation.js
+++ b/components/AttendanceValidation.js
@@ -107,7 +107,7 @@ const AttendanceValidation = ({ onValidationSuccess }) => {
         navigator.geolocation.getCurrentPosition(resolve, reject, {
           enableHighAccuracy: true,
           timeout: 15000,
-          maximumAge: 30000,
+          maximumAge: 0,
         });
       });
 
@@ -236,7 +236,7 @@ const AttendanceValidation = ({ onValidationSuccess }) => {
         navigator.geolocation.getCurrentPosition(resolve, reject, {
           enableHighAccuracy: true,
           timeout: 15000,
-          maximumAge: 30000,
+          maximumAge: 0,
         });
       });
 


### PR DESCRIPTION
## Problem

`AttendanceValidation.js` passes `maximumAge: 30000` to both `navigator.geolocation.getCurrentPosition` calls — one in `requestLocation` and one in `getCurrentLocationForException`. This tells the browser it may serve a cached GPS fix up to 30 seconds old.

A student could walk into the allowed radius, trigger one successful GPS read, then walk away. Any attendance or exception request submitted within the next 30 seconds re-uses the stale cached position and still passes the distance check.

## Fix

Set `maximumAge: 0` in both calls. The browser now always acquires a fresh GPS reading before validation proceeds.

## Files changed

- `components/AttendanceValidation.js` — two occurrences of `maximumAge: 30000` changed to `maximumAge: 0`

Please review and merge this under GSSoC 2026.