### PR TITLE
perf: disable CursorGlow mouse tracking on touch supported screens

### DIFF
--- a/components/CursorGlow.js
+++ b/components/CursorGlow.js
@@ -4,6 +4,8 @@ import { useEffect } from "react";
 
 export default function CursorGlow() {
   useEffect(() => {
+    const isTouchDevice = 'ontouchstart' in window || navigator.maxTouchPoints > 0 || navigator.msMaxTouchPoints > 0;
+    if (isTouchDevice) return;
     const glow = document.getElementById("cursor-glow");
 
     let mouseX = 0;


### PR DESCRIPTION
Fixes #734

This PR returns early from the CursorGlow effect hook on touch-capable devices, avoiding registration of client-side mouse listeners and reducing CPU and battery consumption on mobile and tablet displays.

Requesting `gssoc`, `gssoc:approved` point labels!