### PR TITLE
chore: deprecate duplicate ScrollToTop in favor of BackToTop

### DIFF
--- a/components/ScrollToTop.js
+++ b/components/ScrollToTop.js
@@ -1,39 +1,7 @@
 "use client";
 
-import { useEffect, useState } from "react";
-import { ArrowUp } from "lucide-react";
-
-const SCROLL_THRESHOLD_PX = 320;
+import BackToTop from "./BackToTop";
 
 export default function ScrollToTop() {
-  const [visible, setVisible] = useState(false);
-
-  useEffect(() => {
-    const onScroll = () => {
-      setVisible(window.scrollY > SCROLL_THRESHOLD_PX);
-    };
-
-    onScroll();
-    window.addEventListener("scroll", onScroll, { passive: true });
-    return () => window.removeEventListener("scroll", onScroll);
-  }, []);
-
-  const scrollToTop = () => {
-    window.scrollTo({ top: 0, behavior: "smooth" });
-  };
-
-  if (!visible) {
-    return null;
-  }
-
-  return (
-    <button
-      type="button"
-      onClick={scrollToTop}
-      aria-label="Scroll to top"
-      className="fixed bottom-24 right-6 z-40 flex h-11 w-11 items-center justify-center rounded-full border border-slate-600/80 bg-slate-900/90 text-white shadow-lg backdrop-blur-sm transition hover:border-purple-400/60 hover:bg-slate-800 focus:outline-none focus-visible:ring-2 focus-visible:ring-purple-400"
-    >
-      <ArrowUp className="h-5 w-5" aria-hidden />
-    </button>
-  );
+  return <BackToTop />;
 }


### PR DESCRIPTION
Fixes #735

This PR resolves code duplication by rendering the styled `<BackToTop />` component directly inside the `<ScrollToTop />` wrapper, maintaining backward compatibility while purging duplicate scrolling logic.

Requesting `gssoc`, `gssoc:approved` point labels!