### PR TITLE
fix: enforce maximum file size validation on profile avatar uploads

### DIFF
--- a/components/universal-profile.js
+++ b/components/universal-profile.js
@@ -112,6 +112,25 @@ export default function UniversalProfile() {
     fileInputRef.current?.click();
   };
 
+  const handleFileChange = (e) => {
+    const file = e.target.files[0];
+    if (!file) return;
+    const MAX_SIZE = 5 * 1024 * 1024; // 5MB
+    if (file.size > MAX_SIZE) {
+      alert("File size exceeds the 5MB limit. Please select a smaller file.");
+      e.target.value = "";
+      return;
+    }
+    const reader = new FileReader();
+    reader.onloadend = () => {
+      setFormData((prev) => ({
+        ...prev,
+        avatar: reader.result,
+      }));
+    };
+    reader.readAsDataURL(file);
+  };
+
   const getUserPhoto = () => {
     return user?.photoURL || null;
   };
@@ -559,6 +578,7 @@ export default function UniversalProfile() {
                 ref={fileInputRef}
                 className="hidden"
                 accept="image/*"
+                onChange={handleFileChange}
               />
             </div>
 


### PR DESCRIPTION
Fixes #743

This PR introduces a client-side 5MB limit verification on the profile file upload onChange handler to prevent network timeouts for large files, and reads the file into a data URL.

Requesting `gssoc`, `gssoc:approved` point labels!