### PR TITLE
fix: restrict AttendanceValidation passcode inputs to numeric characters only

### DIFF
--- a/components/AttendanceValidation.js
+++ b/components/AttendanceValidation.js
@@ -604,7 +604,10 @@ const AttendanceValidation = ({ onValidationSuccess }) => {
           <input
             type="password"
             value={passcode}
-            onChange={(e) => setPasscode(e.target.value)}
+            onChange={(e) => {
+              const val = e.target.value.replace(/\D/g, "");
+              setPasscode(val);
+            }}
             placeholder="• • • • • •"
             className="w-full bg-white/5 border-2 border-white/20 rounded-2xl px-8 py-6 text-white placeholder-gray-400 focus:outline-none focus:ring-4 focus:ring-purple-500/50 focus:border-purple-500 text-center text-3xl tracking-[0.5em] font-bold transition-all duration-300"
             maxLength={8}


### PR DESCRIPTION
Fixes #745

This PR updates the passcode input onChange handler to sanitize inputs and ignore non-numeric entries, blocking redundant invalid submissions.

Requesting `gssoc`, `gssoc:approved` point labels!