### PR TITLE
security: rate-limit password reset requests

### DIFF
--- a/app/api/auth/forgot-password/route.js
+++ b/app/api/auth/forgot-password/route.js
@@ -1,0 +1,31 @@
+import { checkRateLimit } from "@/lib/rateLimit";
+import { jsonError, jsonSuccess } from "@/lib/api-response";
+
+const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+export async function POST(request) {
+  try {
+    const ip = request.headers.get("x-forwarded-for")?.split(",")[0].trim() || "unknown";
+
+    // 3 reset requests per minute per IP
+    const rateKey = `pwd-reset:${ip}`;
+    const limit = await checkRateLimit(rateKey);
+
+    if (!limit.allowed) {
+      return jsonError("Too many password reset requests. Please wait before trying again.", 429);
+    }
+
+    const body = await request.json();
+    const { email } = body;
+
+    if (!email || typeof email !== "string" || !EMAIL_PATTERN.test(email.trim())) {
+      return jsonError("A valid email address is required", 400);
+    }
+
+    // Return success without revealing whether the email exists
+    return jsonSuccess({ message: "If that address is registered, a reset email has been sent." }, 200);
+  } catch (error) {
+    console.error("Forgot-password route error:", error);
+    return jsonError("Internal server error", 500);
+  }
+}

--- a/app/auth/page.js
+++ b/app/auth/page.js
@@ -192,6 +192,18 @@ export default function AuthPage() {
     setErrors({});
 
     try {
+      // Server-side rate limit check before triggering Firebase
+      const gateRes = await fetch("/api/auth/forgot-password", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email: emailToReset }),
+      });
+
+      if (gateRes.status === 429) {
+        setErrors({ forgotEmail: "Too many reset attempts. Please wait a moment and try again." });
+        return;
+      }
+
       const result = await resetPassword(emailToReset);
 
       if (result.success) {


### PR DESCRIPTION
## Problem

`handleForgotPassword` in `app/auth/page.js` called Firebase `sendPasswordResetEmail` directly with no server-side rate limiting. An attacker could loop thousands of reset requests against any email address, causing:

- Firebase email quota exhaustion
- Inbox flooding of targeted users
- Account enumeration (Firebase error codes differ per address state)

## Fix

**New API route** — `POST /api/auth/forgot-password` uses the existing MongoDB-backed `checkRateLimit` helper (from `lib/rateLimit.js`), keyed by client IP. Returns `429` when the budget is exceeded.

**Updated `handleForgotPassword`** — hits the gate endpoint first. On `429`, shows the user a cooldown message and does **not** call Firebase. On success, proceeds as before.

The API route returns a generic success message regardless of whether the email exists, to prevent account enumeration.

## Files changed

- `app/api/auth/forgot-password/route.js` — new rate-limit gate route
- `app/auth/page.js` — call gate before triggering Firebase reset

Please review and merge this under GSSoC 2026.