### PR TITLE
fix: reset deferred prompt reference on all outcomes in InstallPWA

### DIFF
--- a/components/InstallPWA.js
+++ b/components/InstallPWA.js
@@ -57,11 +57,8 @@ export default function InstallPWA() {
 
     try {
       const result = await installPrompt.prompt();
-
-      if (result.outcome === "accepted") {
-        setIsVisible(false);
-        setInstallPrompt(null);
-      }
+      setInstallPrompt(null);
+      setIsVisible(false);
     } catch (error) {
       // Silently handle installation errors
     }


### PR DESCRIPTION
Fixes #746

This PR resets the stale `installPrompt` reference and hides the banner on all prompt results in the InstallPWA widget to avoid dead subsequent CTA clicks.

Requesting `gssoc`, `gssoc:approved` point labels!