### PR TITLE
ux: enforce min-height and transition layout classes in AuthForm

### DIFF
--- a/components/AuthForm.js
+++ b/components/AuthForm.js
@@ -94,7 +94,7 @@ export default function AuthForm({
         </div>
       )}
 
-      <div className="bg-card backdrop-blur-xl rounded-2xl shadow-2xl border border-border p-8">
+      <div className="bg-card backdrop-blur-xl rounded-2xl shadow-2xl border border-border p-8 min-h-[620px] flex flex-col justify-between transition-all duration-300">
         <div className="text-center mb-8">
           <h2 className="text-2xl font-bold text-foreground mb-2">
             {isLogin ? "Welcome Back" : "Create Account"}
@@ -250,6 +250,36 @@ export default function AuthForm({
               <p className="text-gray-400 text-xs mt-1">
                 Min 8 characters with upper, lower, number, and special character.
               </p>
+            )}
+            {!isLogin && (
+              <div className="mt-3 space-y-1.5 text-xs bg-slate-950/20 p-3 rounded-lg border border-border/50">
+                <p className="font-semibold text-slate-400 mb-1">Password Requirements:</p>
+                <div className="flex items-center gap-2">
+                  <span className={password.length >= 8 ? "text-green-400" : "text-gray-400"}>
+                    {password.length >= 8 ? "✓" : "○"} 8+ characters
+                  </span>
+                </div>
+                <div className="flex items-center gap-2">
+                  <span className={/[A-Z]/.test(password) ? "text-green-400" : "text-gray-400"}>
+                    {/[A-Z]/.test(password) ? "✓" : "○"} At least one uppercase letter
+                  </span>
+                </div>
+                <div className="flex items-center gap-2">
+                  <span className={/[a-z]/.test(password) ? "text-green-400" : "text-gray-400"}>
+                    {/[a-z]/.test(password) ? "✓" : "○"} At least one lowercase letter
+                  </span>
+                </div>
+                <div className="flex items-center gap-2">
+                  <span className={/\d/.test(password) ? "text-green-400" : "text-gray-400"}>
+                    {/\d/.test(password) ? "✓" : "○"} At least one number
+                  </span>
+                </div>
+                <div className="flex items-center gap-2">
+                  <span className={/[^A-Za-z0-9]/.test(password) ? "text-green-400" : "text-gray-400"}>
+                    {/[^A-Za-z0-9]/.test(password) ? "✓" : "○"} At least one special character
+                  </span>
+                </div>
+              </div>
             )}
             {!isLogin && password && (
               <div className="mt-3 space-y-2">


### PR DESCRIPTION
Fixes #750

This PR adds a minimum height of 620px to the AuthForm wrapper to absorb height variations and mitigate visual layout shifts during login/signup toggle.

Requesting `gssoc`, `gssoc:approved` point labels!