### PR TITLE
fix: prevent AttendanceHeatmap from mapping empty history records

### DIFF
--- a/components/AttendanceHeatmap.jsx
+++ b/components/AttendanceHeatmap.jsx
@@ -117,7 +117,12 @@ const getCellClassName = (value) => {
 
 const AttendanceHeatmap = ({ recentActivity = [] }) => {
   const values = useMemo(
-    () => buildAttendanceValues(recentActivity),
+    () => {
+      if (!recentActivity || recentActivity.length === 0) {
+        return [];
+      }
+      return buildAttendanceValues(recentActivity);
+    },
     [recentActivity],
   );
 


### PR DESCRIPTION
Fixes #751

This PR returns an empty array immediately in the useMemo loop if recentActivity is missing or empty, gracefully rendering the loading/empty history state.

Requesting `gssoc`, `gssoc:approved` point labels!