### PR TITLE
security: enforce RS256 algorithm constraints in middleware token check

### DIFF
--- a/middleware.js
+++ b/middleware.js
@@ -81,6 +81,7 @@ async function verifyIdToken(token) {
     const header = JSON.parse(
       new TextDecoder().decode(base64UrlDecode(parts[0]))
     );
+    if (header.alg !== "RS256") return null;
     const payload = JSON.parse(
       new TextDecoder().decode(base64UrlDecode(parts[1]))
     );


### PR DESCRIPTION
Fixes #741

This PR explicitly checks header.alg === 'RS256' inside the edge JWT decoding method of the middleware to prevent signature algorithm bypass attacks.

Requesting `gssoc`, `gssoc:approved` point labels!