### PR TITLE
fix: resolve race condition allowing duplicate attendance records

### DIFF
--- a/services/attendanceService.js
+++ b/services/attendanceService.js
@@ -1,6 +1,7 @@
 import {
   collection,
-  addDoc,
+  setDoc,
+  doc,
   getDocs,
   query,
   serverTimestamp,
@@ -56,10 +57,10 @@ return !snapshot.empty;
  * @throws {Error} If userId or db is unavailable.
  * @example
  * const result = await recordAttendance({
- *   userId: 'user_abc123',
- *   studentName: 'Alice Smith',
- *   email: 'alice@example.com',
- *   confidenceScore: 0.97,
+ * userId: 'user_abc123',
+ * studentName: 'Alice Smith',
+ * email: 'alice@example.com',
+ * confidenceScore: 0.97,
  * });
  * // { alreadyRecorded: false }
  */
@@ -77,6 +78,8 @@ export async function recordAttendance({
     return { alreadyRecorded: true };
   }
 
+  const todayKey = getTodayKey();
+
   // INTERCEPT OFFLINE SUBMISSIONS
   if (typeof window !== "undefined" && !navigator.onLine) {
     console.warn("Device is offline. Queuing attendance locally.");
@@ -85,7 +88,7 @@ export async function recordAttendance({
       studentName,
       email,
       confidenceScore: confidenceScore ?? 0,
-      date: getTodayKey(),
+      date: todayKey,
     });
     
     // Attempt to register Background Sync for later flush
@@ -94,12 +97,12 @@ export async function recordAttendance({
     return { alreadyRecorded: false, newRate: null, queuedOffline: true };
   }
 
-  await addDoc(collection(db, "attendance_records"), {
+  await setDoc(doc(db, "attendance_records", `${userId}_${todayKey}`), {
     userId,
     studentName,
     email,
     timestamp: serverTimestamp(),
-    date: getTodayKey(),
+    date: todayKey,
     status: "present",
     confidenceScore: confidenceScore ?? 0,
   });


### PR DESCRIPTION
## What type of PR is this?
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [ ] 🎨 UI/UX improvement
- [x] ⚡ Performance improvement
- [ ] 🔒 Security fix

## Description
This PR resolves a database race condition in the `recordAttendance` function. Previously, using `addDoc` allowed multiple parallel network requests (e.g., from rapid button clicks on slow connections) to bypass the `hasCheckedInToday` check and create duplicate daily records for the same student. 

## Related Issues
Closes #823 

## Changes Made
- Transitioned the write operation from `addDoc` to `setDoc`.
- Implemented a deterministic document ID structure (`${userId}_${todayKey}`) to guarantee idempotency. Parallel or duplicate requests will now safely overwrite the single daily document rather than appending duplicates.
- Offline queuing and background sync logic remain entirely unaffected.

## Testing
How did you test these changes?
- [x] Tested locally
- [ ] Tested on mobile
- [ ] Tested different user roles
- [ ] All roles tested

## Checklist
- [x] No hardcoded secrets or credentials
- [x] `.env.local` is not committed
- [x] Code follows project style
- [x] Build passes locally (`npm run build`)
- [x] No console errors/warnings

**GSSoC 2026** Contributor!
/gssoc-page-status