### PR TITLE
fix: critical - restore face recognition pipeline by using image proxy instead of removed image field

### DIFF
--- a/components/FaceRecognizer.js
+++ b/components/FaceRecognizer.js
@@ -197,7 +197,8 @@ export default function FaceRecognizer({ authUser }) {
       await Promise.all(
         labels.map(async (student) => {
           try {
-            const img = await faceapi.fetchImage(student.image);
+            const imgUrl = `/api/images?id=${student._id}`;
+            const img = await faceapi.fetchImage(imgUrl);
             const detection = await faceapi
               .detectSingleFace(img, new faceapi.TinyFaceDetectorOptions())
               .withFaceLandmarks()

--- a/components/FaceRecognizer.js
+++ b/components/FaceRecognizer.js
@@ -197,6 +197,7 @@ export default function FaceRecognizer({ authUser }) {
       await Promise.all(
         labels.map(async (student) => {
           try {
+            if (!student.hasImage) return null;
             const imgUrl = `/api/images?id=${student._id}`;
             const img = await faceapi.fetchImage(imgUrl);
             const detection = await faceapi


### PR DESCRIPTION
## Description

Fixes #693

**Severity: Critical** — Biometric face matching is completely non-functional. The `buildFaceMatcher` function reads `student.image` which was intentionally removed from the labels API for security reasons (commit 5301cd3). `faceapi.fetchImage(undefined)` throws for every student, producing an empty `labeledFaceDescriptors` array — `findBestMatch` always returns `"unknown"`. Face-based attendance check-ins are permanently broken.

## Root Cause

`components/FaceRecognizer.js:200`:
```
const img = await faceapi.fetchImage(student.image);
```

The `/api/labels` endpoint (`app/api/labels/route.js:105-115`) explicitly destructures `image` out:
```
const sanitizedUsers = allUsers.map(({ image, ...rest }) => ({
  ...rest,
  hasImage: !!image,
}));
```

So `student.image` is always `undefined`. The authenticated proxy at `/api/images?id=<id>` was created specifically for this use case but `FaceRecognizer.js` was never updated to use it after the liveness/anti-spoofing refactor (PR #591).

## Changes

### 1. `components/FaceRecognizer.js:200-201` — Use image proxy endpoint
```
// Before: reads removed field (always undefined -> throws)
const img = await faceapi.fetchImage(student.image);

// After: uses authenticated proxy with student._id
const imgUrl = `/api/images?id=${student._id}`;
const img = await faceapi.fetchImage(imgUrl);
```

### 2. `components/FaceRecognizer.js:199` — Early skip for students without images
Added a `hasImage` guard to avoid unnecessary 404 proxy requests for students who haven't uploaded a photo:
```
if (!student.hasImage) return null;
```

## Impact

The `FaceRecognizer` component is the core attendance mechanism for "AI-Powered Smart Student Engagement & Attendance Platform". Without this fix:
- The camera scans indefinitely showing "No labeled faces found ❌"
- Liveness detection runs, confidence bars animate — but matching always fails
- Zero successful face-based attendance check-ins

## Verification

| Scenario | Before | After |
|---|---|---|
| Student with uploaded image (`hasImage: true`) | `fetchImage(undefined)` throws -> descriptor = null | Proxy returns image -> descriptor computed |
| Student without image (`hasImage: false`) | Same throw -> null (wastes request) | `return null` early (no HTTP call) |
| Labels array empty | Returns early (no crash) | Returns early (unchanged) |
| Network/proxy error | Caught -> null | Caught -> null (unchanged) |

## Edge Cases
- **student._id always present**: Projected in labels query, part of `...rest` (not destructured out)
- **Cookie-based auth**: Browser includes auth cookie with same-origin image request -> proxy authenticates correctly
- **Invalid/expired stored image URL**: Proxy returns 502 -> fetchImage throws -> caught -> null
- **Parallel execution**: Promise.all maps independently per student, failures don't block others