### PR TITLE
fix(pwa): cleanup appinstalled event listener to prevent memory leak

### DIFF
--- a/components/InstallPWA.js
+++ b/components/InstallPWA.js
@@ -40,15 +40,17 @@ export default function InstallPWA() {
       setTimeout(() => setIsVisible(true), 5000);
     };
 
-    window.addEventListener("beforeinstallprompt", handler);
-
-    window.addEventListener("appinstalled", () => {
+    const appInstalledHandler = () => {
       setIsInstalled(true);
       setIsVisible(false);
-    });
+    };
+
+    window.addEventListener("beforeinstallprompt", handler);
+    window.addEventListener("appinstalled", appInstalledHandler);
 
     return () => {
       window.removeEventListener("beforeinstallprompt", handler);
+      window.removeEventListener("appinstalled", appInstalledHandler);
     };
   }, []);
 


### PR DESCRIPTION
## What type of PR is this?
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [ ] 🎨 UI/UX improvement
- [x] ⚡ Performance improvement
- [ ] 🔒 Security fix

## Description
This PR resolves a memory leak issue inside the `components/InstallPWA.js` component. Previously, the `appinstalled` event listener was attached using an anonymous callback function, making it impossible to cleanly deregister it during the `useEffect` cleanup cycle. This caused orphaned event listeners to accumulate in memory every time the component was mounted/unmounted.

## Related Issues
Closes #824 

## Changes Made
- Extracted the anonymous inline function for `appinstalled` into a named constant: `appInstalledHandler`.
- Added `window.removeEventListener("appinstalled", appInstalledHandler)` to the `useEffect` cleanup return block to ensure proper teardown.
- Standardized the component's lifecycle destruction to comply with React strict mode behavior.

## Testing
How did you test these changes?
- [x] Tested locally
- [ ] Tested on mobile
- [ ] Tested different user roles
- [ ] All roles tested

## Checklist
- [x] No hardcoded secrets or credentials
- [x] `.env.local` is not committed
- [x] Code follows project style
- [x] Build passes locally (`npm run build`)
- [x] No console errors/warnings

**GSSoC 2026** Contributor!
/gssoc-page-status