### PR TITLE
fix(security): Force fresh GPS locations for attendance validation (#768)

### DIFF
--- a/components/AttendanceValidation.js
+++ b/components/AttendanceValidation.js
@@ -107,7 +107,7 @@ const AttendanceValidation = ({ onValidationSuccess }) => {
         navigator.geolocation.getCurrentPosition(resolve, reject, {
           enableHighAccuracy: true,
           timeout: 15000,
-          maximumAge: 30000,
+          maximumAge: 0,
         });
       });
 
@@ -236,7 +236,7 @@ const AttendanceValidation = ({ onValidationSuccess }) => {
         navigator.geolocation.getCurrentPosition(resolve, reject, {
           enableHighAccuracy: true,
           timeout: 15000,
-          maximumAge: 30000,
+          maximumAge: 0,
         });
       });
 


### PR DESCRIPTION
Description
Resolves #768

Description: This PR closes the "Teleportation Loophole" in AttendanceValidation.js. Previously, the geolocation config had maximumAge: 30000 (30 seconds) set, which allowed the browser to use a cached GPS location instead of requesting a fresh coordinate. This allowed users to cache a valid location inside bounds and submit verification up to 30 seconds later from out of bounds.

Changes Made:

Updated all navigator.geolocation.getCurrentPosition requests in 
AttendanceValidation.js
 to set maximumAge: 0 (preventing cached location acceptance).
This forces the system to always query a fresh, real-time GPS coordinate for both normal validation checks and exception capturing.
