### PR TITLE
perf(hooks): throttle useIdleTimeout event listeners to fix CPU drain

### DIFF
--- a/hooks/useIdleTimeout.js
+++ b/hooks/useIdleTimeout.js
@@ -10,6 +10,7 @@ export function useIdleTimeout() {
   const logoutTimer = useRef(null);
   const warningTimer = useRef(null);
   const warningToastId = useRef(null);
+  const throttleTimer = useRef(null);
 
   const clearTimers = () => {
     if (logoutTimer.current) clearTimeout(logoutTimer.current);
@@ -39,12 +40,24 @@ export function useIdleTimeout() {
 
   useEffect(() => {
     const events = ["mousemove", "keydown", "click", "touchstart", "scroll"];
-    events.forEach((e) => window.addEventListener(e, resetTimers));
+    
+    const throttledReset = () => {
+      if (throttleTimer.current) return;
+      
+      throttleTimer.current = setTimeout(() => {
+        throttleTimer.current = null;
+      }, 1000);
+      
+      resetTimers();
+    };
+
+    events.forEach((e) => window.addEventListener(e, throttledReset, { passive: true }));
     resetTimers();
 
     return () => {
       clearTimers();
-      events.forEach((e) => window.removeEventListener(e, resetTimers));
+      if (throttleTimer.current) clearTimeout(throttleTimer.current);
+      events.forEach((e) => window.removeEventListener(e, throttledReset));
     };
   }, []);
 }


### PR DESCRIPTION
## What type of PR is this?

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [ ] 🎨 UI/UX improvement
- [x] ⚡ Performance improvement
- [ ] 🔒 Security fix

## Description
Resolves a critical performance bottleneck in the `useIdleTimeout` hook. Previously, `resetTimers` was directly bound to high-frequency browser events (`mousemove`, `scroll`, `touchstart`) without any form of throttling. This caused the application to instantiate and destroy JavaScript `setTimeout` loops and React state variables hundreds of times per second whenever a user simply swept their mouse across the screen, leading to severe CPU spiking, UI lag, and battery drain.

## Related Issues

Closes #838 

## Changes Made

* **Event Throttling:** Wrapped the core `resetTimers` function inside a custom `throttledReset` wrapper utilizing `useRef`. This ensures the internal timers are only reset a maximum of once per second, massively reducing execution overhead.
* **Passive Event Listeners:** Added `{ passive: true }` when binding the event listeners to the `window`. This allows the browser's compositor thread to scroll the page smoothly without waiting for the main thread's JavaScript execution to complete.
* **Cleanup Safety:** Added logic to `clearTimeout(throttleTimer.current)` on component unmount to completely eradicate potential memory leaks.

## Testing

How did you test these changes?
- [x] Tested locally
- [ ] Tested on mobile
- [ ] Tested different user roles
- [ ] All roles tested


## Checklist

- [x] No hardcoded secrets or credentials
- [x] `.env.local` is not committed
- [x] Code follows project style
- [ ] Changes are documented
- [x] Build passes locally (`npm run build`)
- [x] No console errors/warnings
