### PR TITLE
Fix: Implement pagination for background attendance sync to prevent OOM (#842)

### DIFF
--- a/worker/index.js
+++ b/worker/index.js
@@ -20,30 +20,42 @@ async function syncAttendanceSW() {
   const records = await getOutboxRecords();
   if (records.length === 0) return;
 
-  try {
-    const response = await fetch("/api/attendance/sync", {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-      },
-      // Credentials same-origin ensures cookies (like authToken) are sent!
-      credentials: "same-origin",
-      body: JSON.stringify({ records }),
-    });
+  const BATCH_SIZE = 50;
+  let totalSynced = 0;
 
-    if (response.ok) {
-      const data = await response.json();
-      if (data.success && data.syncedIds) {
-        for (const id of data.syncedIds) {
-          await removeFromOutbox(id);
+  try {
+    for (let i = 0; i < records.length; i += BATCH_SIZE) {
+      const batch = records.slice(i, i + BATCH_SIZE);
+
+      const response = await fetch("/api/attendance/sync", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        // Credentials same-origin ensures cookies (like authToken) are sent!
+        credentials: "same-origin",
+        body: JSON.stringify({ records: batch }),
+      });
+
+      if (response.ok) {
+        const data = await response.json();
+        if (data.success && data.syncedIds) {
+          for (const id of data.syncedIds) {
+            await removeFromOutbox(id);
+          }
+          totalSynced += data.syncedIds.length;
         }
-        
-        // Notify any open clients that sync completed
-        const clients = await self.clients.matchAll();
-        clients.forEach((client) => {
-          client.postMessage({ type: "SYNC_COMPLETE", count: data.syncedIds.length });
-        });
+      } else {
+        throw new Error(`Failed to sync batch: ${response.status} ${response.statusText}`);
       }
+    }
+
+    if (totalSynced > 0) {
+      // Notify any open clients that sync completed
+      const clients = await self.clients.matchAll();
+      clients.forEach((client) => {
+        client.postMessage({ type: "SYNC_COMPLETE", count: totalSynced });
+      });
     }
   } catch (error) {
     console.error("[Service Worker] Error during background sync:", error);


### PR DESCRIPTION
What changed: Refactored the syncAttendanceSW background sync function in the Service Worker (worker/index.js) to process unsynced attendance records in smaller batches (chunks of 50) rather than sending the entire IndexedDB payload in a single network request.

Why this is needed: Previously, if a user remained offline for an extended period, the accumulated attendance outbox payload could grow significantly. When attempting to sync all records in a single request, it risked triggering server-side payload limits (e.g., Vercel's standard 4.5MB request limit) and could cause Out-of-Memory (OOM) crashes on resource-constrained mobile devices.

Key updates:

Sliced locally stored records into batches of 50.
Sent consecutive fetch requests for each batch recursively instead of a single massive POST request.
Incremented IndexedDB removeFromOutbox cleanups per successful batch sync to guarantee data consistency even if subsequent batches fail midway due to lost connectivity.