### PR TITLE
fix: remove duplicate language dropdown from landing page

### DIFF
--- a/app/page.js
+++ b/app/page.js
@@ -322,19 +322,7 @@ export default function AboutPage() {
       <div className="min-h-screen relative z-50">
         <Navbar />
 
-        <div className="fixed top-24 right-6 z-[9999]">
-  <select
-    value={language}
-    onChange={(e) => setLanguage(e.target.value)}
-    className="bg-purple-600 text-white px-4 py-2 rounded-lg shadow-lg border border-white/20 focus:outline-none focus:ring-2 focus:ring-purple-400"
-    aria-label="Select language"
-  >
-    <option value="en">English</option>
-    <option value="hi">Hindi</option>
-  </select>
-</div>
 
-        
         {/* Hero Section */}
         <section
           id="hero"


### PR DESCRIPTION
## 📝 Description

**What this PR does / why we need it:**
This PR removes the standalone purple language dropdown button that was floating on the right side of the landing page (`app/page.js`). A proper localization/language switch button is already natively integrated into the `Navbar` component, making the standalone floating button redundant and causing UI clutter.

**Changes made:**
- Removed the floating `<select>` language dropdown element from `app/page.js`.

## 🐛 Which issue(s) this PR fixes:
#807 

## 🧪 Testing Notes / Special Notes for Reviewer
- [x] Verified that the floating purple language button is gone from the main landing page.
- [x] Verified that the main language selector inside the top navigation bar still works correctly.
- [x] Tested production build to ensure no errors were introduced by the removal of the markup.
