### PR TITLE
feat(activity): add dynamic clear filters button to activity page

### DIFF
--- a/app/activity/page.js
+++ b/app/activity/page.js
@@ -605,10 +605,25 @@ export default function ActivityPage() {
             <Reveal delay={0.1}>
               <div className="bg-card backdrop-blur-xl rounded-2xl p-6 sm:p-8 border border-border hover:border-accent/20 transition-all duration-300">
                 <div className="flex flex-col sm:flex-row gap-4 sm:items-center sm:justify-between mb-6">
-                  <h3 className="text-xl font-semibold text-foreground flex items-center">
-                    <Filter className="w-5 h-5 mr-3 text-accent" />
-                    Filter Activities
-                  </h3>
+                  <div className="flex items-center gap-4">
+                    <h3 className="text-xl font-semibold text-foreground flex items-center">
+                      <Filter className="w-5 h-5 mr-3 text-accent" />
+                      Filter Activities
+                    </h3>
+                    {(selectedCategory !== "all" || selectedLevel !== "all" || searchQuery !== "") && (
+                      <button
+                        onClick={() => {
+                          setSelectedCategory("all");
+                          setSelectedLevel("all");
+                          setSearchQuery("");
+                        }}
+                        className="text-xs font-medium text-muted-foreground hover:text-accent transition-colors flex items-center gap-1 bg-white/5 hover:bg-white/10 px-3 py-1.5 rounded-full border border-white/10"
+                      >
+                        <RefreshCw className="w-3 h-3" />
+                        Clear
+                      </button>
+                    )}
+                  </div>
                   <div className="w-full sm:w-auto flex items-center space-x-2 bg-background rounded-full px-4 py-2 border border-border">
                     <Search className="w-4 h-4 text-gray-400" />
                     <input


### PR DESCRIPTION
## What type of PR is this?

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 📚 Documentation
- [ ] 🎨 UI/UX improvement
- [ ] ⚡ Performance improvement
- [ ] 🔒 Security fix

## Description

This PR improves the UX on the **Interactive Learning / Activities** page by introducing a dynamic "Clear" button to the filter section.
Previously, if a user selected a specific Category, Level, and typed in the Search bar, they would have to manually un-select and delete their input to get back to the default view. The existing reset button only appeared as a fallback when `0 activities` were found.

## Related Issues

Closes #878 

## Changes Made

* Added a new dynamic `button` element conditionally rendered based on `hasActiveFilters`.
* When clicked, it batch-updates `selectedCategory`, `selectedLevel`, and `searchQuery` back to their default states.
* Used consistent Tailwind styling (`bg-white/5 hover:bg-white/10`) to match the existing glassmorphic theme.

## Testing

How did you test these changes?
- [x] Tested locally
- [ ] Tested on mobile
- [ ] Tested different user roles
- [ ] All roles tested

## Screenshots (if applicable)
**BEFORE-**
<img width="2683" height="658" alt="image" src="https://github.com/user-attachments/assets/7ea8a527-6afe-4fc0-b27d-6f02162a585e" />
**AFTER-**
<img width="2651" height="588" alt="image" src="https://github.com/user-attachments/assets/07192266-f24f-4080-8ed5-24050a7bbfb9" />

## Checklist

- [X] No hardcoded secrets or credentials
- [x] `.env.local` is not committed
- [x] Code follows project style
- [ ] Changes are documented
- [x] Build passes locally (`npm run build`)
- [x] No console errors/warnings
