### PR TITLE
fix(security): sanitize search query in labels route to prevent ReDoS

### DIFF
--- a/app/api/labels/route.js
+++ b/app/api/labels/route.js
@@ -7,6 +7,7 @@ import {
 
 import { requireRole } from "@/lib/rbac";
 import { withErrorHandler } from "@/lib/error-handler";
+import { escapeRegex } from "@/utils/mongoUtils";
 
 export const dynamic = "force-dynamic";
 
@@ -47,14 +48,15 @@ export const GET = withErrorHandler(async (request) => {
     // Authentication and Role Verification
     await requireRole(request, ["admin", "teacher"]);
 
-    // Search query
+    // Search query — escape metacharacters to prevent ReDoS
     const { searchParams } =
       new URL(request.url);
 
+    const rawSearch =
+      searchParams.get("search") || "";
+
     const search =
-      searchParams.get(
-        "search"
-      );
+      escapeRegex(rawSearch);
 
     const query = search
       ? {

--- a/components/_tests_/labelsRoute.test.js
+++ b/components/_tests_/labelsRoute.test.js
@@ -140,6 +140,27 @@ describe("GET /api/labels - Security & Authentication Tests", () => {
     expect(mockLimit).toHaveBeenCalledWith(50);
   });
 
+  test("escapes regex metacharacters in search param before querying MongoDB", async () => {
+    mockToArray.mockResolvedValue([]);
+
+    const req = createMockRequest("valid-token", "10.0.0.5", "http://localhost/api/labels?search=test.*%2B%3F");
+    const response = await GET(req);
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.success).toBe(true);
+    // Characters like . * + ? should be backslash-escaped by escapeRegex
+    expect(mockFind).toHaveBeenCalledWith(
+      {
+        $or: [
+          { name: { $regex: "test\\.\\*\\+\\?", $options: "i" } },
+          { email: { $regex: "test\\.\\*\\+\\?", $options: "i" } },
+        ],
+      },
+      { projection: { _id: 1, name: 1, email: 1, image: 1 } }
+    );
+  });
+
   test("rate limits requests if more than MAX_ATTEMPTS (10) per IP are made (429)", async () => {
     mockToArray.mockResolvedValue([]);
 


### PR DESCRIPTION
Closes #894

### Description
This PR addresses the critical security vulnerability reported in #894 where user input was being directly injected into a MongoDB `$regex` query in the `/api/labels` route without any sanitization. 

### Changes Made
- Imported and applied the existing `escapeRegex` utility from `utils/mongoUtils.js` to sanitize the `search` parameter before passing it to MongoDB.
- Added test coverage in `components/_tests_/labelsRoute.test.js` to verify that regex metacharacters are properly escaped and literal string matching works as intended.

### Security Impact
- Eliminates the risk of Regular Expression Denial of Service (ReDoS) against the labels endpoint.
- Prevents NoSQL regex injection that could have allowed enumeration of users across boundaries.
- Re-uses established sanitization patterns already present in the codebase.