### PR TITLE
fix: replace broken auth gate in Groq route with authenticateRequest() (#891)

### DIFF
--- a/app/api/groq/route.js
+++ b/app/api/groq/route.js
@@ -1,5 +1,5 @@
 import { jsonSuccess, jsonError } from "@/lib/api-response";
-import { verifyFirebaseToken } from "@/lib/firebase-admin";
+import { authenticateRequest } from "@/lib/error-handler";
 import { AppError } from "@/lib/errors";
 
 export const dynamic = "force-dynamic";
@@ -11,19 +11,8 @@ import { checkRateLimit } from "@/lib/rateLimit";
 
 export async function POST(request) {
   try {
-    // Authentication
-    const authorization =
-      request.headers.get("authorization");
-
-    const token =
-      authorization?.split(" ")[1];
-
     const decodedToken =
-      await verifyFirebaseToken(token);
-
-    if (!decodedToken) {
-      return jsonError("Unauthorized", 401);
-    }
+      await authenticateRequest(request);
 
     // Rate limiting
     const rateLimitResult = await checkRateLimit(decodedToken.uid);
@@ -156,6 +145,13 @@ export async function POST(request) {
       message: content,
     });
   } catch (error) {
+    if (error instanceof AppError) {
+      return jsonError(
+        error.message,
+        error.statusCode
+      );
+    }
+
     if (error.name === "AbortError") {
       return jsonError(
         "Gateway Timeout: AI response took too long.",


### PR DESCRIPTION
## Problem

`verifyFirebaseToken()` returns `{ valid: false, reason: "expired", error: "..." }` on failure. The check `if (!decodedToken)` treats this truthy object as valid, so **invalid, expired, or malformed Firebase tokens pass through** and reach the Groq LLM API — consuming paid API quota.

Additionally, `decodedToken.uid` resolves to `undefined` for unauthenticated callers, making all unauthenticated requests share the same rate-limit bucket and fully bypassing per-user throttling.

## Fix

Replaced manual token extraction and broken truthy check with `authenticateRequest()` from `lib/error-handler.js` — the same helper used by `app/api/conversations/route.js`, `app/api/notices/route.js`, and every other secured endpoint:

- `authenticateRequest()` properly inspects `authResult.valid` and throws `UnauthorizedError` on failure
- Added `AppError` handling in the catch block so `UnauthorizedError` returns `401` instead of falling through as a `500`
- Removed 13 lines of duplicated auth boilerplate

Closes #891