### PR TITLE
fix: add SSRF protection to image proxy endpoint (#892)

### DIFF
--- a/app/api/images/route.js
+++ b/app/api/images/route.js
@@ -36,9 +36,38 @@ export const GET = withErrorHandler(async (request) => {
       throw new NotFoundError("Image not found");
     }
 
+    let parsedUrl;
+    try {
+      parsedUrl = new URL(user.image);
+    } catch {
+      throw new ValidationError("Invalid image URL");
+    }
+
+    if (parsedUrl.protocol !== "https:") {
+      throw new ValidationError("Image URL must use HTTPS");
+    }
+
+    const allowedImageHosts = [
+      "public.blob.vercel-storage.com",
+      "lh3.googleusercontent.com",
+    ];
+
+    const hostOk = allowedImageHosts.some(
+      (h) => parsedUrl.hostname === h || parsedUrl.hostname.endsWith("." + h)
+    );
+
+    if (!hostOk) {
+      throw new ValidationError("Image source not allowed");
+    }
+
     const imageResponse = await fetch(user.image);
     if (!imageResponse.ok) {
       throw new AppError("Failed to fetch image", 502);
+    }
+
+    const contentType = imageResponse.headers.get("content-type") || "";
+    if (!contentType.startsWith("image/")) {
+      throw new AppError("Response is not an image", 502);
     }
 
     const imageBuffer = await imageResponse.arrayBuffer();
@@ -46,7 +75,7 @@ export const GET = withErrorHandler(async (request) => {
     return new NextResponse(imageBuffer, {
       status: 200,
       headers: {
-        "Content-Type": imageResponse.headers.get("content-type") || "image/jpeg",
+        "Content-Type": contentType,
         "Cache-Control": "no-store, no-cache, must-revalidate",
         "X-Content-Type-Options": "nosniff",
       },


### PR DESCRIPTION
## Problem

`GET /api/images` fetches `user.image` from MongoDB and forwards the response body — with **zero URL validation**. A user whose `image` field is modified (via DB compromise, future profile-edit, etc.) can make the server fetch internal network addresses, cloud metadata endpoints (`169.254.169.254`), and private services, exfiltrating responses to the client (SSRF).

## Fix

Three layers of defense added before the `fetch()` call in `app/api/images/route.js`:

1. **URL parse + protocol validation** — Rejects malformed URLs and non-`https:` schemes (blocks `http://169.254.169.254`, `http://localhost`, `data:`, `file:`, etc.)
2. **Hostname allowlist** — Only permits `*.public.blob.vercel-storage.com` and `lh3.googleusercontent.com` (matching the existing patterns in `next.config.mjs`). Uses exact-match + `endsWith(. + host)` to prevent subdomain tricks.
3. **Response content-type guard** — After fetch, verifies the response `Content-Type` starts with `image/` so non-image payloads from internal services are never proxied to the client.

## Attack vectors blocked

| Vector | Blocked by |
|---|---|
| `http://169.254.169.254/latest/meta-data/` | Protocol check (must be `https:`) |
| `http://127.0.0.1:3000/admin` | Protocol check |
| `https://evil.com/exfiltrate` | Hostname allowlist |
| `https://public.blob.vercel-storage.com.evil.com/` | `endsWith` check prevents suffix tricks |
| `https://evilpublic.blob.vercel-storage.com/` | Dot-prefix in `endsWith("." + host)` prevents prefix tricks |
| Internal service returns HTML/JSON | Content-Type check (`image/` prefix) |

Closes #892