### PR TITLE
fix: add length bounds to exceptions API to prevent DoS

### DIFF
--- a/app/api/exceptions/create/route.js
+++ b/app/api/exceptions/create/route.js
@@ -10,11 +10,11 @@ export const POST = withErrorHandler(async (request) => {
     const body = await request.json();
     const { reason, details, date } = body;
 
-    if (!reason || typeof reason !== "string" || reason.trim() === "") {
-      throw new ValidationError("Reason is required and must be a string");
+    if (!reason || typeof reason !== "string" || reason.trim() === "" || reason.length > 200) {
+      throw new ValidationError("Reason is required and must be under 200 characters");
     }
-    if (!details || typeof details !== "string" || details.trim() === "") {
-      throw new ValidationError("Details are required and must be a string");
+    if (!details || typeof details !== "string" || details.trim() === "" || details.length > 1000) {
+      throw new ValidationError("Details are required and must be under 1000 characters");
     }
     if (!date || typeof date !== "string" || date.trim() === "") {
       throw new ValidationError("Date is required and must be a string");


### PR DESCRIPTION
## Description
Resolves #887 

Previously, the `POST /api/exceptions/create` endpoint validated that `reason` and `details` were strings, but did not enforce any maximum length limits. This allowed attackers to send massive, multi-megabyte strings in the payload, which could lead to memory exhaustion on the server (Denial of Service) and bloat the MongoDB storage.

**Changes:**
- Added strict string length validation for the `reason` (max 200 chars) and `details` (max 1000 chars) fields.
- Throws a standard `ValidationError` if the bounds are exceeded, rejecting the payload before connecting to the database.