### PR TITLE
fix: resolve canvas bounding box misalignment on mobile devices

### DIFF
--- a/components/FaceRecognizer.js
+++ b/components/FaceRecognizer.js
@@ -256,9 +256,12 @@ export default function FaceRecognizer({ authUser }) {
     lastDetectionTime.current = now;
 
     const canvas = canvasRef.current;
+    
+    // Fix: Use getBoundingClientRect to match responsive Tailwind w-full scaling on mobile screens
+    const rect = video.getBoundingClientRect();
     const displaySize = {
-      width: video.videoWidth || 720,
-      height: video.videoHeight || 500,
+      width: rect.width || video.videoWidth || 720,
+      height: rect.height || video.videoHeight || 500,
     };
 
     canvas.width = displaySize.width;


### PR DESCRIPTION
## Description
Resolves #884

Resolves an issue in the `FaceRecognizer` component where the green face-tracking bounding boxes become misaligned on mobile and responsive views.

Previously, the tracking `<canvas>` was sized using the hardcoded `video.videoWidth` property. Because the video element uses Tailwind's responsive `w-full` class, the actual rendered CSS width on mobile devices is much smaller than the intrinsic video width, causing the absolute-positioned canvas to draw the bounding boxes in the wrong location or entirely off-screen.

**Changes:**
- Replaced the hardcoded `videoWidth` calculations with `video.getBoundingClientRect()`.
- This ensures the `faceapi` canvas dynamically scales its dimensions to match the actual CSS rendered pixels on any screen size.