### PR TITLE
fix(ui): remove redundant language dropdown from landing page

### DIFF
--- a/app/page.js
+++ b/app/page.js
@@ -341,18 +341,6 @@ export default function AboutPage() {
       <div className="min-h-screen relative z-50">
         <Navbar />
 
-        <div className="fixed top-24 right-6 z-[9999]">
-          <select
-            value={language}
-            onChange={(e) => setLanguage(e.target.value)}
-            className="bg-purple-600 text-white px-4 py-2 rounded-lg shadow-lg border border-white/20 focus:outline-none focus:ring-2 focus:ring-purple-400"
-            aria-label="Select language"
-          >
-            <option value="en">English</option>
-            <option value="hi">Hindi</option>
-          </select>
-        </div>
-
         {/* Hero Section */}
         <section
           id="hero"
@@ -427,7 +415,7 @@ export default function AboutPage() {
         <section
           id="mission"
           className="py-24 px-4 sm:px-6 lg:px-8 relative overflow-hidden"
-        >
+          >
           <div className="max-w-6xl mx-auto">
             {/* Minimal High-End Intro Header */}
             <Reveal className="mb-24 max-w-2xl">


### PR DESCRIPTION
## What type of PR is this?

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [x] 🎨 UI/UX improvement
- [ ] ⚡ Performance improvement
- [x] 🔒 Security fix

## Description

Removed the redundant, floating purple language selector dropdown from the right side of the main landing page view. This UI cleanup resolves the fragmentation and visual clutter caused by having two duplicate translation elements active simultaneously on a single viewport. 

## Related Issues

Closes #907 

## Changes Made

- Removed the `fixed top-24 right-6` layout container wrapping the secondary language `<select>` menu from `page.js`.
- Retained the `language` state logic to guarantee that the primary language toggle inside the navigation bar component operates smoothly without breaking.
- Fixed layout clutter on the landing page hero viewport to deliver a more seamless and clean academic management workspace.

## Testing

How did you test these changes?
- [x] Tested locally
- [x] Tested on mobile
- [x] Tested different user roles
- [x] All roles tested

## Screenshots (if applicable)

### Before
<img width="1903" height="901" alt="image" src="https://github.com/user-attachments/assets/cfb9cef7-8b46-47c7-89b6-1cd69929f914" />

### After
<img width="1906" height="898" alt="image" src="https://github.com/user-attachments/assets/ddefe470-b662-4c0c-b587-ddb26b70c063" />

## Checklist

- [x] No hardcoded secrets or credentials
- [x] `.env.local` is not committed
- [x] Code follows project style
- [x] Changes are documented
- [x] Build passes locally (`npm run build`)
- [x] No console errors/warnings