### PR TITLE
fix(productivity): wire up creative boosts to trigger 2 min timer

### DIFF
--- a/app/productivity/page.js
+++ b/app/productivity/page.js
@@ -1094,12 +1094,20 @@ export default function ProductivityPage() {
                 </p>
                 <div className="flex flex-wrap gap-2">
                   {["Breathing", "Stretch", "Hydrate"].map((item) => (
-                    <span
+                    <button
                       key={item}
-                      className="px-3 py-1 rounded-full text-xs bg-white/10 border border-white/10"
+                      onClick={() => {
+                        setMode("short");
+                        setSessionSeconds(120);
+                        setTimeLeft(120);
+                        setManualMinutes("2");
+                        setIsRunning(true);
+                        window.scrollTo({ top: 0, behavior: "smooth" });
+                      }}
+                      className="px-3 py-1 rounded-full text-xs bg-white/10 border border-white/10 hover:bg-white/20 transition-colors cursor-pointer text-white"
                     >
                       {item}
-                    </span>
+                    </button>
                   ))}
                 </div>
               </motion.div>


### PR DESCRIPTION
## What type of PR is this?

- [x] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 📚 Documentation
- [x] 🎨 UI/UX improvement
- [ ] ⚡ Performance improvement
- [ ] 🔒 Security fix

## Description

Resolves an issue where the "Creative Boosts" action chips ("Breathing", "Stretch", "Hydrate") on the `/productivity` page were completely static and unresponsive.

## Related Issues

Closes #911 

## Changes Made

- Converted the static `<span>` elements into semantic `<button>` elements with hover states.
- Attached an `onClick` handler that updates the core timer state.
- Clicking a boost now instantly switches the mode to `break`, loads a 120-second (2 minute) duration, starts the timer automatically, and smooth-scrolls the user back to the top of the page to view the active countdown.

## Testing

How did you test these changes?
- [x] Tested locally
- [ ] Tested on mobile
- [ ] Tested different user roles
- [ ] All roles tested


## Checklist

- [x] No hardcoded secrets or credentials
- [x] `.env.local` is not committed
- [x] Code follows project style
- [ ] Changes are documented
- [x] Build passes locally (`npm run build`)
- [x] No console errors/warnings
