### PR TITLE
fix: resolve invalid 0:60 display in teacher attendance countdown timer

### DIFF
--- a/components/TeacherDashboardComponent.js
+++ b/components/TeacherDashboardComponent.js
@@ -551,7 +551,7 @@ useEffect(() => {
               <div className="text-sm text-gray-400">Window closes in</div>
               <div className="text-white font-semibold">
                 {10 - currentTime.getMinutes()}:
-                {String(currentTime.getSeconds()).padStart(2, "0")} min
+                {String(currentTime.getSeconds() === 0 ? 0 : 60 - currentTime.getSeconds()).padStart(2, "0")} min
               </div>
             </div>
           </div>


### PR DESCRIPTION
## What type of PR is this?
- [x] 🐛 Bug fix

## Description
Teacher dashboard attendance countdown displayed 
invalid time values like 0:60 at exact minute 
boundaries. Fixed by adding guard when seconds = 0.

## Related Issues
Closes #539

## Changes Made
- Fixed countdown seconds calculation in 
  TeacherDashboardComponent.js
- Added === 0 guard to show 00 instead of 60
- Seconds now correctly display 59→00

## Testing
- [x] Tested locally

## Checklist
- [x] Code follows project style
- [x] No console errors/warnings

@Premshaw23 Ready for review! 🚀