### PR TITLE
fix: validate server-derived attendance sync data

### DIFF
--- a/app/api/attendance/sync/route.js
+++ b/app/api/attendance/sync/route.js
@@ -12,14 +12,39 @@ const syncSchema = z.object({
     z.object({
       id: z.number().optional(), // IDB key
       userId: z.string(),
-      studentName: z.string(),
-      email: z.string(),
-      confidenceScore: z.number(),
+      studentName: z.string().optional(),
+      email: z.string().optional(),
+      confidenceScore: z.number().optional(),
       queuedAt: z.number(),
       date: z.string().optional(),
     })
   ).min(1),
 });
+
+export function normalizeConfidenceScore(confidenceScore) {
+  const parsedScore = Number(confidenceScore);
+
+  if (!Number.isFinite(parsedScore)) {
+    return 0;
+  }
+
+  return Math.max(0, Math.min(1, parsedScore));
+}
+
+function resolveAttendanceIdentity(decodedToken, userProfile) {
+  const profileName = [userProfile?.fullName, userProfile?.displayName, decodedToken?.name]
+    .find((value) => typeof value === "string" && value.trim())
+    ?.trim();
+
+  const profileEmail = [userProfile?.email, decodedToken?.email]
+    .find((value) => typeof value === "string" && value.trim())
+    ?.trim();
+
+  return {
+    studentName: profileName || "Unknown User",
+    email: profileEmail || "",
+  };
+}
 
 async function handleSync(request) {
   const decodedToken = await requireAuth(request);
@@ -29,6 +54,19 @@ async function handleSync(request) {
   initFirebaseAdmin();
   const db = getFirestore();
   const batch = db.batch();
+  const userProfile = await getUserProfile(decodedToken.uid);
+
+  if (!userProfile) {
+    return NextResponse.json(
+      {
+        success: false,
+        error: "User profile not found for attendance sync.",
+      },
+      { status: 404 },
+    );
+  }
+
+  const serverIdentity = resolveAttendanceIdentity(decodedToken, userProfile);
   
   const successfulIds = [];
   
@@ -55,7 +93,7 @@ async function handleSync(request) {
 
     // Force date to match the validated queuedAt timestamp, ignoring any spoofed client date
     const recordDate = new Date(record.queuedAt).toISOString().slice(0, 10);
-    const userDateKey = `${record.userId}_${recordDate}`;
+    const userDateKey = `${decodedToken.uid}_${recordDate}`;
 
     if (processedUserDates.has(userDateKey)) {
       successfulIds.push(record.id); // Acknowledge as success to remove from local queue
@@ -64,7 +102,7 @@ async function handleSync(request) {
 
     // Check if attendance already exists in Firestore for this date
     const attendanceQuery = await db.collection("attendance_records")
-      .where("userId", "==", record.userId)
+      .where("userId", "==", decodedToken.uid)
       .where("date", "==", recordDate)
       .limit(1)
       .get();
@@ -77,14 +115,24 @@ async function handleSync(request) {
 
     // Prepare new document
     const newDocRef = db.collection("attendance_records").doc();
+
+    if (
+      (record.studentName && record.studentName !== serverIdentity.studentName) ||
+      (record.email && record.email !== serverIdentity.email)
+    ) {
+      console.warn(
+        `User ${decodedToken.uid} submitted offline attendance metadata that does not match the server profile`,
+      );
+    }
+
     batch.set(newDocRef, {
-      userId: record.userId,
-      studentName: record.studentName,
-      email: record.email,
+      userId: decodedToken.uid,
+      studentName: serverIdentity.studentName,
+      email: serverIdentity.email,
       timestamp: FieldValue.serverTimestamp(),
       date: recordDate,
       status: "present",
-      confidenceScore: record.confidenceScore || 0,
+      confidenceScore: normalizeConfidenceScore(record.confidenceScore),
       offlineSynced: true,
       queuedAt: new Date(record.queuedAt),
     });

--- a/app/api/attendance/sync/route.test.js
+++ b/app/api/attendance/sync/route.test.js
@@ -1,0 +1,161 @@
+import { POST, normalizeConfidenceScore } from "./route";
+import { requireAuth } from "@/lib/rbac";
+import { getUserProfile } from "@/lib/firebase-admin";
+import { getFirestore, FieldValue } from "firebase-admin/firestore";
+
+jest.mock("@/lib/rbac", () => ({
+  requireAuth: jest.fn(),
+}));
+
+jest.mock("@/lib/firebase-admin", () => ({
+  initFirebaseAdmin: jest.fn(),
+  getUserProfile: jest.fn(),
+}));
+
+jest.mock("firebase-admin/firestore", () => ({
+  getFirestore: jest.fn(),
+  FieldValue: {
+    serverTimestamp: jest.fn(() => "server-timestamp"),
+  },
+}));
+
+jest.mock("next/server", () => ({
+  NextResponse: {
+    json: (body, init = {}) => ({
+      status: init.status ?? 200,
+      json: async () => body,
+    }),
+  },
+}));
+
+jest.mock("@/lib/error-handler", () => ({
+  withErrorHandler: (handler) => handler,
+}));
+
+describe("attendance sync route", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test("uses server profile data instead of client-supplied attendance identity", async () => {
+    requireAuth.mockResolvedValue({
+      uid: "user-123",
+      email: "auth@example.com",
+      name: "Auth Name",
+    });
+
+    getUserProfile.mockResolvedValue({
+      fullName: "Server Name",
+      email: "server@example.com",
+    });
+
+    const batch = {
+      set: jest.fn(),
+      commit: jest.fn().mockResolvedValue(undefined),
+    };
+
+    const attendanceQuery = { empty: true };
+    const collectionRef = {
+      where: jest.fn().mockReturnThis(),
+      limit: jest.fn().mockReturnThis(),
+      get: jest.fn().mockResolvedValue(attendanceQuery),
+      doc: jest.fn(() => ({})),
+    };
+
+    getFirestore.mockReturnValue({
+      batch: jest.fn(() => batch),
+      collection: jest.fn(() => collectionRef),
+    });
+
+    const response = await POST({
+      json: async () => ({
+        records: [
+          {
+            id: 1,
+            userId: "user-123",
+            studentName: "Tampered Name",
+            email: "tampered@example.com",
+            confidenceScore: 1.7,
+            queuedAt: Date.now(),
+          },
+        ],
+      }),
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      success: true,
+      syncedIds: [1],
+    });
+
+    expect(getUserProfile).toHaveBeenCalledWith("user-123");
+    expect(batch.set).toHaveBeenCalledWith(
+      expect.any(Object),
+      expect.objectContaining({
+        userId: "user-123",
+        studentName: "Server Name",
+        email: "server@example.com",
+        confidenceScore: 1,
+        timestamp: FieldValue.serverTimestamp.mock.results[0].value,
+        offlineSynced: true,
+      }),
+    );
+  });
+
+  test("rejects sync when the server profile is missing", async () => {
+    requireAuth.mockResolvedValue({
+      uid: "user-123",
+      email: "auth@example.com",
+      name: "Auth Name",
+    });
+
+    getUserProfile.mockResolvedValue(null);
+
+    const batch = {
+      set: jest.fn(),
+      commit: jest.fn().mockResolvedValue(undefined),
+    };
+
+    const collectionRef = {
+      where: jest.fn().mockReturnThis(),
+      limit: jest.fn().mockReturnThis(),
+      get: jest.fn(),
+      doc: jest.fn(() => ({})),
+    };
+
+    getFirestore.mockReturnValue({
+      batch: jest.fn(() => batch),
+      collection: jest.fn(() => collectionRef),
+    });
+
+    const response = await POST({
+      json: async () => ({
+        records: [
+          {
+            id: 2,
+            userId: "user-123",
+            studentName: "Tampered Name",
+            email: "tampered@example.com",
+            confidenceScore: 0.5,
+            queuedAt: Date.now(),
+          },
+        ],
+      }),
+    });
+
+    expect(response.status).toBe(404);
+    await expect(response.json()).resolves.toEqual({
+      success: false,
+      error: "User profile not found for attendance sync.",
+    });
+    expect(batch.set).not.toHaveBeenCalled();
+    expect(batch.commit).not.toHaveBeenCalled();
+  });
+
+  test("normalizes confidence scores into the valid range", () => {
+    expect(normalizeConfidenceScore(-2)).toBe(0);
+    expect(normalizeConfidenceScore(0.42)).toBe(0.42);
+    expect(normalizeConfidenceScore(3.5)).toBe(1);
+    expect(normalizeConfidenceScore(Number.NaN)).toBe(0);
+  });
+});


### PR DESCRIPTION

## What type of PR is this?

* [x] 🐛 Bug fix
* [ ] ✨ New feature
* [ ] 📚 Documentation
* [ ] 🎨 UI/UX improvement
* [ ] ⚡ Performance improvement
* [x] 🔒 Security fix

## 🎯 Purpose of this Pull Request
Harden offline attendance sync so the server no longer trusts client-supplied identity data and confidence values. This prevents tampering with `studentName`, `email`, and `confidenceScore` during background sync.

## 🔗 Related Issue / Link
Fixes #925 

## 🛠️ Description of Changes
- Updated `/api/attendance/sync` to derive attendance identity from the authenticated server-side user profile instead of trusting offline payload fields.
- Clamped `confidenceScore` to a valid `0` to `1` range and treated invalid values as `0`.
- Added a fail-closed path for missing user profiles so sync is rejected unless server-side profile data exists.
- Added regression tests covering tampered offline payloads, profile-missing rejection, and confidence score normalization.

## 🧪 Verification / Testing Done
- [ ] Rendered locally and checked dark/light modes.
- [ ] Tested on Chrome/Safari/Firefox.
- [x] Ran relevant unit tests (`npm test -- --runInBand app/api/attendance/sync/route.test.js`).

## 📸 Screenshots / GIFs
Not applicable. This PR only changes server-side sync behavior and tests.

## 📋 Checklist
- [x] My code follows the code style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation accordingly.
- [x] My changes generate no new warnings or console errors.
- [x] I have deleted any temporary or debugging console logs.

## Additional note

Hello @Premshaw23 
I am working on this issue under GSSoC'26 as a contributor. This issue can labled as `bug` and `security`. please assign necessary labels.