### PR TITLE
fix: replace TOCTOU check-then-insert with atomic Firestore transaction

### DIFF
--- a/components/_tests_/attendanceService.test.js
+++ b/components/_tests_/attendanceService.test.js
@@ -1,0 +1,181 @@
+import { recordAttendance, hasCheckedInToday } from "@/services/attendanceService";
+import { runTransaction, getDocs } from "firebase/firestore";
+
+// ── Mocks ─────────────────────────────────────────────────────────────────────
+
+jest.mock("@/lib/firebaseConfig", () => ({
+  db: { type: "firestore" },
+}));
+
+jest.mock("@/services/statsService", () => ({
+  recalculateAttendanceRate: jest.fn().mockResolvedValue(0.9),
+}));
+
+jest.mock("@/lib/offlineStore", () => ({
+  saveToOutbox: jest.fn().mockResolvedValue(undefined),
+}));
+
+jest.mock("@/lib/syncService", () => ({
+  registerBackgroundSync: jest.fn().mockResolvedValue(undefined),
+}));
+
+jest.mock("firebase/firestore", () => ({
+  collection: jest.fn(),
+  doc: jest.fn().mockReturnValue({ id: "mock-doc-ref" }),
+  getDocs: jest.fn(),
+  query: jest.fn(),
+  runTransaction: jest.fn(),
+  serverTimestamp: jest.fn().mockReturnValue("mock-timestamp"),
+  where: jest.fn(),
+  limit: jest.fn(),
+}));
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+const makeExistingDoc = () => ({ exists: () => true });
+const makeNewDoc = () => ({ exists: () => false });
+
+const mockTransactionSet = jest.fn();
+
+const makeTransactionExecutor = (docSnapshot) => (db, callback) => {
+  const transaction = {
+    get: jest.fn().mockResolvedValue(docSnapshot),
+    set: mockTransactionSet,
+  };
+  return callback(transaction);
+};
+
+const baseParams = {
+  userId: "user-123",
+  studentName: "Alice Smith",
+  email: "alice@test.com",
+  confidenceScore: 0.97,
+};
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("recordAttendance - atomic TOCTOU fix", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    Object.defineProperty(navigator, "onLine", {
+      value: true,
+      configurable: true,
+      writable: true,
+    });
+  });
+
+  test("throws if userId is missing", async () => {
+    await expect(recordAttendance({ ...baseParams, userId: null })).rejects.toThrow(
+      "Attendance cannot be saved without a signed-in user."
+    );
+  });
+
+  test("returns { alreadyRecorded: true } if record already exists in transaction", async () => {
+    runTransaction.mockImplementation(makeTransactionExecutor(makeExistingDoc()));
+
+    const result = await recordAttendance(baseParams);
+
+    expect(result).toEqual({ alreadyRecorded: true });
+    expect(mockTransactionSet).not.toHaveBeenCalled();
+  });
+
+  test("inserts record and returns { alreadyRecorded: false, newRate } when no existing record", async () => {
+    runTransaction.mockImplementation(makeTransactionExecutor(makeNewDoc()));
+
+    const result = await recordAttendance(baseParams);
+
+    expect(result).toEqual({ alreadyRecorded: false, newRate: 0.9 });
+    expect(mockTransactionSet).toHaveBeenCalledWith(
+      { id: "mock-doc-ref" },
+      expect.objectContaining({
+        userId: "user-123",
+        studentName: "Alice Smith",
+        email: "alice@test.com",
+        confidenceScore: 0.97,
+        status: "present",
+        timestamp: "mock-timestamp",
+      })
+    );
+  });
+
+  test("uses runTransaction — never uses a separate pre-check query before writing", async () => {
+    runTransaction.mockImplementation(makeTransactionExecutor(makeNewDoc()));
+
+    await recordAttendance(baseParams);
+
+    // The old pattern called getDocs for the pre-check; the new pattern must NOT
+    expect(getDocs).not.toHaveBeenCalled();
+    expect(runTransaction).toHaveBeenCalledTimes(1);
+  });
+
+  test("concurrent requests: only the first write commits, second sees existing doc", async () => {
+    let firstCallCommitted = false;
+
+    // Simulate concurrent execution: both calls start, first commits, second sees existing
+    runTransaction.mockImplementation((db, callback) => {
+      const docSnapshot = firstCallCommitted ? makeExistingDoc() : makeNewDoc();
+      firstCallCommitted = true;
+
+      const transaction = {
+        get: jest.fn().mockResolvedValue(docSnapshot),
+        set: mockTransactionSet,
+      };
+      return callback(transaction);
+    });
+
+    const [result1, result2] = await Promise.all([
+      recordAttendance(baseParams),
+      recordAttendance(baseParams),
+    ]);
+
+    // Only one write should have occurred
+    expect(mockTransactionSet).toHaveBeenCalledTimes(1);
+
+    // First call inserted, second detected duplicate
+    expect(result1).toEqual({ alreadyRecorded: false, newRate: 0.9 });
+    expect(result2).toEqual({ alreadyRecorded: true });
+  });
+
+  test("queues offline when navigator.onLine is false and returns queuedOffline flag", async () => {
+    Object.defineProperty(navigator, "onLine", {
+      value: false,
+      configurable: true,
+      writable: true,
+    });
+
+    const { saveToOutbox } = require("@/lib/offlineStore");
+    const result = await recordAttendance(baseParams);
+
+    expect(result).toEqual({ alreadyRecorded: false, newRate: null, queuedOffline: true });
+    expect(saveToOutbox).toHaveBeenCalledWith(
+      expect.objectContaining({ userId: "user-123" })
+    );
+    expect(runTransaction).not.toHaveBeenCalled();
+  });
+});
+
+describe("hasCheckedInToday", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  test("returns true when attendance record exists for today", async () => {
+    getDocs.mockResolvedValue({ empty: false });
+
+    const result = await hasCheckedInToday("user-123");
+
+    expect(result).toBe(true);
+  });
+
+  test("returns false when no attendance record exists for today", async () => {
+    getDocs.mockResolvedValue({ empty: true });
+
+    const result = await hasCheckedInToday("user-123");
+
+    expect(result).toBe(false);
+  });
+
+  test("returns false when userId is missing", async () => {
+    const result = await hasCheckedInToday(null);
+    expect(result).toBe(false);
+    expect(getDocs).not.toHaveBeenCalled();
+  });
+});

--- a/services/attendanceService.js
+++ b/services/attendanceService.js
@@ -1,10 +1,6 @@
 import {
   collection,
-<<<<<<< Updated upstream
-  addDoc,
-=======
   doc,
->>>>>>> Stashed changes
   getDocs,
   query,
   runTransaction,
@@ -16,6 +12,8 @@ import {
 import { db } from "@/lib/firebaseConfig";
 
 import { recalculateAttendanceRate } from "./statsService";
+import { saveToOutbox } from "@/lib/offlineStore";
+import { registerBackgroundSync } from "@/lib/syncService";
 
 function getTodayKey() {
   return new Date().toISOString().slice(0, 10);
@@ -76,23 +74,6 @@ export async function recordAttendance({
     throw new Error("Attendance cannot be saved without a signed-in user.");
   }
 
-<<<<<<< Updated upstream
-  if (await hasCheckedInToday(userId)) {
-    return { alreadyRecorded: true };
-  }
-
-  await addDoc(collection(db, "attendance_records"), {
-    userId,
-    studentName,
-    email,
-    timestamp: serverTimestamp(),
-    date: getTodayKey(),
-    status: "present",
-    confidenceScore: confidenceScore ?? 0,
-  });
-
-  await recalculateAttendanceRate(userId);
-=======
   const todayKey = getTodayKey();
 
   // INTERCEPT OFFLINE SUBMISSIONS
@@ -140,7 +121,6 @@ export async function recordAttendance({
   }
 
   const newRate = await recalculateAttendanceRate(userId);
->>>>>>> Stashed changes
 
-  return { alreadyRecorded: false };
+  return { alreadyRecorded: false, newRate };
 }

--- a/services/attendanceService.js
+++ b/services/attendanceService.js
@@ -1,8 +1,13 @@
 import {
   collection,
+<<<<<<< Updated upstream
   addDoc,
+=======
+  doc,
+>>>>>>> Stashed changes
   getDocs,
   query,
+  runTransaction,
   serverTimestamp,
   where,
   limit,
@@ -71,6 +76,7 @@ export async function recordAttendance({
     throw new Error("Attendance cannot be saved without a signed-in user.");
   }
 
+<<<<<<< Updated upstream
   if (await hasCheckedInToday(userId)) {
     return { alreadyRecorded: true };
   }
@@ -86,6 +92,55 @@ export async function recordAttendance({
   });
 
   await recalculateAttendanceRate(userId);
+=======
+  const todayKey = getTodayKey();
+
+  // INTERCEPT OFFLINE SUBMISSIONS
+  if (typeof window !== "undefined" && !navigator.onLine) {
+    console.warn("Device is offline. Queuing attendance locally.");
+    await saveToOutbox({
+      userId,
+      studentName,
+      email,
+      confidenceScore: confidenceScore ?? 0,
+      date: todayKey,
+    });
+    
+    // Attempt to register Background Sync for later flush
+    await registerBackgroundSync();
+
+    return { alreadyRecorded: false, newRate: null, queuedOffline: true };
+  }
+
+  const docRef = doc(db, "attendance_records", `${userId}_${todayKey}`);
+  let alreadyRecorded = false;
+
+  // Atomic check-and-write: prevents TOCTOU race condition where concurrent
+  // requests could both pass the existence check and insert duplicate records.
+  // The document ID (userId_date) enforces the unique constraint per user per day.
+  await runTransaction(db, async (transaction) => {
+    const existing = await transaction.get(docRef);
+    if (existing.exists()) {
+      alreadyRecorded = true;
+      return;
+    }
+    transaction.set(docRef, {
+      userId,
+      studentName,
+      email,
+      timestamp: serverTimestamp(),
+      date: todayKey,
+      status: "present",
+      confidenceScore: confidenceScore ?? 0,
+    });
+  });
+
+  if (alreadyRecorded) {
+    return { alreadyRecorded: true };
+  }
+
+  const newRate = await recalculateAttendanceRate(userId);
+>>>>>>> Stashed changes
 
   return { alreadyRecorded: false };
 }


### PR DESCRIPTION
Fixes #<179>

## 🔧 Description of Changes
- Replaced TOCTOU check-then-insert pattern in [recordAttendance]) with atomic Firestore [runTransaction](cci:1://file:///Users/architvarma/Documents/gssocLearnova/Learnova/components/_tests_/attendanceService.test.js:36:4-36:60)
- Document ID `${userId}_${date}` enforces unique-per-day constraint
- Added test suite (9 tests) covering concurrent requests and duplicate prevention

## ✅ Verification / Testing Done
- [x] Ran unit tests: `npx jest --testPathPatterns=attendanceService --no-coverage` → 9/9 passed
- [ ] Tested on Chrome/Safari/Firefox.
- [x] Ran relevant linters or unit tests (`npm run lint` / `npm test`).

## 📸 Screenshots / GIFs
N/A — backend logic fix, no UI changes.
