### PR TITLE
security: enforce payload size limits and type safety on chatbot route

### DIFF
--- a/app/api/groq/route.js
+++ b/app/api/groq/route.js
@@ -64,8 +64,17 @@ export async function POST(request) {
       );
     }
 
+    // Rate limit payload size
+    const contentLength = parseInt(request.headers.get("content-length") || "0", 10);
+    if (contentLength > 50000) {
+      return jsonError("Payload too large", 413);
+    }
+
     // Parse body
     const body = await request.json();
+    if (typeof body.message !== "string" && typeof body.userMessage !== "string") {
+      return jsonError("Invalid message format", 400);
+    }
 
     const rawMessage =
       typeof body.message === "string"


### PR DESCRIPTION
Fixes #993

Limits request content size to 50KB and enforces strict type validation on chatbot text fields before passing variables to LLM connectors.

Requesting review and assignment labels! ✨