### PR TITLE
fix: clean up notice board SSE connections on client abort and stream cancel

### DIFF
--- a/app/api/notices/stream/route.js
+++ b/app/api/notices/stream/route.js
@@ -106,6 +106,12 @@ export async function GET(request) {
            if (changeStream) changeStream.close().catch(() => {});
            try { controller.close(); } catch (e) {}
         });
+      },
+      cancel() {
+        isConnected = false;
+        clearInterval(heartbeatInterval);
+        if (pollInterval) clearInterval(pollInterval);
+        if (changeStream) changeStream.close().catch(() => {});
       }
     });
 


### PR DESCRIPTION
Fixes #996

Implements connection stream cancel callbacks in the ReadableStream constructor to immediately close MongoDB change streams and interval timers on connection drops.

Requesting review and assignment labels! ✨