### PR TITLE
security: restrict student registration to whitelist email domains

### DIFF
--- a/app/api/register/route.js
+++ b/app/api/register/route.js
@@ -260,6 +260,12 @@ export const POST =
       } =
         validationResult.data;
 
+      const allowedDomains = (process.env.ALLOWED_EMAIL_DOMAINS || "institute.edu,learnova.edu").split(",");
+      const domain = email.split("@")[1];
+      if (allowedDomains.length > 0 && !allowedDomains.includes(domain)) {
+        return jsonError("Unauthorized email domain for registration", 400);
+      }
+
       // Validate file
       if (
         !file ||


### PR DESCRIPTION
Fixes #1000

Asserts incoming emails against whitelisted institute domains to restrict student face-descriptor registrations to school emails.

Requesting review and assignment labels! ✨