### PR TITLE
fix: optimize NoticeSearch debounce parameters to 300ms

### DIFF
--- a/components/NoticeSearch.jsx
+++ b/components/NoticeSearch.jsx
@@ -33,7 +33,7 @@ const NoticeSearch = ({
   useEffect(() => {
     const timer = window.setTimeout(() => {
       onSearchChange(localSearch.trim());
-    }, 220);
+    }, 300);
     return () => window.clearTimeout(timer);
   }, [localSearch, onSearchChange]);
 


### PR DESCRIPTION
Fixes #1003

Increases local notice search keyboard debounce timers to 300ms to reduce rendering updates and ensure performance responsiveness.

Requesting review and assignment labels! ✨