### PR TITLE
fix: prevent client construction leaks on database hot-reloads

### DIFF
--- a/lib/mongodb.js
+++ b/lib/mongodb.js
@@ -30,11 +30,14 @@ export async function connectDb() {
     
     // Handle hot-reloading in development to preserve the connection pool
     if (process.env.NODE_ENV === "development") {
-      if (!global._mongoClientPromise) {
-        global._mongoClientPromise = client.connect();
+      if (!global._mongoClient) {
+        global._mongoClient = new MongoClient(uri, options);
+        global._mongoClientPromise = global._mongoClient.connect();
       }
+      client = global._mongoClient;
       clientPromise = global._mongoClientPromise;
     } else {
+      client = new MongoClient(uri, options);
       clientPromise = client.connect();
     }
   }


### PR DESCRIPTION
Fixes #1005

Saves constructed MongoClient instance within global context in development to prevent duplicate client instantiations on Hot Module Replacement (HMR) reloads.

Requesting review and assignment labels! ✨