### PR TITLE
fix: autoFocus first input field in passcode verification form

### DIFF
--- a/components/AttendanceValidation.js
+++ b/components/AttendanceValidation.js
@@ -602,6 +602,7 @@ const AttendanceValidation = ({ onValidationSuccess }) => {
       <div className="space-y-6">
         <div className="relative">
           <input
+            autoFocus
             type="password"
             value={passcode}
             onChange={(e) => setPasscode(e.target.value)}


### PR DESCRIPTION
Fixes #1006

Injects the autoFocus HTML5 attribute into passcode inputs inside AttendanceValidation to auto-focus inputs on modal load.

Requesting review and assignment labels! ✨