### PR TITLE
fix: allow optional banner values inside settings validation schemas

### DIFF
--- a/app/api/settings/route.js
+++ b/app/api/settings/route.js
@@ -20,6 +20,7 @@ const settingsSchema = z
         phone: z.string().optional(),
         bio: z.string().optional(),
         avatar: z.string().optional(),
+        banner: z.string().optional(),
       })
       .strict()
       .optional(),


### PR DESCRIPTION
Fixes #1007

Modifies profile metadata validation filters to include banner properties to prevent settings updates from failing when profile banner fields are left blank.

Requesting review and assignment labels! ✨