### PR TITLE
fix: bypass Workbox service worker caching for dynamic API paths

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -16,6 +16,10 @@ const withPWA = withPWAInit({
     disableDevLogs: true,
     runtimeCaching: [
       {
+        urlPattern: /\/api\/.*/i,
+        handler: "NetworkOnly",
+      },
+      {
         urlPattern: /^https:\/\/fonts\.(?:googleapis|gstatic)\.com\/.*/i,
         handler: "CacheFirst",
         options: {


### PR DESCRIPTION
Fixes #1009

Declares an explicit NetworkOnly configuration matching local /api/ routes within next PWA configurations to prevent dynamic data from caching.

Requesting review and assignment labels! ✨