### PR TITLE
a11y: add aria-pressed to active chatbot category selection buttons

### DIFF
--- a/components/ChatBot.js
+++ b/components/ChatBot.js
@@ -459,6 +459,7 @@ const LearnovaChatbot = () => {
                     id
                   )
                 }
+                aria-pressed={currentCategory === id}
                 className={`flex items-center gap-1 px-3 py-2 rounded-lg text-xs transition-all ${
                   currentCategory === id
                     ? themeClasses.categoryButtonActive


### PR DESCRIPTION
Fixes #1011

Updates chatbot pills with dynamic aria-pressed attributes to communicate category selection state modifications to screen readers.

Requesting review and assignment labels! ✨