### PR TITLE
fix: trigger outbox sync automatically on window online events

### DIFF
--- a/lib/syncService.js
+++ b/lib/syncService.js
@@ -66,3 +66,10 @@ export async function registerBackgroundSync() {
     syncAttendanceQueue();
   }
 }
+
+if (typeof window !== "undefined") {
+  window.addEventListener("online", () => {
+    syncAttendanceQueue();
+  });
+}
+


### PR DESCRIPTION
Fixes #999

Registers window online recovery listeners to automatically invoke offline outbox queue uploads without requiring manual interface reloads.

Requesting review and assignment labels! ✨