### PR TITLE
docs: document missing MONGODB_DB env variable in README solve#1047

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,7 @@ NEXT_PUBLIC_FIREBASE_MEASUREMENT_ID=your_measurement_id
 
 # MongoDB
 MONGODB_URI=your_mongodb_connection_string
+MONGODB_DB=learnova
 
 # Vercel Blob
 BLOB_READ_WRITE_TOKEN=your_vercel_blob_token


### PR DESCRIPTION
Closes #1047

Adds the missing `MONGODB_DB` database configuration environment variable to the `README.md` setup credentials guide, matching `.env.example`.

