### PR TITLE
fix: resolve memory leak in registration page image loader

### DIFF
--- a/components/register.js
+++ b/components/register.js
@@ -39,6 +39,7 @@ export default function RegisterPage() {
     if (!registeredUser?._id) return;
 
     let cancelled = false;
+    let url = null;
 
     const loadImage = async () => {
       try {
@@ -50,8 +51,12 @@ export default function RegisterPage() {
         if (!res.ok || cancelled) return;
 
         const blob = await res.blob();
-        const url = URL.createObjectURL(blob);
-        if (!cancelled) setRegisteredUserImageUrl(url);
+        url = URL.createObjectURL(blob);
+        if (!cancelled) {
+          setRegisteredUserImageUrl(url);
+        } else {
+          URL.revokeObjectURL(url);
+        }
       } catch {
         // silently fail
       }
@@ -61,6 +66,9 @@ export default function RegisterPage() {
 
     return () => {
       cancelled = true;
+      if (url) {
+        URL.revokeObjectURL(url);
+      }
     };
   }, [registeredUser]);
 


### PR DESCRIPTION
Fixes #1143

Resolves a memory leak in the profile registration page image loader by ensuring the created object URL is properly revoked on component unmount or when the registered user updates.

Requesting review and assignment labels! ✨