### PR TITLE
fix: resolve firebase auth hydration mismatch in navbar (#422)

### DIFF
--- a/components/Navbar.js
+++ b/components/Navbar.js
@@ -68,29 +68,28 @@ export function Navbar() {
     userProfile,
     signOut,
     isAuthenticated,
+    loading,
   } = useAuthContext();
 
   const dropdownRef = useRef(null);
   const langRef = useRef(null); // Ref to track language dropdown outside clicks
   const pathname = usePathname();
   const { theme, setTheme, resolvedTheme } = useTheme();
-  const [prefersDark, setPrefersDark] = useState(() => {
-    if (typeof window === "undefined") return null;
-    try {
-      const saved = localStorage.getItem("theme");
-      if (saved === "light") return false;
-      if (saved === "dark") return true;
-      return (
-        typeof window.matchMedia === "function" &&
-        window.matchMedia("(prefers-color-scheme: dark)").matches
-      );
-    } catch (e) {
-      return null;
-    }
-  });
+  const [prefersDark, setPrefersDark] = useState(null);
 
   useEffect(() => {
     setMounted(true);
+    try {
+      const saved = localStorage.getItem("theme");
+      if (saved === "light") setPrefersDark(false);
+      else if (saved === "dark") setPrefersDark(true);
+      else {
+        setPrefersDark(
+          typeof window.matchMedia === "function" &&
+          window.matchMedia("(prefers-color-scheme: dark)").matches
+        );
+      }
+    } catch (e) {}
   }, []);
 
   useEffect(() => {
@@ -351,7 +350,9 @@ export function Navbar() {
                 </button>
               )}
 
-              {isAuthenticated ? (
+              {loading ? (
+                <div className="w-24 h-10 bg-zinc-200 dark:bg-zinc-800 animate-pulse rounded-xl" />
+              ) : isAuthenticated ? (
                 <div className="flex items-center space-x-3 pl-1 border-l border-zinc-200 dark:border-zinc-800">
                   
                   {/* Notifications Module Panel */}
@@ -538,7 +539,9 @@ export function Navbar() {
 
             {/* Primary Action Buttons */}
             <div className="pt-2 border-t border-zinc-100 dark:border-zinc-900">
-              {isAuthenticated ? (
+              {loading ? (
+                <div className="w-full h-10 bg-zinc-200 dark:bg-zinc-800 animate-pulse rounded-lg" />
+              ) : isAuthenticated ? (
                 <Button onClick={handleLogout} variant="destructive" size="default" className="w-full text-white rounded-lg text-sm h-10">
                   <LogOut className="h-4 w-4 mr-2" /> Logout
                 </Button>


### PR DESCRIPTION
## 🎯 Purpose of this Pull Request
Resolve the Firebase Auth Hydration Mismatch warning and correct the `prefersDark` inline style mismatch that was occurring in the `Navbar`.

## 🔗 Related Issue / Link
Fixes #422 (Replacement for closed PR #569 due to merge conflicts)

## 🛠️ Description of Changes
List the major changes introduced by this PR:
- **Clean Sync:** Branched directly from the latest `master` to avoid the massive 90+ file formatting merge conflicts present in PR #569.
- **Fixed Auth Flash:** Updated `Navbar.js` to extract the `loading` state from `useAuthContext()`. Replaced the conditional rendering of the Login/Profile buttons with a pulsing UI skeleton when `loading` is true, preventing the client from hydrating the Server's "unauthenticated" HTML state incorrectly.
- **Fixed Theme Hydration:** Refactored the `prefersDark` `useState` initializer to default to `null` initially rather than running synchronous `window` checks, preventing `backgroundColor` inline style hydration errors in the `<nav>` element.

## 🧪 Verification / Testing Done
How did you test your changes? Mention exact steps, browsers used, or automation test suites run:
- [x] Rendered locally and checked dark/light modes.
- [x] Tested on Chrome and Edge and confirmed no Hydration errors appear in the browser console.
- [x] Verified that the pulsing loading skeleton accurately masks the UI shift while Firebase determines the auth state.

## 📸 Screenshots / GIFs
*(No visual changes aside from an improved loading skeleton in the Navbar during the initial auth state resolution)*

## 📋 Checklist
Before submitting, please make sure you check the following:
- [x] My code follows the code style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation accordingly.
- [x] My changes generate no new warnings or console errors.
- [x] I have deleted any temporary or debugging console logs.