### PR TITLE
fix: cancel cursor glow requestAnimationFrame on unmount

### DIFF
--- a/components/CursorGlow.js
+++ b/components/CursorGlow.js
@@ -10,6 +10,7 @@ export default function CursorGlow() {
     let mouseY = 0;
     let glowX = 0;
     let glowY = 0;
+    let animationFrameId = null;
 
     const move = (e) => {
       mouseX = e.clientX;
@@ -26,13 +27,16 @@ export default function CursorGlow() {
         glow.style.top = `${glowY}px`;
       }
 
-      requestAnimationFrame(animate);
+      animationFrameId = requestAnimationFrame(animate);
     }
 
     animate();
 
     return () => {
       document.removeEventListener("mousemove", move);
+      if (animationFrameId) {
+        cancelAnimationFrame(animationFrameId);
+      }
     };
   }, []);
 


### PR DESCRIPTION
Fixes #1158

Resolves CPU and animation loop memory leak in `CursorGlow.js` by saving the frame request ID and calling `cancelAnimationFrame` inside the cleanup function of the mouse follower `useEffect` hook.

Requesting review and assignment labels! ✨