### PR TITLE
[BUG] CSP nonce generation uses btoa

### DIFF
--- a/middleware.js
+++ b/middleware.js
@@ -10,6 +10,31 @@ const JWKS = createRemoteJWKSet(JWKS_URL);
 
 const FIREBASE_PROJECT_ID = process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID;
 
+const BASE64_CHARS =
+  "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+
+function generateNonce() {
+  const bytes = new Uint8Array(16);
+  crypto.getRandomValues(bytes);
+
+  let nonce = "";
+  for (let index = 0; index < bytes.length; index += 3) {
+    const byte1 = bytes[index];
+    const byte2 = bytes[index + 1];
+    const byte3 = bytes[index + 2];
+
+    nonce += BASE64_CHARS[byte1 >> 2];
+    nonce += BASE64_CHARS[((byte1 & 0x03) << 4) | (byte2 >> 4)];
+    nonce +=
+      index + 1 < bytes.length
+        ? BASE64_CHARS[((byte2 & 0x0f) << 2) | (byte3 >> 6)]
+        : "=";
+    nonce += index + 2 < bytes.length ? BASE64_CHARS[byte3 & 0x3f] : "=";
+  }
+
+  return nonce;
+}
+
 /**
  * Verifies a Firebase ID token's RS256 signature and all standard claims.
  * Runs entirely in the Edge Runtime using the jose library.
@@ -54,8 +79,8 @@ export async function middleware(request) {
   let contentSecurityPolicyHeaderValue;
 
   if (isPage) {
-    // Generate a cryptographic nonce (base-64 encoded UUID)
-    nonce = btoa(crypto.randomUUID());
+    // Generate a cryptographic nonce without relying on Edge-incompatible helpers.
+    nonce = generateNonce();
     
     // Construct the CSP string using the generated nonce
     const csp = [


### PR DESCRIPTION
GSSoC

## 🔗 Related Issue / Link
Fixes #1152

## 🛠️ Description of Changes
Replaced the Edge-unsafe nonce path in middleware.js with a `crypto.getRandomValues`-based base64 encoder, so the middleware no longer depends on `btoa()` or `crypto.randomUUID()` to build the CSP nonce. The middleware now calls that helper when generating the CSP for page requests in middleware.js.




## 📋 Checklist
Before submitting, please make sure you check the following:
- [x] My code follows the code style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation accordingly.
- [x] My changes generate no new warnings or console errors.
- [x] I have deleted any temporary or debugging console logs.
