### PR TITLE
perf: add Firebase subscription pooling, offline persistence, and sha…

### DIFF
--- a/app/layout.js
+++ b/app/layout.js
@@ -1,6 +1,7 @@
 // 1. Enhanced layout.js with proper structured data for sitelinks
 
 import { NotificationProvider } from "@/contexts/NotificationContext";
+import { FirestoreProvider } from "@/contexts/FirestoreContext";
 import React from "react";
 import { Geist, Geist_Mono } from "next/font/google";
 import { Suspense } from "react";
@@ -8,7 +9,7 @@ import { Toaster } from "react-hot-toast";
 import "./globals.css";
 import { AuthProvider } from "@/contexts/AuthContext";
 import { ThemeProvider } from "@/components/ThemeProvider";
-import ErrorBoundary from "@/components/ErrorBoundary"; // Imported ErrorBoundary
+import ErrorBoundary from "@/components/ErrorBoundary";
 import LearnovaChatbot from "@/components/ChatBot";
 import ClientLayout from "@/components/ClientLayout";
 import Footer from "@/components/Footer";
@@ -263,35 +264,37 @@ export default function RootLayout({ children }) {
             shadow="0 0 10px #4f46e5,0 0 5px #4f46e5"
           />
           <AuthProvider>
-            <NotificationProvider>
-              <Suspense fallback={null}>
-                <main id="main-content" className="outline-none" tabIndex="-1">
-                  <PageTransition>{children}</PageTransition>
-                </main>
+            <FirestoreProvider>
+              <NotificationProvider>
+                <Suspense fallback={null}>
+                  <main id="main-content" className="outline-none" tabIndex="-1">
+                    <PageTransition>{children}</PageTransition>
+                  </main>
 
-                <ScrollToTop />
+                  <ScrollToTop />
 
-                {/* Chatbot safely isolated inside ErrorBoundary */}
-                <div className="z-50">
-                  <ErrorBoundary>
-                    <LearnovaChatbot />
-                  </ErrorBoundary>
-                </div>
+                  {/* Chatbot safely isolated inside ErrorBoundary */}
+                  <div className="z-50">
+                    <ErrorBoundary>
+                      <LearnovaChatbot />
+                    </ErrorBoundary>
+                  </div>
 
-                <Footer />
-                <ClientLayout />
-                <BackToTop />
+                  <Footer />
+                  <ClientLayout />
+                  <BackToTop />
 
-                <Toaster
-                  position="top-right"
-                  toastOptions={{
-                    duration: 4000,
-                    style: { fontWeight: 600 },
-                  }}
-                />
-                <OfflineIndicator />
-              </Suspense>
-            </NotificationProvider>
+                  <Toaster
+                    position="top-right"
+                    toastOptions={{
+                      duration: 4000,
+                      style: { fontWeight: 600 },
+                    }}
+                  />
+                  <OfflineIndicator />
+                </Suspense>
+              </NotificationProvider>
+            </FirestoreProvider>
           </AuthProvider>
         </ThemeProvider>
       </body>

--- a/components/noticeBoard.js
+++ b/components/noticeBoard.js
@@ -5,15 +5,7 @@ import { motion, AnimatePresence } from "framer-motion";
 import toast from "react-hot-toast";
 
 import { useAuth } from "@/hooks/useAuth";
-import { db } from "@/lib/firebaseConfig";
-
-import {
-  collection,
-  query,
-  where,
-  onSnapshot,
-} from "firebase/firestore";
-
+import { useNotices } from "@/contexts/FirestoreContext";
 import { Navbar } from "./Navbar";
 import NoticeSearch from "./NoticeSearch";
 import NoticeFilters from "./NoticeFilters";
@@ -31,14 +23,11 @@ const CATEGORIES = [
 ];
 
 const SmartNoticeBoard = () => {
-  const {
-    user,
-    userProfile,
-    loading: authLoading,
-  } = useAuth();
+  const { user, loading: authLoading } = useAuth();
 
-  const [notices, setNotices] = useState([]);
-  const [loading, setLoading] = useState(true);
+  // ── Consume the shared pooled subscription from FirestoreContext ──────────
+  // No local onSnapshot — notices arrive from the global singleton listener.
+  const { notices: rawNotices, loading: noticesLoading, error: noticesError } = useNotices();
 
   const [searchQuery, setSearchQuery] =
     useState("");
@@ -77,9 +66,22 @@ const SmartNoticeBoard = () => {
   const userId =
     user?.uid || user?.id || "anonymous";
 
-  const getUserRole = () => {
-    return userProfile?.role || "student";
-  };
+  // Normalise createdAt to a JS Date so downstream components can safely call
+  // getRelativeTime() regardless of whether it arrived as a Firestore Timestamp
+  // or was already converted by firestorePool's snapshot mapper.
+  const notices = useMemo(
+    () =>
+      rawNotices.map((n) => ({
+        ...n,
+        createdAt:
+          n.createdAt instanceof Date
+            ? n.createdAt
+            : n.createdAt?.toDate
+            ? n.createdAt.toDate()
+            : new Date(n.createdAt || Date.now()),
+      })),
+    [rawNotices]
+  );
 
   // Derived activity
   const derivedActivity = useMemo(() => {
@@ -103,77 +105,23 @@ const SmartNoticeBoard = () => {
       }));
   }, [activity, notices]);
 
-  // Load notices
+  const loading = authLoading || noticesLoading;
+
+  // Show toast once if the pool reports an error
   useEffect(() => {
-    if (authLoading) return;
-
-    if (!user) {
-      setLoading(false);
-      return;
+    if (noticesError) {
+      toast.error("Failed to load notices");
     }
+  }, [noticesError]);
 
-    const userRole = getUserRole();
-
-    const q = query(
-      collection(db, "notices"),
-      where(
-        "targetAudience",
-        "array-contains",
-        userRole
-      )
-    );
-
-    const unsubscribe = onSnapshot(
-      q,
-      (snapshot) => {
-        const noticesData = snapshot.docs.map(
-          (doc) => {
-            const data = doc.data();
-
-            return {
-              id: doc.id,
-              ...data,
-              createdAt:
-                data.createdAt?.toDate
-                  ? data.createdAt.toDate()
-                  : new Date(
-                      data.createdAt ||
-                        Date.now()
-                    ),
-            };
-          }
-        );
-
-        setNotices(noticesData);
-        setLoading(false);
-      },
-      (error) => {
-        console.error(
-          "Error fetching notices:",
-          error
-        );
-
-        toast.error("Failed to load notices");
-
-        setLoading(false);
-      }
-    );
-
-    // Load read notices
+  // Load persisted read-state from localStorage
+  useEffect(() => {
+    if (!userId || userId === "anonymous") return;
     try {
-      const savedReadNotices =
-        localStorage.getItem(
-          `readNotices_${userId}`
-        );
-
-      if (savedReadNotices) {
-        const parsed = JSON.parse(
-          savedReadNotices
-        );
-
-        if (Array.isArray(parsed)) {
-          setReadNotices(new Set(parsed));
-        }
+      const saved = localStorage.getItem(`readNotices_${userId}`);
+      if (saved) {
+        const parsed = JSON.parse(saved);
+        if (Array.isArray(parsed)) setReadNotices(new Set(parsed));
       }
     } catch (err) {
       console.error(
@@ -181,14 +129,7 @@ const SmartNoticeBoard = () => {
         err
       );
     }
-
-    return () => unsubscribe();
-  }, [
-    user,
-    userProfile,
-    authLoading,
-    userId,
-  ]);
+  }, [userId]);
 
   // Save read state
   const saveReadState = useCallback(

--- a/contexts/FirestoreContext.js
+++ b/contexts/FirestoreContext.js
@@ -1,0 +1,257 @@
+"use client";
+
+/**
+ * contexts/FirestoreContext.js
+ *
+ * Global React Context that exposes pooled, cached Firestore collections.
+ * Mount <FirestoreProvider> once in layout.js (inside <AuthProvider>) and every
+ * downstream component can call useNotices(), useAttendance(), etc. without
+ * creating their own onSnapshot listeners.
+ *
+ * Architecture:
+ *  - Uses firestorePool (singleton) to deduplicate Firestore listeners.
+ *  - Exposes stable references via useMemo / useCallback so consumers only
+ *    re-render when their specific slice of data actually changes.
+ *  - Offline persistence is enabled in lib/firebaseConfig.js; this context
+ *    benefits automatically — cached reads work even when the device is offline.
+ */
+
+import {
+  createContext,
+  useContext,
+  useState,
+  useEffect,
+  useMemo,
+  useRef,
+  useCallback,
+} from "react";
+import { useAuth } from "@/hooks/useAuth";
+import firestorePool from "@/lib/firestorePool";
+
+// ─── Context ───────────────────────────────────────────────────────────────────
+
+const FirestoreContext = createContext(null);
+
+// ─── Helpers ───────────────────────────────────────────────────────────────────
+
+/**
+ * Internal hook — subscribes to one pool key and returns cached state.
+ * Delivers the current cached value synchronously to avoid loading flash.
+ */
+function usePooledCollection(key, buildQuery, enabled = true) {
+  const cached = firestorePool.getCached(key);
+  const [data, setData] = useState(cached ?? []);
+  const [loading, setLoading] = useState(cached === null && enabled);
+  const [error, setError] = useState(null);
+  const queryRef = useRef(null);
+
+  useEffect(() => {
+    if (!enabled) {
+      setLoading(false);
+      return;
+    }
+
+    // Build the Firestore query (may be null if db isn't ready)
+    const q = buildQuery();
+    if (!q) {
+      setLoading(false);
+      return;
+    }
+    queryRef.current = q;
+
+    const unsub = firestorePool.subscribe(
+      key,
+      q,
+      (docs) => {
+        setData(docs);
+        setLoading(false);
+        setError(null);
+      },
+      (err) => {
+        console.error(`[FirestorePool] Error on "${key}":`, err);
+        setError(err);
+        setLoading(false);
+      }
+    );
+
+    return unsub;
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [key, enabled]);
+
+  return { data, loading, error };
+}
+
+// ─── Provider ──────────────────────────────────────────────────────────────────
+
+export function FirestoreProvider({ children }) {
+  const { user, userProfile, loading: authLoading } = useAuth();
+  const uid = user?.uid ?? null;
+  const userRole = userProfile?.role ?? "student";
+  const isReady = !authLoading && !!uid;
+
+  // ── Notices ──────────────────────────────────────────────────────────────────
+  const noticesKey = `notices:role:${userRole}`;
+  const noticesQuery = useCallback(() => {
+    if (!isReady) return null;
+    try {
+      // Dynamic import so this module stays SSR-safe
+      const { db } = require("@/lib/firebaseConfig");
+      const { collection, query, where } = require("firebase/firestore");
+      if (!db) return null;
+      return query(
+        collection(db, "notices"),
+        where("targetAudience", "array-contains", userRole)
+      );
+    } catch {
+      return null;
+    }
+  }, [isReady, userRole]);
+
+  const {
+    data: notices,
+    loading: noticesLoading,
+    error: noticesError,
+  } = usePooledCollection(noticesKey, noticesQuery, isReady);
+
+  // ── Attendance ────────────────────────────────────────────────────────────────
+  const attendanceKey = `attendance:uid:${uid}`;
+  const attendanceQuery = useCallback(() => {
+    if (!isReady) return null;
+    try {
+      const { db } = require("@/lib/firebaseConfig");
+      const { collection, query, where, orderBy, limit } = require("firebase/firestore");
+      if (!db) return null;
+      return query(
+        collection(db, "attendance"),
+        where("studentId", "==", uid),
+        orderBy("timestamp", "desc"),
+        limit(60)
+      );
+    } catch {
+      return null;
+    }
+  }, [isReady, uid]);
+
+  const {
+    data: attendanceRecords,
+    loading: attendanceLoading,
+    error: attendanceError,
+  } = usePooledCollection(attendanceKey, attendanceQuery, isReady);
+
+  // ── User Notifications ────────────────────────────────────────────────────────
+  const userNotifKey = `userNotifications:uid:${uid}`;
+  const userNotifQuery = useCallback(() => {
+    if (!isReady) return null;
+    try {
+      const { db } = require("@/lib/firebaseConfig");
+      const { collection, query, where, orderBy, limit } = require("firebase/firestore");
+      if (!db) return null;
+      return query(
+        collection(db, "notifications"),
+        where("recipientId", "==", uid),
+        orderBy("createdAt", "desc"),
+        limit(30)
+      );
+    } catch {
+      return null;
+    }
+  }, [isReady, uid]);
+
+  const {
+    data: firestoreNotifications,
+    loading: notificationsLoading,
+    error: notificationsError,
+  } = usePooledCollection(userNotifKey, userNotifQuery, isReady);
+
+  // ── Stable context value (only re-creates when content changes) ────────────────
+  const value = useMemo(
+    () => ({
+      // Notices
+      notices,
+      noticesLoading,
+      noticesError,
+
+      // Attendance
+      attendanceRecords,
+      attendanceLoading,
+      attendanceError,
+
+      // Firestore Notifications
+      firestoreNotifications,
+      notificationsLoading,
+      notificationsError,
+
+      // Auth passthrough helpers
+      uid,
+      userRole,
+      isReady,
+    }),
+    [
+      notices,
+      noticesLoading,
+      noticesError,
+      attendanceRecords,
+      attendanceLoading,
+      attendanceError,
+      firestoreNotifications,
+      notificationsLoading,
+      notificationsError,
+      uid,
+      userRole,
+      isReady,
+    ]
+  );
+
+  return (
+    <FirestoreContext.Provider value={value}>
+      {children}
+    </FirestoreContext.Provider>
+  );
+}
+
+// ─── Consumer Hooks ────────────────────────────────────────────────────────────
+
+function useFirestoreContext() {
+  const ctx = useContext(FirestoreContext);
+  if (!ctx) {
+    throw new Error(
+      "useFirestoreContext must be used inside <FirestoreProvider>. " +
+        "Make sure FirestoreProvider is mounted in app/layout.js."
+    );
+  }
+  return ctx;
+}
+
+/** Returns the shared, cached notices array and loading state. */
+export function useNotices() {
+  const { notices, noticesLoading, noticesError } = useFirestoreContext();
+  return { notices, loading: noticesLoading, error: noticesError };
+}
+
+/** Returns shared cached attendance records for the signed-in student. */
+export function useAttendanceRecords() {
+  const { attendanceRecords, attendanceLoading, attendanceError } =
+    useFirestoreContext();
+  return {
+    attendanceRecords,
+    loading: attendanceLoading,
+    error: attendanceError,
+  };
+}
+
+/** Returns shared cached Firestore notifications for the signed-in user. */
+export function useFirestoreNotifications() {
+  const { firestoreNotifications, notificationsLoading, notificationsError } =
+    useFirestoreContext();
+  return {
+    firestoreNotifications,
+    loading: notificationsLoading,
+    error: notificationsError,
+  };
+}
+
+/** Returns top-level auth helpers that FirestoreProvider already holds. */
+export function useFirestoreAuth() {
+  const { uid, userRole, isReady } = useFirestoreContext();
+  return { uid, userRole, isReady };
+}

--- a/contexts/FirestoreContext.js
+++ b/contexts/FirestoreContext.js
@@ -27,6 +27,8 @@ import {
 } from "react";
 import { useAuth } from "@/hooks/useAuth";
 import firestorePool from "@/lib/firestorePool";
+import { db } from "@/lib/firebaseConfig";
+import { collection, query, where, orderBy, limit } from "firebase/firestore";
 
 // ─── Context ───────────────────────────────────────────────────────────────────
 
@@ -92,12 +94,8 @@ export function FirestoreProvider({ children }) {
   // ── Notices ──────────────────────────────────────────────────────────────────
   const noticesKey = `notices:role:${userRole}`;
   const noticesQuery = useCallback(() => {
-    if (!isReady) return null;
+    if (!isReady || !db) return null;
     try {
-      // Dynamic import so this module stays SSR-safe
-      const { db } = require("@/lib/firebaseConfig");
-      const { collection, query, where } = require("firebase/firestore");
-      if (!db) return null;
       return query(
         collection(db, "notices"),
         where("targetAudience", "array-contains", userRole)
@@ -116,11 +114,8 @@ export function FirestoreProvider({ children }) {
   // ── Attendance ────────────────────────────────────────────────────────────────
   const attendanceKey = `attendance:uid:${uid}`;
   const attendanceQuery = useCallback(() => {
-    if (!isReady) return null;
+    if (!isReady || !db) return null;
     try {
-      const { db } = require("@/lib/firebaseConfig");
-      const { collection, query, where, orderBy, limit } = require("firebase/firestore");
-      if (!db) return null;
       return query(
         collection(db, "attendance"),
         where("studentId", "==", uid),
@@ -141,11 +136,8 @@ export function FirestoreProvider({ children }) {
   // ── User Notifications ────────────────────────────────────────────────────────
   const userNotifKey = `userNotifications:uid:${uid}`;
   const userNotifQuery = useCallback(() => {
-    if (!isReady) return null;
+    if (!isReady || !db) return null;
     try {
-      const { db } = require("@/lib/firebaseConfig");
-      const { collection, query, where, orderBy, limit } = require("firebase/firestore");
-      if (!db) return null;
       return query(
         collection(db, "notifications"),
         where("recipientId", "==", uid),

--- a/lib/firebaseConfig.js
+++ b/lib/firebaseConfig.js
@@ -14,12 +14,16 @@ import {
   browserSessionPersistence,
   setPersistence,
 } from "firebase/auth";
-import { getFirestore } from "firebase/firestore";
-// TODO: Add SDKs for Firebase products that you want to use
-// https://firebase.google.com/docs/web/setup#available-libraries
+import {
+  getFirestore,
+  enableIndexedDbPersistence,
+  CACHE_SIZE_UNLIMITED,
+  initializeFirestore,
+  persistentLocalCache,
+  persistentMultipleTabManager,
+} from "firebase/firestore";
 
 // Your web app's Firebase configuration
-// For Firebase JS SDK v7.20.0 and later, measurementId is optional
 const firebaseConfig = {
   apiKey: process.env.NEXT_PUBLIC_FIREBASE_API_KEY,
   authDomain: process.env.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN,
@@ -35,14 +39,36 @@ let app;
 let auth = null;
 let db = null;
 
-const isValidApiKey = firebaseConfig.apiKey && 
-                      firebaseConfig.apiKey !== "your_api_key" && 
-                      !firebaseConfig.apiKey.includes("your");
+const isValidApiKey =
+  firebaseConfig.apiKey &&
+  firebaseConfig.apiKey !== "your_api_key" &&
+  !firebaseConfig.apiKey.includes("your");
 
 if (isValidApiKey) {
-  app = initializeApp(firebaseConfig);
+  // Avoid re-initializing on hot-reload
+  app = getApps().length === 0 ? initializeApp(firebaseConfig) : getApps()[0];
   auth = getAuth(app);
-  db = getFirestore(app);
+
+  // Use the modern persistent cache API (Firestore v9.21+).
+  // This replaces enableIndexedDbPersistence and supports multiple tabs natively.
+  // Falls back to getFirestore() if the environment does not support it (e.g. SSR).
+  if (typeof window !== "undefined") {
+    try {
+      db = initializeFirestore(app, {
+        localCache: persistentLocalCache({
+          tabManager: persistentMultipleTabManager(),
+        }),
+      });
+    } catch (err) {
+      // initializeFirestore throws if Firestore was already initialized for this app
+      // (e.g. in development fast-refresh). Fall back to the already-initialised instance.
+      console.warn("[Firestore] Persistent cache init skipped:", err.code ?? err.message);
+      db = getFirestore(app);
+    }
+  } else {
+    // SSR — plain Firestore without persistence
+    db = getFirestore(app);
+  }
 } else {
   console.warn("Firebase env vars missing or invalid. Running without Firebase.");
 }
@@ -57,3 +83,4 @@ if (typeof window !== "undefined" && app) {
 }
 
 export { analytics };
+

--- a/lib/firestorePool.js
+++ b/lib/firestorePool.js
@@ -1,0 +1,126 @@
+/**
+ * lib/firestorePool.js
+ *
+ * Centralized Firestore subscription pool.
+ * Maintains exactly ONE active onSnapshot listener per unique query key.
+ * Any number of React components can subscribe to the same key —
+ * they all share the same underlying Firestore listener and receive
+ * the identical cached snapshot without triggering extra reads.
+ *
+ * Usage:
+ *   const unsub = firestorePool.subscribe(key, query, onData, onError);
+ *   // later:
+ *   unsub(); // decrements ref-count; unsubscribes from Firestore when count → 0
+ */
+
+const firestorePool = (() => {
+  /**
+   * Map<key, { unsub: fn, data: any, error: any, listeners: Set<fn>, errorListeners: Set<fn> }>
+   */
+  const pool = new Map();
+
+  /**
+   * Subscribe to a Firestore query through the pool.
+   *
+   * @param {string}   key       - Unique, stable string identifying this query.
+   * @param {Query}    query     - Firestore Query object (from collection/query helpers).
+   * @param {Function} onData    - Called with the latest data array on every snapshot.
+   * @param {Function} [onError] - Called with any Firestore error.
+   * @returns {Function} Unsubscribe function. Call it when the consumer unmounts.
+   */
+  function subscribe(key, query, onData, onError) {
+    if (!pool.has(key)) {
+      // First subscriber — create the real Firestore listener
+      const entry = {
+        unsub: null,
+        data: null,
+        error: null,
+        listeners: new Set(),
+        errorListeners: new Set(),
+      };
+      pool.set(key, entry);
+
+      // Lazily import onSnapshot to avoid SSR issues
+      import("firebase/firestore").then(({ onSnapshot }) => {
+        if (!pool.has(key)) return; // entry was cleaned up before import resolved
+
+        const firestoreUnsub = onSnapshot(
+          query,
+          (snapshot) => {
+            const docs = snapshot.docs.map((doc) => ({
+              id: doc.id,
+              ...doc.data(),
+            }));
+            const e = pool.get(key);
+            if (!e) return;
+            e.data = docs;
+            e.error = null;
+            e.listeners.forEach((cb) => cb(docs));
+          },
+          (err) => {
+            const e = pool.get(key);
+            if (!e) return;
+            e.error = err;
+            e.errorListeners.forEach((cb) => cb(err));
+          }
+        );
+
+        const e = pool.get(key);
+        if (e) {
+          e.unsub = firestoreUnsub;
+        } else {
+          // All consumers unsubscribed while we were loading — clean up immediately
+          firestoreUnsub();
+        }
+      });
+    }
+
+    const entry = pool.get(key);
+    entry.listeners.add(onData);
+    if (onError) entry.errorListeners.add(onError);
+
+    // If we already have cached data, deliver it immediately (instant render)
+    if (entry.data !== null) {
+      onData(entry.data);
+    }
+    if (entry.error !== null && onError) {
+      onError(entry.error);
+    }
+
+    // Return unsubscribe handle
+    return () => {
+      const e = pool.get(key);
+      if (!e) return;
+
+      e.listeners.delete(onData);
+      if (onError) e.errorListeners.delete(onError);
+
+      // When no consumers remain, tear down the Firestore listener
+      if (e.listeners.size === 0) {
+        if (e.unsub) e.unsub();
+        pool.delete(key);
+      }
+    };
+  }
+
+  /**
+   * Returns the last cached data for a key, or null if not yet loaded.
+   */
+  function getCached(key) {
+    return pool.get(key)?.data ?? null;
+  }
+
+  /**
+   * Force-clear every listener (useful in tests / hot-reload).
+   */
+  function reset() {
+    pool.forEach((entry) => {
+      if (entry.unsub) entry.unsub();
+    });
+    pool.clear();
+  }
+
+  return { subscribe, getCached, reset };
+})();
+
+export default firestorePool;

--- a/package-lock.json
+++ b/package-lock.json
@@ -7481,9 +7481,6 @@
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
       "license": "MIT",
-      "peer": true
-<<<<<<< HEAD
-=======
     },
     "node_modules/dompurify": {
       "version": "3.4.5",
@@ -7494,7 +7491,6 @@
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
       }
->>>>>>> ba70f66180771a279b4bd8c601f3c5e959751ab3
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -7479,8 +7479,8 @@
       "version": "0.5.16",
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
-      "dev": true,
       "license": "MIT",
+      "peer": true
     },
     "node_modules/dompurify": {
       "version": "3.4.5",


### PR DESCRIPTION
## Performance: Centralized Firebase Subscription Pooling & Offline Persistence
Closes #987 
### Problem
Multiple dashboard components (`noticeBoard.js`, etc.) each created their own independent `onSnapshot` Firestore listeners. This caused:
- Duplicate reads to the same Firestore collections
- Dashboard shimmer/flicker when navigating between tabs
- Listener teardown and recreation on every page navigation
- Inconsistent React re-renders from competing parallel listeners
- No offline resilience — pages would break without a network connection

### Solution

#### `lib/firestorePool.js` (NEW)
Singleton subscription pool that maintains **exactly one active `onSnapshot` listener per unique query key**. Multiple components can subscribe to the same key — sharing the underlying Firestore listener and receiving cached snapshots without triggering extra reads. When the last consumer unmounts, the Firestore listener is torn down.

#### `contexts/FirestoreContext.js` (NEW)
Global React Context powered by the pool. Exposes stable, memoized hooks:
- `useNotices()` — shared cached notice array for the signed-in user's role
- `useAttendanceRecords()` — shared cached attendance records
- `useFirestoreNotifications()` — shared cached Firestore notifications

#### `lib/firebaseConfig.js` (MODIFIED)
Enabled Firestore offline persistence via `persistentLocalCache` + `persistentMultipleTabManager` (Firestore v9.21+). Replaces legacy `enableIndexedDbPersistence` API with full multi-tab support. Also fixed duplicate app initialization on hot-reload using `getApps()` guard.

#### `app/layout.js` (MODIFIED)
Mounted `<FirestoreProvider>` inside `<AuthProvider>` so all child pages and components inherit the shared pooled listeners from the root.

#### `components/noticeBoard.js` (MODIFIED)
Removed local `onSnapshot` subscription and replaced it with `useNotices()` from `FirestoreContext`. The component now renders instantly from cached data with zero additional Firestore reads.

### Performance Impact
| Metric | Before | After |
|---|---|---|
| Firestore reads (notices) | 1 per component mount | 1 total across all consumers |
| Listener lifecycle | Created/destroyed on each nav | Survives navigation, cleaned up on app unmount |
| Dashboard initial render | Skeleton flicker each visit | Instant from cache |
| Offline behavior | Crash / blank | Cached reads served from IndexedDB |
