### PR TITLE
fix: resolve ReferenceError crash on Admin Dashboard by importing useAuth

### DIFF
--- a/components/AdminDashboard.js
+++ b/components/AdminDashboard.js
@@ -28,6 +28,9 @@ import ChartSkeleton from "@/components/ui/ChartSkeleton";
 import DashboardSkeleton from "@/components/ui/DashboardSkeleton";
 import SkeletonCard from "@/components/ui/SkeletonCard";
 
+// CRITICAL FIX: Imported missing useAuth hook to prevent ReferenceError crash
+import { useAuth } from "@/hooks/useAuth";
+
 const AttendanceTrendsChart = dynamic(
   () => import("@/components/charts/AttendanceTrendsChart"),
   { ssr: false, loading: () => <ChartSkeleton variant="chart" /> }


### PR DESCRIPTION
## What type of PR is this?
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [ ] 🎨 UI/UX improvement
- [ ] ⚡ Performance improvement
- [ ] 🔒 Security fix

## Description
This PR resolves a critical application crash on the Super Admin Dashboard. The component was invoking the custom `useAuth()` hook to get the current logged-in `user` object but was missing its corresponding import statement at the top of the file, resulting in an instantaneous `ReferenceError: useAuth is not defined` runtime failure.

## Related Issues
Closes #1179 

## Changes Made
- Synchronously imported the missing `useAuth` hook from `@/hooks/useAuth` inside `components/AdminDashboard.js`.
- Fixed the runtime execution path so the dashboard securely reads the authentication scope and renders the infrastructure graphs flawlessly.

## Testing
How did you test these changes?
- [x] Tested locally
- [ ] Tested on mobile
- [ ] Tested different user roles
- [ ] All roles tested

## Checklist
- [x] No hardcoded secrets or credentials
- [x] `.env.local` is not committed
- [x] Code follows project style
- [x] Build passes locally (`npm run build`)
- [x] No console errors/warnings

**GSSoC 2026** Contributor!
/gssoc-page-status