### PR TITLE
fix: prevent memory leak on contact page cooldown timer

### DIFF
--- a/app/contact/page.js
+++ b/app/contact/page.js
@@ -39,6 +39,7 @@ export default function Contact() {
   const [cooldownTimer, setCooldownTimer] = useState(0);
 
   useEffect(() => {
+    let interval; // Store interval reference securely
     const COOLDOWN_MS = 60 * 1000;
     const lastSubmit = localStorage.getItem('learnova_contact_last_submit');
     if (lastSubmit) {
@@ -47,7 +48,7 @@ export default function Contact() {
       if (remaining > 0) {
         setCooldown(true);
         setCooldownTimer(remaining);
-        const interval = setInterval(() => {
+        interval = setInterval(() => {
           setCooldownTimer((prev) => {
             if (prev <= 1) {
               clearInterval(interval);
@@ -59,6 +60,11 @@ export default function Contact() {
         }, 1000);
       }
     }
+    
+    // CRITICAL FIX: Cleanup function to destroy the interval on component unmount
+    return () => {
+      if (interval) clearInterval(interval);
+    };
   }, []);
 
   const handleInputChange = (e) => {


### PR DESCRIPTION
## What type of PR is this?
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [ ] 🎨 UI/UX improvement
- [x] ⚡ Performance improvement
- [ ] 🔒 Security fix

## Description
This PR resolves a background memory leak found in the `app/contact/page.js` component. The `setInterval` for the cooldown timer was previously left running indefinitely if the user navigated away from the page, causing state updates on unmounted components.

## Related Issues
Closes #1188 

## Changes Made
- Added a `return () => clearInterval(interval)` cleanup block inside the `useEffect` hook.
- Prevented orphaned background timers from accumulating in the browser's memory cycle.

## Testing
How did you test these changes?
- [x] Tested locally
- [ ] Tested on mobile
- [ ] Tested different user roles
- [ ] All roles tested

## Checklist
- [x] No hardcoded secrets or credentials
- [x] `.env.local` is not committed
- [x] Code follows project style
- [x] Build passes locally (`npm run build`)
- [x] No console errors/warnings

**GSSoC 2026** Contributor!
/gssoc-page-status