### PR TITLE
perf(FaceRecognizer): lazy load face-api.js to reduce bundle size

### DIFF
--- a/components/FaceRecognizer.js
+++ b/components/FaceRecognizer.js
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
-import * as faceapi from "face-api.js";
+
 import { Button } from "@/components/ui/button";
 import useLabels from "@/components/useLabels";
 import { recordAttendance } from "@/services/attendanceService";
@@ -117,6 +117,9 @@ export default function FaceRecognizer({ authUser }) {
 
     const loadModels = async () => {
       try {
+        setMessage("Downloading ML models...");
+        const faceapi = await import("face-api.js");
+
         await Promise.all([
           faceapi.nets.tinyFaceDetector.loadFromUri(MODEL_URL),
           faceapi.nets.faceLandmark68Net.loadFromUri(MODEL_URL),
@@ -193,6 +196,8 @@ export default function FaceRecognizer({ authUser }) {
   const buildFaceMatcher = async () => {
     if (!labels || labels.length === 0) return;
 
+    const faceapi = await import("face-api.js");
+
     const labeledFaceDescriptors = (
       await Promise.all(
         labels.map(async (student) => {
@@ -241,6 +246,7 @@ export default function FaceRecognizer({ authUser }) {
       return;
     }
 
+    const faceapi = await import("face-api.js");
     const video = videoRef.current;
     
     // Ensure video is playing and has valid dimensions before processing


### PR DESCRIPTION
## Description
This PR addresses issue #265 by refactoring `components/FaceRecognizer.js` to dynamically load the `face-api.js` machine learning dependency.

Previously, `face-api.js` was statically imported at the top of the file, causing Next.js to bundle the entire ML package within the critical client bundle. This significantly increased the Initial Load Time, degraded Time to Interactive (TTI), and penalized Lighthouse scores across the app. 

### Key Changes
1. Removed the synchronous `import * as faceapi from "face-api.js"` from `FaceRecognizer.js`.
2. Implemented Dynamic Imports (`await import("face-api.js")`) precisely when the models are requested:
   - Within `loadModels()`
   - Within `buildFaceMatcher()`
   - Within `processVideo()`
3. Added user-facing loading states (`"Downloading ML models..."`) so users with slower connections know that heavy assets are being requested on demand.

## Expected Benefits
- Substantial reduction in the initial JS chunk size.
- Improved application boot-up speed.
- The browser now only fetches, parses, and compiles `face-api.js` on the specific workflows that explicitly instantiate the camera scanning.

