### PR TITLE
[SECURITY]: Enforce object-level authorization for avatar image endpoint

### DIFF
--- a/app/api/images/route.js
+++ b/app/api/images/route.js
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 import { connectDb } from "@/lib/mongodb";
-import { requireAuth } from "@/lib/rbac";
+import { requireAuth, requireRole } from "@/lib/rbac";
 import { withErrorHandler } from "@/lib/error-handler";
 import { AppError, ValidationError, NotFoundError } from "@/lib/errors";
 import { put } from "@vercel/blob";
@@ -23,7 +23,8 @@ export const GET = withErrorHandler(async (request) => {
       throw new ValidationError(firstError);
     }
 
-    await requireAuth(request);
+    // Authenticate the requester and capture the decoded token for ownership checks
+    const decodedToken = await requireAuth(request);
 
     const db = await connectDb();
     const users = db.collection("users");
@@ -38,11 +39,29 @@ export const GET = withErrorHandler(async (request) => {
 
     const user = await users.findOne(
       { _id: objectId },
-      { projection: { image: 1 } }
+      { projection: { image: 1, firebaseUid: 1 } }
     );
 
     if (!user || !user.image) {
       throw new NotFoundError("Image not found");
+    }
+
+    // Enforce object-level authorization: only the owner or privileged roles may fetch another user's image
+    const ownerUid = user.firebaseUid || null;
+    if (ownerUid && ownerUid !== decodedToken.uid) {
+      try {
+        // Allow admins or institute-level users to access other users' images
+        await requireRole(request, ["admin", "institute"]);
+      } catch (err) {
+        throw new AppError("Forbidden: insufficient permissions to access requested image", 403);
+      }
+    } else if (!ownerUid && ownerUid !== decodedToken.uid) {
+      // If there's no firebaseUid on the user doc, be conservative and deny access unless privileged
+      try {
+        await requireRole(request, ["admin", "institute"]);
+      } catch (err) {
+        throw new AppError("Forbidden: insufficient permissions to access requested image", 403);
+      }
     }
 
     let parsedUrl;

--- a/components/_tests_/imagesRoute.test.js
+++ b/components/_tests_/imagesRoute.test.js
@@ -1,0 +1,110 @@
+jest.mock("next/server", () => ({
+  NextResponse: jest.fn().mockImplementation((body, init) => ({
+    status: init?.status || 200,
+    body,
+    headers: new Map(Object.entries(init?.headers || {})),
+  })),
+}));
+
+jest.mock("@/lib/mongodb", () => ({
+  connectDb: jest.fn(),
+}));
+
+// Mock mongodb ObjectId to avoid importing ESM-built bson code during tests
+jest.mock("mongodb", () => ({
+  ObjectId: class ObjectId {
+    constructor(id) {
+      this.id = id;
+    }
+    toString() {
+      return String(this.id);
+    }
+  },
+}));
+
+jest.mock("@/lib/rbac", () => ({
+  requireAuth: jest.fn(),
+  requireRole: jest.fn(),
+}));
+
+jest.mock("@/lib/error-handler", () => ({
+  withErrorHandler: (fn) => fn,
+}));
+
+jest.mock("@/lib/errors", () => ({
+  AppError: class AppError extends Error {
+    constructor(message, status) {
+      super(message);
+      this.status = status;
+    }
+  },
+  ValidationError: class ValidationError extends Error {},
+  NotFoundError: class NotFoundError extends Error {},
+}));
+
+const { GET } = require("@/app/api/images/route");
+
+const { connectDb } = require("@/lib/mongodb");
+const { requireAuth, requireRole } = require("@/lib/rbac");
+
+describe("GET /api/images - authorization", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    global.fetch = jest.fn();
+  });
+
+  const createReq = (id, headers = {}) => ({
+    url: `http://localhost/api/images?id=${encodeURIComponent(id)}`,
+    headers: {
+      get: jest.fn().mockImplementation((name) => headers[name.toLowerCase()] || null),
+    },
+  });
+
+  test("owner can fetch their image", async () => {
+    requireAuth.mockResolvedValue({ uid: "owner-uid" });
+
+    const userDoc = { image: "https://public.blob.vercel-storage.com/a.jpg", firebaseUid: "owner-uid" };
+    connectDb.mockResolvedValue({ collection: () => ({ findOne: jest.fn().mockResolvedValue(userDoc) }) });
+
+    global.fetch.mockResolvedValue({ ok: true, headers: { get: () => "image/jpeg" }, arrayBuffer: async () => Buffer.from([1, 2, 3]).buffer });
+
+    const req = createReq("someObjectId");
+    const res = await GET(req);
+
+    expect(res.status).toBe(200);
+    expect(global.fetch).toHaveBeenCalledWith(userDoc.image);
+  });
+
+  test("non-owner without privileges is forbidden", async () => {
+    requireAuth.mockResolvedValue({ uid: "attacker-uid" });
+    requireRole.mockImplementation(() => { throw new Error("not allowed"); });
+
+    const userDoc = { image: "https://public.blob.vercel-storage.com/a.jpg", firebaseUid: "owner-uid" };
+    connectDb.mockResolvedValue({ collection: () => ({ findOne: jest.fn().mockResolvedValue(userDoc) }) });
+
+    const req = createReq("someObjectId");
+
+    await expect(GET(req)).rejects.toThrow("Forbidden");
+  });
+
+  test("privileged role can fetch other user's image", async () => {
+    requireAuth.mockResolvedValue({ uid: "attacker-uid" });
+    requireRole.mockResolvedValue(true);
+
+    const userDoc = { image: "https://public.blob.vercel-storage.com/a.jpg", firebaseUid: "owner-uid" };
+    connectDb.mockResolvedValue({ collection: () => ({ findOne: jest.fn().mockResolvedValue(userDoc) }) });
+
+    global.fetch.mockResolvedValue({ ok: true, headers: { get: () => "image/png" }, arrayBuffer: async () => Buffer.from([4,5,6]).buffer });
+
+    const req = createReq("someObjectId");
+    const res = await GET(req);
+
+    expect(res.status).toBe(200);
+    expect(global.fetch).toHaveBeenCalledWith(userDoc.image);
+  });
+
+  test("invalid id parameter results in validation error", async () => {
+    const req = { url: `http://localhost/api/images`, headers: { get: jest.fn().mockReturnValue(null) } };
+    await expect(GET(req)).rejects.toThrow();
+  });
+});


### PR DESCRIPTION
## 🎯 Purpose of this Pull Request

This PR fixes an object-level authorization (IDOR) vulnerability in the image API that allowed authenticated users to access another user’s avatar by supplying an arbitrary user ID in the query parameter.

The fix ensures that only:

* the resource owner, or
* authorized privileged roles (`admin`, `institute`)

can access a user’s avatar image.

---

## 🔗 Related Issue / Link

Fixes #1199 

---

## 🛠️ Description of Changes

### Updated `route.js`

* Added ownership validation using the authenticated user’s UID
* Restricted image access to:

  * resource owner
  * `admin`
  * `institute`
* Added conservative deny behavior when ownership metadata is missing
* Prevented unauthorized access to arbitrary user avatars

### Added Tests (`imagesRoute.test.js`)

Added unit tests for:

* owner access
* unauthorized non-owner access
* privileged-role access
* invalid/missing ID handling

---

## 🔒 Security Impact

This PR fixes an **IDOR (Insecure Direct Object Reference)** vulnerability where authenticated users could retrieve avatar images belonging to other users.

The updated authorization logic now enforces proper object-level access control and reduces unintended exposure of user profile data.

---

## 🧪 Verification / Testing Done

* [x] Tested locally
* [x] Added authorization unit tests
* [x] Verified unauthorized users receive `403 Forbidden`
* [x] Verified owners can access their own avatar
* [x] Verified privileged roles retain access
* [x] Tested in production environment

### Manual Verification Steps

1. Run tests:

```bash id="tv9v0u"
npm test -- components/_tests_/imagesRoute.test.js
```

2. Start the application:

```bash id="8lc2gb"
npm run dev
```

3. Verify API behavior:

* Owner request:

  ```text
  /api/images?id=<owner_id>
  ```

  → returns `200`

* Non-owner request:

  ```text
  /api/images?id=<another_user_id>
  ```

  → returns `403 Forbidden`

* Admin/institute request:
  → allowed access

---

## 📸 Screenshots / GIFs

Not applicable — backend/API authorization fix.

---

## 📋 Checklist

* [x] Code follows project conventions
* [x] Performed self-review
* [x] Added regression/unit tests
* [x] No hardcoded credentials or secrets
* [x] No unnecessary console/debug logs added
* [x] Authorization checks added for protected resources
* [x] No breaking UI changes introduced
* [x] Tests pass locally

---

## Additional Note

I am GSSoC'26 Contributor.