### PR TITLE
Unify attendance writes to Firestore

### DIFF
--- a/app/api/attendance/record/route.js
+++ b/app/api/attendance/record/route.js
@@ -1,6 +1,7 @@
-import { connectDb } from "@/lib/mongodb";
 import { jsonError, jsonSuccess } from "@/lib/api-response";
 import { withErrorHandler, authenticateRequest } from "@/lib/error-handler";
+import { initFirebaseAdmin, getUserProfile } from "@/lib/firebase-admin";
+import { getFirestore, FieldValue } from "firebase-admin/firestore";
 
 export const POST = withErrorHandler(async (request) => {
   // 1. Secure token validation ensures only logged-in users can ping this route
@@ -8,6 +9,7 @@ export const POST = withErrorHandler(async (request) => {
 
   const body = await request.json();
   const { userId, studentName, email, confidenceScore, date } = body;
+  const normalizedDate = (date || new Date().toISOString().slice(0, 10)).toString();
 
   // 2. Ensure they are only submitting attendance for their own UID!
   if (decodedToken.uid !== userId) {
@@ -19,24 +21,32 @@ export const POST = withErrorHandler(async (request) => {
     return jsonError("Bad Request: Confidence score too low", 400);
   }
 
-  const db = await connectDb();
-  
-  // 4. Secure server-side database insertion (Uses Upsert to prevent duplicates just like setDoc did)
-  await db.collection("attendance_records").updateOne(
-    { userId, date },
-    {
-      $set: {
+  // 4. Write attendance to Firestore (single source of truth).
+  // Use a deterministic doc id to prevent duplicates and match client duplicate checks.
+  initFirebaseAdmin();
+  const db = getFirestore();
+  const userProfile = await getUserProfile(decodedToken.uid);
+  const instituteId = userProfile?.instituteId || null;
+  const resolvedName = userProfile?.fullName || userProfile?.displayName || studentName;
+  const resolvedEmail = userProfile?.email || email;
+
+  await db
+    .collection("attendance_records")
+    .doc(`${userId}_${normalizedDate}`)
+    .set(
+      {
         userId,
-        studentName,
-        email,
-        timestamp: new Date(),
-        date: date || new Date().toISOString().slice(0, 10),
+        studentName: resolvedName,
+        email: resolvedEmail,
+        instituteId,
+        timestamp: FieldValue.serverTimestamp(),
+        date: normalizedDate,
         status: "present",
-        confidenceScore
-      }
-    },
-    { upsert: true }
-  );
+        confidenceScore,
+        offlineSynced: false,
+      },
+      { merge: true },
+    );
 
   return jsonSuccess({ alreadyRecorded: false }, 201);
 });

--- a/app/api/attendance/record/route.test.js
+++ b/app/api/attendance/record/route.test.js
@@ -1,0 +1,88 @@
+import { POST } from "./route";
+import { authenticateRequest } from "@/lib/error-handler";
+import { getUserProfile } from "@/lib/firebase-admin";
+import { getFirestore, FieldValue } from "firebase-admin/firestore";
+
+jest.mock("@/lib/error-handler", () => ({
+  authenticateRequest: jest.fn(),
+  withErrorHandler: (handler) => handler,
+}));
+
+jest.mock("@/lib/firebase-admin", () => ({
+  initFirebaseAdmin: jest.fn(),
+  getUserProfile: jest.fn(),
+}));
+
+jest.mock("firebase-admin/firestore", () => ({
+  getFirestore: jest.fn(),
+  FieldValue: {
+    serverTimestamp: jest.fn(() => "server-timestamp"),
+  },
+}));
+
+jest.mock("next/server", () => ({
+  NextResponse: {
+    json: (body, init = {}) => ({
+      status: init.status ?? 200,
+      json: async () => body,
+    }),
+  },
+}));
+
+describe("attendance record route", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test("writes attendance to Firestore with canonical doc id + instituteId", async () => {
+    authenticateRequest.mockResolvedValue({ uid: "user-123" });
+
+    getUserProfile.mockResolvedValue({
+      fullName: "Server Name",
+      email: "server@example.com",
+      instituteId: "inst-999",
+    });
+
+    const set = jest.fn().mockResolvedValue(undefined);
+    const docRef = { set };
+    const collectionRef = { doc: jest.fn(() => docRef) };
+
+    getFirestore.mockReturnValue({
+      collection: jest.fn(() => collectionRef),
+    });
+
+    const response = await POST({
+      json: async () => ({
+        userId: "user-123",
+        studentName: "Client Name",
+        email: "client@example.com",
+        confidenceScore: 75,
+        date: "2026-05-25",
+      }),
+      headers: new Headers([["authorization", "Bearer test"]]),
+      cookies: { get: jest.fn() },
+    });
+
+    expect(response.status).toBe(201);
+    await expect(response.json()).resolves.toEqual({
+      success: true,
+      data: { alreadyRecorded: false },
+    });
+
+    expect(collectionRef.doc).toHaveBeenCalledWith("user-123_2026-05-25");
+    expect(set).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: "user-123",
+        studentName: "Server Name",
+        email: "server@example.com",
+        instituteId: "inst-999",
+        date: "2026-05-25",
+        status: "present",
+        offlineSynced: false,
+        timestamp: FieldValue.serverTimestamp.mock.results[0].value,
+      }),
+      { merge: true },
+    );
+  });
+});
+

--- a/app/api/attendance/sync/route.js
+++ b/app/api/attendance/sync/route.js
@@ -67,6 +67,7 @@ async function handleSync(request) {
   }
 
   const serverIdentity = resolveAttendanceIdentity(decodedToken, userProfile);
+  const instituteId = userProfile?.instituteId || null;
   
   const successfulIds = [];
   
@@ -101,20 +102,15 @@ async function handleSync(request) {
     }
 
     // Check if attendance already exists in Firestore for this date
-    const attendanceQuery = await db.collection("attendance_records")
-      .where("userId", "==", decodedToken.uid)
-      .where("date", "==", recordDate)
-      .limit(1)
-      .get();
+    // Use the canonical deterministic doc id to stay consistent with the online flow.
+    const newDocRef = db.collection("attendance_records").doc(`${decodedToken.uid}_${recordDate}`);
+    const existingAttendance = await newDocRef.get();
 
-    if (!attendanceQuery.empty) {
+    if (existingAttendance.exists) {
       successfulIds.push(record.id);
       processedUserDates.add(userDateKey);
       continue;
     }
-
-    // Prepare new document
-    const newDocRef = db.collection("attendance_records").doc();
 
     if (
       (record.studentName && record.studentName !== serverIdentity.studentName) ||
@@ -129,6 +125,7 @@ async function handleSync(request) {
       userId: decodedToken.uid,
       studentName: serverIdentity.studentName,
       email: serverIdentity.email,
+      instituteId,
       timestamp: FieldValue.serverTimestamp(),
       date: recordDate,
       status: "present",

--- a/app/api/attendance/sync/route.test.js
+++ b/app/api/attendance/sync/route.test.js
@@ -54,12 +54,12 @@ describe("attendance sync route", () => {
       commit: jest.fn().mockResolvedValue(undefined),
     };
 
-    const attendanceQuery = { empty: true };
+    const docRef = {
+      get: jest.fn().mockResolvedValue({ exists: false }),
+    };
+
     const collectionRef = {
-      where: jest.fn().mockReturnThis(),
-      limit: jest.fn().mockReturnThis(),
-      get: jest.fn().mockResolvedValue(attendanceQuery),
-      doc: jest.fn(() => ({})),
+      doc: jest.fn(() => docRef),
     };
 
     getFirestore.mockReturnValue({
@@ -89,6 +89,8 @@ describe("attendance sync route", () => {
     });
 
     expect(getUserProfile).toHaveBeenCalledWith("user-123");
+    expect(collectionRef.doc).toHaveBeenCalledWith(expect.stringMatching(/^user-123_\d{4}-\d{2}-\d{2}$/));
+    expect(docRef.get).toHaveBeenCalledTimes(1);
     expect(batch.set).toHaveBeenCalledWith(
       expect.any(Object),
       expect.objectContaining({
@@ -117,10 +119,7 @@ describe("attendance sync route", () => {
     };
 
     const collectionRef = {
-      where: jest.fn().mockReturnThis(),
-      limit: jest.fn().mockReturnThis(),
-      get: jest.fn(),
-      doc: jest.fn(() => ({})),
+      doc: jest.fn(() => ({ get: jest.fn() })),
     };
 
     getFirestore.mockReturnValue({


### PR DESCRIPTION
## 🎯 Purpose of this Pull Request

Fixes the attendance split-brain bug where online check-ins were silently written to MongoDB while all stats, dashboards, and duplicate checks read from Firestore — causing online attendance to never appear in analytics. This PR unifies both online and offline attendance persistence to Firestore as the single source of truth.

## 🔗 Related Issue / Link

Fixes [Premshaw23/Learnova#1176](https://github.com/Premshaw23/Learnova/issues/1176)

**Branch:** `fix/1176-attendance-single-source`
**Fork:** https://github.com/ionfwsrijan/Learnova/tree/fix/1176-attendance-single-source

## 🛠️ Description of Changes

- **`app/api/attendance/record/route.js`** — Switched online attendance persistence from MongoDB to Firestore using a deterministic document ID (`${userId}_${date}`) and ensures `instituteId` is written on every record, making it consistent with what `statsService.js` and `app/api/institute/stats/route.js` query.
- **`app/api/attendance/sync/route.js`** — Offline sync now also uses the same deterministic doc ID format (`${userId}_${date}`) and includes `instituteId`, so online and offline records are structurally identical and never produce duplicates.
- **`app/api/attendance/record/route.test.js`** — Added/updated tests covering the online check-in Firestore write path, deterministic doc ID, and `instituteId` field presence.
- **`app/api/attendance/sync/route.test.js`** — Added/updated tests verifying offline sync writes to Firestore with the correct doc ID and schema.

## 🧪 Verification / Testing Done

- [x] Ran the affected test suites directly:
  ```
  .\node_modules\.bin\jest.cmd app/api/attendance/sync/route.test.js app/api/attendance/record/route.test.js
  ```
- [x] Verified that online check-in no longer writes to MongoDB `attendance_records`.
- [x] Verified that Firestore-based stats (`services/statsService.js`) and institute dashboard (`app/api/institute/stats/route.js`) correctly reflect online attendance after the fix.
- [x] Confirmed offline sync and online check-in produce non-conflicting, idempotent upserts using the same deterministic doc ID.
- [x] Ran relevant linters (`npm run lint`).

## 📸 Screenshots / GIFs

_No UI changes in this PR — this fix is backend/data-layer only. Analytics and dashboard correctness can be verified by marking attendance online and confirming the Attendance Rate KPI updates._

## 📋 Checklist

- [x] My code follows the code style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation accordingly.
- [x] My changes generate no new warnings or console errors.
- [x] I have deleted any temporary or debugging console logs.
