### PR TITLE
Add tests: EmptyNoticeState component unit tests

### DIFF
--- a/components/__tests__/EmptyNoticeState.test.jsx
+++ b/components/__tests__/EmptyNoticeState.test.jsx
@@ -1,0 +1,58 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import EmptyNoticeState from "../EmptyNoticeState";
+
+describe("EmptyNoticeState", () => {
+  const defaultProps = {
+    query: "",
+    onResetFilters: jest.fn(),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test("renders default message correctly when search query is empty", () => {
+    render(<EmptyNoticeState {...defaultProps} />);
+
+    // Verify main header
+    expect(screen.getByText("No notices found")).toBeInTheDocument();
+
+    // Verify default body message
+    expect(
+      screen.getByText(
+        "There are no notices available right now. Reset filters or try again later."
+      )
+    ).toBeInTheDocument();
+
+    // Verify reset button is rendered
+    expect(
+      screen.getByRole("button", { name: /reset filters/i })
+    ).toBeInTheDocument();
+  });
+
+  test("renders search query correctly in the warning message when search filters return no results", () => {
+    const props = {
+      ...defaultProps,
+      query: "exam schedule",
+    };
+    render(<EmptyNoticeState {...props} />);
+
+    // Verify customized query warning message
+    expect(
+      screen.getByText(
+        'No notices match "exam schedule". Try broadening the keywords, selecting a different category, or removing some filters.'
+      )
+    ).toBeInTheDocument();
+  });
+
+  test("triggers the onResetFilters callback function when the 'Reset filters' button is clicked", async () => {
+    const user = userEvent.setup();
+    render(<EmptyNoticeState {...defaultProps} />);
+
+    const resetBtn = screen.getByRole("button", { name: /reset filters/i });
+    await user.click(resetBtn);
+
+    expect(defaultProps.onResetFilters).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## 🎯 Purpose of this Pull Request
The codebase currently has minimal test coverage. This contribution adds comprehensive unit test coverage for the simple, reusable `EmptyNoticeState` component to prevent regression bugs.

## 🔗 Related Issue / Link
Fixes #1124 

## 🛠️ Description of Changes
- Added unit tests utilizing `@testing-library/react` and `@testing-library/user-event` to verify:
  - Renders default message correctly when search query is empty.
  - Renders search query correctly in the warning message when search filters return no results.
  - Triggers the `onResetFilters` callback function when the "Reset filters" button is clicked.
- Added `@testing-library/dom` as a devDependency in `package.json` to resolve test runner dependency resolutions.

## 🧪 Verification / Testing Done
- [x] Ran relevant linters or unit tests (`npm run lint` / `npm test`).
  - Executed tests locally using Jest with: `npm run test components/__tests__/EmptyNoticeState.test.jsx`
  - Verified all tests pass successfully:
    ```text
    PASS components/__tests__/EmptyNoticeState.test.jsx
      EmptyNoticeState
        √ renders default message correctly when search query is empty (317 ms)
        √ renders search query correctly in the warning message when search filters return no results (26 ms)
        √ triggers the onResetFilters callback function when the 'Reset filters' button is clicked (197 ms)
   


