### PR TITLE
fix(notices): consolidate notices stream SSE connection and memory le…solve#1206

### DIFF
--- a/app/api/notices/stream/route.js
+++ b/app/api/notices/stream/route.js
@@ -114,23 +114,36 @@ export async function GET(request) {
           return controller.close();
         }
 
-        const entry = {
-          id: connId,
-          close() {
-            isConnected = false;
-            try { controller.close(); } catch {}
-          },
-        };
-
-        userStreams.set(userId, entry);
-        connectionCount++;
-
         const onNotice = (doc) => {
           if (!isConnected) return;
           if (doc.targetAudience && doc.targetAudience.includes(userRole)) {
             sendEvent("new-notice", { ...doc, id: doc._id.toString() });
           }
         };
+
+        const cleanup = () => {
+          const current = userStreams.get(userId);
+          if (current && current.id === connId) {
+            userStreams.delete(userId);
+            connectionCount = Math.max(0, connectionCount - 1);
+          }
+          isConnected = false;
+          clearInterval(heartbeatInterval);
+          if (pollInterval) clearInterval(pollInterval);
+          if (idleTimer) clearTimeout(idleTimer);
+          removeListener(userId, onNotice);
+          try { controller.close(); } catch {}
+        };
+
+        const entry = {
+          id: connId,
+          close() {
+            cleanup();
+          },
+        };
+
+        userStreams.set(userId, entry);
+        connectionCount++;
 
         addListener(userId, onNotice);
         const hasStream = await getSharedStream();
@@ -159,9 +172,7 @@ export async function GET(request) {
         const resetIdle = () => {
           if (idleTimer) clearTimeout(idleTimer);
           idleTimer = setTimeout(() => {
-            if (!isConnected) return;
-            isConnected = false;
-            try { controller.close(); } catch {}
+            cleanup();
           }, IDLE_TIMEOUT_MS);
         };
         resetIdle();
@@ -171,17 +182,7 @@ export async function GET(request) {
         }, 15000);
 
         request.signal.addEventListener("abort", () => {
-          const current = userStreams.get(userId);
-          if (current && current.id === connId) {
-            userStreams.delete(userId);
-            connectionCount = Math.max(0, connectionCount - 1);
-          }
-          isConnected = false;
-          clearInterval(heartbeatInterval);
-          if (pollInterval) clearInterval(pollInterval);
-          if (idleTimer) clearTimeout(idleTimer);
-          removeListener(userId, onNotice);
-          try { controller.close(); } catch {}
+          cleanup();
         });
       },
     });


### PR DESCRIPTION
closes #1206 
### Description
Active connections in `/api/notices/stream` were leaking when users refreshed or opened multiple tabs, eventually locking out users with a `503` error when connections reached the maximum threshold of 50.

### Key Changes
* **Centralized Teardown Helper**: Built a singular `cleanup` helper in the stream route scope to manage intervals, change stream listeners, and connection counters.
* **Lifecycle Bindings**: Bound this helper to all stream termination pathways: server-driven tab overrides (`existing.close()`), browser-driven tab closures (`request.signal`'s `abort`), and inactivity timeouts.
* **Stale Context Prevention**: Correctly disposes of all background loops, database event listeners, and connection counts when connections are superseded.