### PR TITLE
Fix privilege escalation via client-set role

### DIFF
--- a/app/api/auth/set-role/route.js
+++ b/app/api/auth/set-role/route.js
@@ -1,0 +1,61 @@
+import { jsonError, jsonSuccess } from "@/lib/api-response";
+import { withErrorHandler, authenticateRequest } from "@/lib/error-handler";
+import { initializeFirebase } from "@/lib/firebase-admin";
+import admin from "firebase-admin";
+import { z } from "zod";
+
+const ALLOWED_ROLES = ["student", "teacher", "institute"];
+
+const setRoleSchema = z.object({
+  role: z.enum(ALLOWED_ROLES, {
+    errorMap: () => ({ message: "Role must be student, teacher, or institute" }),
+  }),
+  fullName: z.string().trim().min(1, "Full name is required").max(100),
+  instituteName: z.string().trim().max(200).optional(),
+});
+
+export const POST = withErrorHandler(async (request) => {
+  const decodedToken = await authenticateRequest(request);
+
+  const body = await request.json();
+
+  const validation = setRoleSchema.safeParse(body);
+  if (!validation.success) {
+    return jsonError(
+      validation.error.issues[0]?.message || "Validation failed",
+      400
+    );
+  }
+
+  const { role, fullName, instituteName } = validation.data;
+
+  initializeFirebase();
+
+  // Cryptographically sign the role into the Firebase token so the
+  // middleware can verify it without touching Firestore
+  await admin.auth().setCustomUserClaims(decodedToken.uid, { role });
+
+  // Write the user profile to Firestore from the server so the client
+  // cannot tamper with the role or any other field
+  const userProfile = {
+    uid: decodedToken.uid,
+    email: decodedToken.email,
+    fullName,
+    role,
+    createdAt: new Date().toISOString(),
+    emailVerified: decodedToken.email_verified || false,
+    lastLogin: new Date().toISOString(),
+  };
+
+  if (role === "institute" && instituteName) {
+    userProfile.instituteName = instituteName;
+  }
+
+  await admin
+    .firestore()
+    .collection("users")
+    .doc(decodedToken.uid)
+    .set(userProfile);
+
+  return jsonSuccess({ userProfile }, 201);
+});

--- a/services/authService.js
+++ b/services/authService.js
@@ -9,7 +9,7 @@ import {
   signOut,
   deleteUser,
 } from "firebase/auth";
-import { doc, setDoc, getDoc } from "firebase/firestore";
+import { doc, getDoc, updateDoc } from "firebase/firestore";
 import {
   createUserProfile,
   getErrorMessage,
@@ -61,10 +61,26 @@ export const loginWithEmail = async (email, password, selectedRole) => {
         };
       }
 
-      // Update last login
-      await setDoc(doc(db, "users", user.uid), {
-        ...userData,
+      // Update last login — use updateDoc to avoid overwriting the
+      // entire document (including role) with potentially stale data
+      await updateDoc(doc(db, "users", user.uid), {
         lastLogin: new Date(),
+      });
+
+      // Migrate existing users to have cryptographically signed custom
+      // claims.  Fire-and-forget — the login succeeds regardless.
+      user.getIdToken().then((token) => {
+        fetch("/api/auth/set-role", {
+          method: "POST",
+          headers: {
+            Authorization: `Bearer ${token}`,
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            role: userData.role,
+            fullName: userData.fullName || "",
+          }),
+        }).catch(() => {});
       });
 
       return { success: true, userData };
@@ -216,9 +232,24 @@ export const loginWithGoogle = async (
 
     // Update last login for existing users
     if (userData) {
-      await setDoc(doc(db, "users", user.uid), {
-        ...userData,
+      await updateDoc(doc(db, "users", user.uid), {
         lastLogin: new Date(),
+      });
+
+      // Migrate existing users to have cryptographically signed custom
+      // claims.  Fire-and-forget — the login succeeds regardless.
+      user.getIdToken().then((token) => {
+        fetch("/api/auth/set-role", {
+          method: "POST",
+          headers: {
+            Authorization: `Bearer ${token}`,
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            role: userData.role,
+            fullName: userData.fullName || "",
+          }),
+        }).catch(() => {});
       });
     }
 

--- a/utils/authUtils.js
+++ b/utils/authUtils.js
@@ -1,5 +1,3 @@
-import { doc, setDoc } from "firebase/firestore";
-import { db } from "@/lib/firebaseConfig";
 import { USER_ROLES } from "@/constants/userRoles";
 import { initializeUserStats } from "@/services/statsService";
 import {
@@ -69,7 +67,9 @@ export const getErrorMessage = (errorCode) => {
 };
 
 /**
- * Creates and stores a user profile in Firestore.
+ * Creates and stores a user profile via the server-side role validation
+ * endpoint. The role is cryptographically signed into the Firebase token
+ * via custom claims so the middleware can trust it.
  * @param {Object} user - Firebase authenticated user object.
  * @param {string} role - Role assigned to the user.
  * @param {Object} additionalData - Additional profile information.
@@ -82,29 +82,35 @@ export const createUserProfile = async (user, role, additionalData = {}) => {
     throw new Error("Full name is required");
   }
 
-  const userProfile = {
-    uid: user.uid,
-    email: user.email,
-    fullName: fullName.trim(),
-    role,
-    createdAt: new Date(),
-    emailVerified: user.emailVerified,
-    lastLogin: new Date(),
-  };
+  const idToken = await user.getIdToken();
 
-  if (role === USER_ROLES.INSTITUTE) {
-    if (!instituteName?.trim()) {
-      throw new Error("Institute name is required");
-    }
-    userProfile.instituteName = instituteName.trim();
+  const response = await fetch("/api/auth/set-role", {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${idToken}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      role,
+      fullName: fullName.trim(),
+      ...(role === USER_ROLES.INSTITUTE && instituteName?.trim()
+        ? { instituteName: instituteName.trim() }
+        : {}),
+    }),
+  });
+
+  const data = await response.json();
+
+  if (!response.ok || !data.success) {
+    throw new Error(
+      data.error || "Failed to create user profile. Please try again."
+    );
   }
-
-  await setDoc(doc(db, "users", user.uid), userProfile);
 
   // Initialize their empty dashboard stats
   await initializeUserStats(user.uid);
 
-  return userProfile;
+  return data.data.userProfile;
 };
 
 /**


### PR DESCRIPTION
#1236 
## What this fixes

During signup the role (student, teacher, institute, admin) was written directly to Firestore from the client in `createUserProfile` (`utils/authUtils.js:102` via `setDoc`). Admin SDK `setCustomUserClaims()` was never called anywhere in the codebase, so the middleware always fell back to reading the client-written Firestore document — allowing anyone who could manipulate the client-side write to register as any role, including admin.

## Root cause

Two interacting problems: (1) `createUserProfile` wrote the role to Firestore directly from the browser with no server involvement, so the role value came entirely from the signup form without backend validation. (2) `loginWithEmail` and `loginWithGoogle` both used `setDoc` with a spread of the full document on every login, which meant the role field was re-written to Firestore on every authentication event. Since `middleware.js` prioritises `payload.role` from JWT custom claims (which were never set), it always fell through to the Firestore REST API fallback, which returned the client-written role.

## What changed

- **`app/api/auth/set-role/route.js` (new)** — Server-side POST endpoint that authenticates via Firebase ID token, validates role against an allowlist (student, teacher, institute; admin is rejected), calls `admin.auth().setCustomUserClaims()` to cryptographically sign the role into the JWT, and writes the user profile to Firestore authoritatively from the backend.

- **`utils/authUtils.js:78-114`** — `createUserProfile` now calls `POST /api/auth/set-role` with the user's ID token instead of calling `setDoc` directly on Firestore. Server handles both claims and profile write.

- **`services/authService.js:64-84, 233-253`** — Both `loginWithEmail` and `loginWithGoogle` changed from `setDoc(doc(...), { ...userData, lastLogin })` (which overwrites the entire document including role) to `updateDoc(doc(...), { lastLogin })` (which updates only the lastLogin field).

- **`services/authService.js:70-84, 239-253`** — A fire-and-forget call to `/api/auth/set-role` is made during login so existing users gradually receive custom claims without requiring a separate migration.

## How to verify

1. Attempt to sign up with role set to "admin" via DevTools — the `POST /api/auth/set-role` endpoint will reject it with a 400 (role not in allowlist).
2. Verify that `admin.auth().setCustomUserClaims(uid, { role })` is called during signup by adding a log to the endpoint.
3. Observe that the login flow no longer calls `setDoc` with spread — Firestore should only receive an `updateDoc` for `lastLogin`.
4. Confirm existing users who log in after the deploy have their role claim populated in their Firebase ID token (via `user.getIdTokenResult()`).

## Edge cases considered

- **Admin signup** — Blocked explicitly by the allowlist. Admin accounts would need to be created manually or through a separate mechanism.
- **Existing users without custom claims** — Handled by the fire-and-forget call during login. On first login after deploy, the set-role endpoint establishes their custom claims.
- **Token refresh timing** — New users who sign up may not immediately have custom claims in their current JWT. The middleware's Firestore fallback is preserved for this window (and for users who haven't logged in post-deploy). It will be removed in a follow-up once all users have been migrated.
- **Institute name** — Preserved and passed through to the server endpoint for institute role signups.
- **Login latency** — The set-role call during login is fire-and-forget (`.catch(() => {})`), so it never blocks or fails the login flow.
- **Google signup** — Follows the same `createUserProfile` path that now routes through the server endpoint.