### PR TITLE
fix: duplicate fallbacks key in PWA config

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -7,9 +7,6 @@ const withPWA = withPWAInit({
     document: "/~offline",
   },
   disable: process.env.NODE_ENV === "development",
-  fallbacks: {
-    document: "/offline.html",
-  },
   register: true,
   skipWaiting: true,
   reloadOnOnline: true,


### PR DESCRIPTION
## 🎯 Purpose of this Pull Request
This PR fixes a bug in the Next.js PWA configuration where the fallbacks key was duplicated inside the withPWAInit options object.

Previously, the configuration object defined fallbacks twice (pointing to /~offline and /offline.html), which causes JavaScript to overwrite the first key with the second one. This PR consolidates the configuration by removing the duplicate key to ensure the correct offline fallback document is mapped accurately

## 🔗 Related Issue / Link
Fixes #1289 

## 🛠️ Description of Changes
Removed the duplicate fallbacks key containing document: "/offline.html" from next.config.mjs.

## 🧪 Verification / Testing Done
How did you test your changes? Mention exact steps, browsers used, or automation test suites run:
- [x] Rendered locally and checked dark/light modes.
- [ ] Tested on Chrome/Safari/Firefox.
- [x] Ran relevant linters or unit tests (`npm run lint` / `npm test`).


## 📋 Checklist
Before submitting, please make sure you check the following:
- [x] My code follows the code style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation accordingly.
- [x] My changes generate no new warnings or console errors.
- [x] I have deleted any temporary or debugging console logs.
