### PR TITLE
fix: improve text contrast on auth page for light mode

### DIFF
--- a/components/AuthForm.js
+++ b/components/AuthForm.js
@@ -81,8 +81,8 @@ export default function AuthForm({
                   >
                     <IconComponent className="w-6 h-6 text-white" />
                   </div>
-                  <div className="text-left">
-                    <h4 className="font-semibold text-white">{config.title}</h4>
+                    <div className="text-left">
+                    <h4 className="font-semibold text-card-foreground">{config.title}</h4>
                     <p className="text-muted-foreground text-sm">
                       Click to change role
                     </p>

--- a/components/HeroSection.js
+++ b/components/HeroSection.js
@@ -17,7 +17,7 @@ export default function HeroSection({ selectedRole }) {
         </div>
 
         {/* Heading */}
-        <h1 className="text-4xl md:text-5xl lg:text-6xl font-bold leading-tight text-white">
+        <h1 className="text-4xl md:text-5xl lg:text-6xl font-bold leading-tight text-foreground">
           Transforming Education
         </h1>
 


### PR DESCRIPTION
## Description
Fixed contrast issues on the `/auth` page that made text invisible in light mode.

@Premshaw23 , Approve this UNDER GSSoC 26' , closes #1288 
## Changes
- **`components/AuthForm.js`** — Changed the role selection button heading from `text-white` to `text-card-foreground`. The button uses `bg-card`, which is light gray in light mode, making white text unreadable. `text-card-foreground` correctly adapts to both themes.
- **`components/HeroSection.js`** — Changed "Transforming Education" heading from `text-white` to `text-foreground`. The page background is white in light mode, making white text invisible.
## Before/After
| Mode | Before | After |
|------|--------|-------|
| Light | White text on light gray/white backgrounds — invisible | Dark text properly visible |
| Dark | White text on dark backgrounds — fine (unchanged) | Light text on dark backgrounds — fine (unchanged) |
<img width="1919" height="913" alt="Screenshot 2026-05-25 171303" src="https://github.com/user-attachments/assets/03dcd7ca-5358-42f1-91cb-8c4dc8047d1d" />
<img width="1919" height="1079" alt="Screenshot 2026-05-25 175726" src="https://github.com/user-attachments/assets/7a22bd02-61c8-4be0-b4e8-e8bd0914b25c" />
