### PR TITLE
Fix the chatbot meassage visibility in light and dark mode

### DIFF
--- a/components/ChatBot.js
+++ b/components/ChatBot.js
@@ -251,7 +251,7 @@ const CodeBlock = ({ language, code }) => {
 // ---------------------------------------------------------------------------
 const markdownComponents = {
   p: ({ children }) => (
-    <p className="my-2 text-sm leading-relaxed text-gray-200 last:mb-0">{children}</p>
+    <p className="my-2 text-sm leading-relaxed text-black dark:text-white last:mb-0">{children}</p>
   ),
   strong: ({ children }) => (
     <strong className="font-semibold text-purple-400">{children}</strong>


### PR DESCRIPTION
## 🎯 Purpose of this Pull Request
This PR fixes the chatbot message visibility in light and dark mode.

## 🔗 Related Issue / Link
Fixes #1254

## 🛠️ Description of Changes
List the major changes introduced by this PR:
- Change the text message to black in light mode
- White in dark mode

## 🧪 Verification / Testing Done
How did you test your changes? Mention exact steps, browsers used, or automation test suites run:
- [X] Rendered locally and checked dark/light modes.
- [X] Tested on Chrome/Safari/Firefox.

## 📸 Screenshots / GIFs

<img width="1910" height="975" alt="Screenshot 2026-05-25 182230" src="https://github.com/user-attachments/assets/0db35b64-977f-4052-ab11-a4d3f52db604" />

<img width="1910" height="975" alt="Screenshot 2026-05-25 182221" src="https://github.com/user-attachments/assets/df6496f7-1931-493b-88e2-2ece5e3eea52" />

## 📋 Checklist
Before submitting, please make sure you check the following:
- [X] My code follows the code style guidelines of this project.
- [X] I have performed a self-review of my own code.
- [X] My changes generate no new warnings or console errors.
