### PR TITLE
fix(ui): remove Explore More CTA from auth pages

### DIFF
--- a/components/HeroSection.js
+++ b/components/HeroSection.js
@@ -1,8 +1,11 @@
 "use client";
 
 import { Sparkles, Shield, Zap } from "lucide-react";
+import { usePathname } from "next/navigation";
 
 export default function HeroSection({ selectedRole }) {
+  const pathname = usePathname();
+
   return (
     <div>
       {/* Hero Content */}
@@ -28,14 +31,16 @@ export default function HeroSection({ selectedRole }) {
         </p>
 
         {/* CTA Button */}
-        <div className="mt-8 flex justify-center lg:justify-start">
-          <a
-            href="#mission"
-            className="inline-flex items-center gap-2 px-6 py-3 rounded-full bg-indigo-600 hover:bg-indigo-700 text-white transition-all duration-300 shadow-lg"
-          >
-            Explore More ↓
-          </a>
-        </div>
+        { pathname !== "/auth" && (
+          <div className="mt-8 flex justify-center lg:justify-start">
+            <a
+              href="#mission"
+              className="inline-flex items-center gap-2 px-6 py-3 rounded-full bg-indigo-600 hover:bg-indigo-700 text-white transition-all duration-300 shadow-lg"
+            >
+              Explore More ↓
+            </a>
+          </div>
+        )}
       </div>
 
       {/* Features Grid */}


### PR DESCRIPTION
## 🎯 Purpose of this Pull Request
This PR improves the user experience by removing the "Explore More ↓" CTA from authentication pages where it is not relevant. The CTA is part of the `HeroSection` component and was unintentionally visible on login/signup screens due to component reuse.

## 🔗 Related Issue / Link
Fixes #1281

## 🛠️ Description of Changes
List the major changes introduced by this PR:
- Conditionally rendered "Explore More ↓" CTA in `HeroSection`
- Ensured CTA is not visible on the auth page (`/auth`)

## 🧪 Verification / Testing Done
How did you test your changes? Mention exact steps, browsers used, or automation test suites run:
- [X] Rendered locally and checked dark/light modes.
- [X] Tested on Chrome/Safari/Firefox.
- [ ] Ran relevant linters or unit tests (`npm run lint` / `npm test`).

## 📸 Screenshots / GIFs

_Before_
<img width="1356" height="746" alt="Screenshot From 2026-05-25 19-44-31" src="https://github.com/user-attachments/assets/a19371f4-9061-46d0-9920-0f27a02c81a4" />

_After_
<img width="1356" height="746" alt="Screenshot From 2026-05-25 19-43-51" src="https://github.com/user-attachments/assets/6732dfc6-7565-4fe4-8258-2e3504f941d7" />


## 📋 Checklist
Before submitting, please make sure you check the following:
- [X] My code follows the code style guidelines of this project.
- [X] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation accordingly.
- [X] My changes generate no new warnings or console errors.
- [X] I have deleted any temporary or debugging console logs.

