### PR TITLE
fix(firebase): remove unused auth and firestore imports to resolve tech debt #1073

### DIFF
--- a/lib/firebaseConfig.js
+++ b/lib/firebaseConfig.js
@@ -1,23 +1,8 @@
 import { initializeApp, getApps } from "firebase/app";
 import { getAnalytics } from "firebase/analytics";
-import {
-  getAuth,
-  GoogleAuthProvider,
-  GithubAuthProvider,
-  signInWithPopup,
-  signInWithEmailAndPassword,
-  createUserWithEmailAndPassword,
-  fetchSignInMethodsForEmail,
-  linkWithCredential,
-  sendEmailVerification,
-  browserLocalPersistence,
-  browserSessionPersistence,
-  setPersistence,
-} from "firebase/auth";
+import { getAuth } from "firebase/auth";
 import {
   getFirestore,
-  enableIndexedDbPersistence,
-  CACHE_SIZE_UNLIMITED,
   initializeFirestore,
   persistentLocalCache,
   persistentMultipleTabManager,


### PR DESCRIPTION
This PR cleans up the Firebase configuration by removing unused imports from `firebase/auth` and `firebase/firestore` in `lib/firebaseConfig.js`, resolving unresolved technical debt (#1073).