### PR TITLE
fix: improve PWA install popup responsiveness on mobile

### DIFF
--- a/components/InstallPWA.js
+++ b/components/InstallPWA.js
@@ -85,14 +85,12 @@ export default function InstallPWA() {
 
   return (
     <div
-      className={`fixed bottom-4 right-4 z-50 transition-all duration-500 ease-out transform ${
-        isVisible
+       className={`fixed bottom-4 left-1/2 -translate-x-1/2 sm:left-auto sm:right-4 sm:translate-x-0 z-50 w-[92%] sm:w-auto transition-all duration-500 ease-out transform ${        isVisible
           ? "opacity-100 scale-100 translate-y-0"
           : "opacity-0 scale-95 translate-y-8 pointer-events-none"
       }`}
     >
-      <div className="relative w-full max-w-sm sm:max-w-[360px] mx-auto bg-slate-900/90 backdrop-blur-xl border border-purple-500/20 rounded-2xl shadow-2xl p-5 sm:p-6 overflow-hidden transition-all duration-300 hover:border-purple-500/40 hover:shadow-purple-500/10">
-        {/* Ambient Background Glows */}
+<div className="relative w-full max-w-[340px] sm:max-w-[360px] mx-auto bg-slate-900/90 backdrop-blur-xl border border-purple-500/20 rounded-2xl shadow-2xl p-5 sm:p-6 overflow-hidden transition-all duration-300 hover:border-purple-500/40 hover:shadow-purple-500/10">        {/* Ambient Background Glows */}
         <div className="absolute -top-12 -left-12 h-24 w-24 rounded-full bg-purple-500/10 blur-2xl pointer-events-none" />
         <div className="absolute -bottom-12 -right-12 h-24 w-24 rounded-full bg-blue-500/10 blur-2xl pointer-events-none" />
 
@@ -119,7 +117,8 @@ export default function InstallPWA() {
             </p>
 
             {/* Action Buttons */}
-            <div className="flex gap-2.5 mt-4">
+            <div className="flex flex-col sm:flex-row gap-2.5 mt-4">
+            
               <button
                 onClick={handleInstall}
                 className="flex-1 inline-flex items-center justify-center px-4 py-2 rounded-xl bg-gradient-to-r from-purple-600 to-indigo-600 text-white font-semibold text-xs hover:scale-[1.03] active:scale-[0.97] transition-all duration-300 cursor-pointer shadow-lg shadow-purple-600/20"


### PR DESCRIPTION
## 🎯 Purpose of this Pull Request

This PR improves the responsiveness of the PWA install popup on smaller mobile screens. The popup was overlapping important content on the auth page, affecting usability and visibility.

## 🔗 Related Issue / Link

Fixes #1279

## 🛠️ Description of Changes

* Centered the PWA install popup on smaller screens
* Reduced popup width for better responsiveness
* Improved mobile layout handling
* Updated button layout to stack properly on smaller devices

## 🧪 Verification / Testing Done

* [x] Rendered locally and tested in mobile responsive mode
* [x] Tested on Chrome DevTools using Samsung Galaxy A51/71 viewport
* [x] Verified popup no longer overlaps auth page content
* [x] Checked responsiveness for popup buttons and layout
* [ ] Ran relevant linters or unit tests (`npm run lint` / `npm test`)

## 📸 Screenshots / GIFs

Added screenshots showing the improved responsive behavior on smaller mobile screens.

## 📋 Checklist

* [x] My code follows the code style guidelines of this project.
* [x] I have performed a self-review of my own code.
* [ ] I have commented my code, particularly in hard-to-understand areas.
* [ ] I have updated the documentation accordingly.
* [x] My changes generate no new warnings or console errors.
* [x] I have deleted any temporary or debugging console logs.
<img width="1920" height="1080" alt="Screenshot (2464)" src="https://github.com/user-attachments/assets/75dfdd41-767d-43cc-a23d-ce02b8472f9e" />
<img width="1920" height="1080" alt="Screenshot (2453)" src="https://github.com/user-attachments/assets/b08e6026-a56b-4685-9e0d-34a792ffa0c8" />

