### PR TITLE
feat(ui): add skeleton loaders for data-fetching pages

### DIFF
--- a/app/courses/loading.jsx
+++ b/app/courses/loading.jsx
@@ -1,0 +1,69 @@
+import React from "react";
+import Skeleton from "@/components/ui/Skeleton";
+
+/**
+ * CoursesLoading Component
+ * Next.js loading convention segment for the course directories.
+ * Displays a structured layout including header titles, filter categories,
+ * and a responsive grid of card placeholders.
+ */
+export default function CoursesLoading() {
+  return (
+    <div className="min-h-screen bg-slate-950 text-white p-6 space-y-8 pt-24 relative overflow-hidden">
+      {/* Background glow orbs */}
+      <div className="fixed inset-0 bg-[radial-gradient(ellipse_at_top,_var(--tw-gradient-stops))] from-blue-900/10 via-slate-950 to-slate-950 -z-10 pointer-events-none" />
+
+      {/* Directory Title and Search */}
+      <div className="max-w-7xl mx-auto space-y-4">
+        <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4">
+          <div className="space-y-2">
+            <Skeleton className="h-8 w-48 bg-slate-800/80" />
+            <Skeleton className="h-4 w-72 bg-slate-800/50" />
+          </div>
+          <Skeleton className="h-10 w-full sm:w-64 bg-slate-800/60 rounded-xl" />
+        </div>
+        <div className="flex gap-2 flex-wrap">
+          <Skeleton className="h-8 w-16 bg-slate-800/50 rounded-full" />
+          <Skeleton className="h-8 w-24 bg-slate-800/50 rounded-full" />
+          <Skeleton className="h-8 w-20 bg-slate-800/50 rounded-full" />
+        </div>
+      </div>
+
+      {/* Responsive Grid of Course Cards */}
+      <div className="max-w-7xl mx-auto grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+        {Array.from({ length: 6 }).map((_, i) => (
+          <div
+            key={i}
+            className="bg-white/5 border border-white/10 rounded-2xl p-5 space-y-4 flex flex-col justify-between backdrop-blur-md shadow-lg"
+          >
+            <div className="space-y-3">
+              {/* Card Image Placeholder */}
+              <Skeleton className="w-full h-40 bg-slate-800/70 rounded-xl" />
+              
+              {/* Category tag */}
+              <Skeleton className="h-5 w-20 bg-slate-800/50 rounded-lg" />
+
+              {/* Title */}
+              <Skeleton className="h-6 w-3/4 bg-slate-800/80" />
+              
+              {/* Description */}
+              <div className="space-y-1.5 pt-1">
+                <Skeleton className="h-3 w-full bg-slate-800/40" />
+                <Skeleton className="h-3 w-5/6 bg-slate-800/40" />
+              </div>
+            </div>
+
+            {/* Bottom info section */}
+            <div className="flex items-center justify-between border-t border-white/5 pt-4 mt-2">
+              <div className="flex items-center gap-2">
+                <Skeleton className="w-6 h-6 rounded-full bg-slate-800/60" />
+                <Skeleton className="h-3.5 w-16 bg-slate-800/50" />
+              </div>
+              <Skeleton className="h-8 w-20 bg-slate-800/60 rounded-lg" />
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/app/dashboard/loading.jsx
+++ b/app/dashboard/loading.jsx
@@ -1,0 +1,79 @@
+import React from "react";
+import Skeleton from "@/components/ui/Skeleton";
+
+/**
+ * DashboardLoading Component
+ * Next.js loading convention segment for the dashboard pages.
+ * Displays structural grid skeletons mimicking widgets, charts, and data panels.
+ */
+export default function DashboardLoading() {
+  return (
+    <div className="min-h-screen bg-slate-950 text-white p-6 space-y-8 pt-24 relative overflow-hidden">
+      {/* Background glow orbs */}
+      <div className="fixed inset-0 bg-[radial-gradient(ellipse_at_top,_var(--tw-gradient-stops))] from-purple-900/10 via-slate-950 to-slate-950 -z-10 pointer-events-none" />
+
+      {/* Header skeleton */}
+      <div className="max-w-7xl mx-auto bg-white/5 border border-white/10 rounded-2xl p-6 backdrop-blur-md flex flex-col md:flex-row md:items-center justify-between gap-6 shadow-2xl">
+        <div className="flex items-center gap-4">
+          <Skeleton className="w-12 h-12 rounded-xl bg-slate-800/80" />
+          <div className="space-y-2">
+            <Skeleton className="h-5 w-40 bg-slate-800/80" />
+            <Skeleton className="h-3.5 w-60 bg-slate-800/50" />
+          </div>
+        </div>
+        <div className="flex items-center gap-3">
+          <Skeleton className="h-10 w-28 bg-slate-800/60 rounded-xl" />
+          <Skeleton className="h-10 w-10 bg-slate-800/60 rounded-xl" />
+        </div>
+      </div>
+
+      {/* Main Grid skeleton */}
+      <div className="max-w-7xl mx-auto grid grid-cols-1 md:grid-cols-3 gap-8">
+        {/* Left main content widgets */}
+        <div className="md:col-span-2 space-y-6">
+          {/* Card containing mini widgets */}
+          <div className="bg-white/5 border border-white/10 rounded-2xl p-6 space-y-4">
+            <div className="flex justify-between items-center">
+              <Skeleton className="h-6 w-32 bg-slate-800/80" />
+              <Skeleton className="h-4 w-16 bg-slate-800/60" />
+            </div>
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+              <Skeleton className="h-28 bg-slate-800/60 rounded-xl" />
+              <Skeleton className="h-28 bg-slate-800/60 rounded-xl" />
+            </div>
+          </div>
+
+          {/* List panel */}
+          <div className="bg-white/5 border border-white/10 rounded-2xl p-6 space-y-4">
+            <Skeleton className="h-6 w-48 bg-slate-800/80" />
+            <div className="space-y-3">
+              <Skeleton className="h-12 bg-slate-800/50 rounded-xl" />
+              <Skeleton className="h-12 bg-slate-800/50 rounded-xl" />
+              <Skeleton className="h-12 bg-slate-800/50 rounded-xl" />
+            </div>
+          </div>
+        </div>
+
+        {/* Right sidebar widgets */}
+        <div className="space-y-6">
+          {/* Sidebar widget 1 */}
+          <div className="bg-white/5 border border-white/10 rounded-2xl p-6 space-y-4">
+            <Skeleton className="h-6 w-36 bg-slate-800/80" />
+            <Skeleton className="h-40 bg-slate-800/60 rounded-xl" />
+          </div>
+
+          {/* Sidebar widget 2 */}
+          <div className="bg-white/5 border border-white/10 rounded-2xl p-6 space-y-4">
+            <div className="flex items-center gap-3">
+              <Skeleton className="w-10 h-10 rounded-full bg-slate-800/80" />
+              <div className="space-y-2 flex-1">
+                <Skeleton className="h-4 w-full bg-slate-800/80" />
+                <Skeleton className="h-3 w-2/3 bg-slate-800/50" />
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/ui/Skeleton.jsx
+++ b/components/ui/Skeleton.jsx
@@ -1,0 +1,19 @@
+import React from "react";
+import { cn } from "@/lib/utils";
+
+/**
+ * Skeleton Component
+ * Generic, pulse-animated placeholder block for loading states.
+ * Merges incoming Tailwind styles using standard `cn` utility.
+ */
+export default function Skeleton({ className, ...props }) {
+  return (
+    <div
+      className={cn(
+        "animate-pulse rounded-md bg-gray-200 dark:bg-zinc-800/60",
+        className
+      )}
+      {...props}
+    />
+  );
+}


### PR DESCRIPTION
## 🎯 Purpose of this Pull Request
This Pull Request significantly improves the application's perceived performance and User Experience (UX). By introducing Next.js `loading.jsx` boundaries and animated skeleton components, users are immediately provided with visual feedback and a structural layout outline while server-side data is actively being fetched, eliminating frustrating blank screens.

## 🔗 Related Issue / Link
Fixes #1311

## 🛠️ Description of Changes
List the major changes introduced by this PR:
- **Skeleton Component:** Created a highly reusable `<Skeleton />` UI component utilizing Tailwind's `animate-pulse` utility.
- **Dashboard Loading State:** Added `app/dashboard/loading.jsx` to immediately render a mock layout of the dashboard widgets while user data loads.
- **Courses Loading State:** Added `app/courses/loading.jsx` to render a responsive grid of skeleton cards, matching the dimensions of the actual course list items.

## 🧪 Verification / Testing Done
How did you test your changes? Mention exact steps, browsers used, or automation test suites run:
- [x] Rendered locally and checked dark/light modes.
- [x] Tested on Chrome/Safari/Firefox.
- [ ] Ran relevant linters or unit tests (`npm run lint` / `npm test`).

*Testing Steps:* Opened the browser's Developer Tools (Network tab) and throttled the connection to "Slow 3G". Navigated to the Dashboard and Course Library routes to verify that the skeleton layouts rendered immediately and smoothly pulsed until the artificial network delay completed and the real data hydrated the screen.

## 📸 Screenshots / GIFs
If this PR changes or introduces any UI components, please add screenshots or a short GIF showing the before and after states.

*(You can drag and drop a short GIF demonstrating the skeleton loaders active during a page transition here)*

## 📋 Checklist
Before submitting, please make sure you check the following:
- [x] My code follows the code style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation accordingly.
- [x] My changes generate no new warnings or console errors.
- [x] I have deleted any temporary or debugging console logs.