### PR TITLE
Fix hydration mismatch warning caused by next-themes

### DIFF
--- a/app/layout.js
+++ b/app/layout.js
@@ -236,6 +236,7 @@ export default function RootLayout({ children }) {
         />
       </head>
       <body
+        suppressHydrationWarning
         className={`font-sans ${geistSans.variable} ${geistMono.variable} antialiased bg-background text-foreground min-h-screen transition-colors duration-300`}
       >
         <a


### PR DESCRIPTION
## 🎯 Purpose of this Pull Request
This PR suppresses the expected hydration mismatch warning caused by `next-themes` in the Next.js App Router setup.

The warning occurred because the server-rendered theme and client-rendered theme differed during hydration, leading to unnecessary console warnings during development.

---

## 🔗 Related Issue / Link
Fixes #1383 

---

## 🛠️ Description of Changes
- Added `suppressHydrationWarning` to the theme-rendered element in `app/layout.js`
- Reduced unnecessary React hydration warnings in the browser console
- Preserved existing dark/light theme functionality without affecting UI behavior

---

## 🧪 Verification / Testing Done
- [x] Rendered locally and checked dark/light modes
- [x] Tested in Chrome
- [x] Verified hydration warnings no longer appear in console
- [x] Confirmed no UI or theme functionality was affected
- [x] Ran project locally using `npm run dev`

---

## 📋 Checklist
- [x] My code follows the code style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings or console errors
- [x] I have deleted any temporary or debugging console logs