### PR TITLE
fix(auth): use merge: true when updating user role to avoid overwriting data.

### DIFF
--- a/app/api/auth/set-role/route.js
+++ b/app/api/auth/set-role/route.js
@@ -55,7 +55,7 @@ export const POST = withErrorHandler(async (request) => {
     .firestore()
     .collection("users")
     .doc(decodedToken.uid)
-    .set(userProfile);
+    .set(userProfile, { merge: true });
 
   return jsonSuccess({ userProfile }, 201);
 });


### PR DESCRIPTION
## 🎯 Purpose of this Pull Request
This PR fixes a critical data overwrite issue in the `/api/auth/set-role` endpoint. Previously, the endpoint updated a user's role using Firestore's `.set(userProfile)` without the merge option, which completely overwrote the entire existing user document. This effectively wiped out any of the user's previously saved preferences, historical data, and other custom attributes. 
By adding the `{ merge: true }` option, the endpoint now safely merges the updated role and user fields while preserving all other pre-existing data in the user's Firestore document.

## 🔗 Related Issue / Link
Fixes #1364 

## 🛠️ Description of Changes
- Modified the Firestore document update logic in `app/api/auth/set-role/route.js`.
- Added `{ merge: true }` to the `.set()` method to ensure partial updates instead of complete document overwrites.

## 🧪 Verification / Testing Done
How did you test your changes? Mention exact steps, browsers used, or automation test suites run:
- [ ] Rendered locally and checked dark/light modes.
- [ ] Tested on Chrome/Safari/Firefox.
- [x] Ran relevant linters or unit tests (`npm run lint` / `npm test`).

## 📋 Checklist
Before submitting, please make sure you check the following:
- [x] My code follows the code style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation accordingly.
- [x] My changes generate no new warnings or console errors.
- [x] I have deleted any temporary or debugging console logs.
