### PR TITLE
perf(leaderboard): optimize user details fetch with Promise.all to resolve N+1 queries

### DIFF
--- a/app/leaderboards/page.js
+++ b/app/leaderboards/page.js
@@ -90,10 +90,7 @@ export default function LeaderboardsPage() {
         const q = query(collection(db, "userStats"), orderBy("totalXp", "desc"), limit(50));
         const snapshot = await getDocs(q);
         
-        const fetchedData = [];
-        let currentRank = 1;
-        
-        for (const docSnap of snapshot.docs) {
+        const fetchedData = await Promise.all(snapshot.docs.map(async (docSnap, index) => {
           const stats = docSnap.data();
           const userId = docSnap.id;
           
@@ -106,18 +103,18 @@ export default function LeaderboardsPage() {
             console.warn("Could not fetch user details for", userId);
           }
           
-          fetchedData.push({
+          return {
             id: userId,
             name: userData.displayName || "Unknown Learner",
             score: stats.totalXp || stats.score || 0,
             avatar: userData.photoURL || "👩‍🎓",
-            rank: currentRank++,
+            rank: index + 1,
             change: "same",
             streak: stats.currentStreak || stats.streak || 0,
             badges: stats.badges || (stats.unlockedBadges ? stats.unlockedBadges.length : 0),
             isCurrentUser: user?.uid === userId
-          });
-        }
+          };
+        }));
         
         if (fetchedData.length > 0) {
           setLeaderboardData(fetchedData);


### PR DESCRIPTION
## 🎯 Purpose of this Pull Request
This PR addresses an N+1 query performance bottleneck on the `/leaderboards` page. 
Previously, the app fetched the top 50 `userStats` documents and then used a sequential `for...of` loop to `await getDoc()` for each individual user's profile details. This caused a waterfall of network requests that significantly slowed down the page load.
By refactoring the sequential loop into an array of Promises and executing them concurrently with `Promise.all()`, the network requests for user profiles are now dispatched in parallel. This dramatically reduces network latency and improves overall rendering speed.

## 🔗 Related Issue / Link
Fixes #1365 

## 🛠️ Description of Changes
- Refactored the `fetchLeaderboard` logic in `app/leaderboards/page.js`.
- Replaced the `for...of` loop with a `.map()` that generates an array of fetch Promises.
- Used `await Promise.all()` to resolve the user detail queries concurrently.

## 🧪 Verification / Testing Done
How did you test your changes? Mention exact steps, browsers used, or automation test suites run:
- [ ] Rendered locally and checked dark/light modes.
- [ ] Tested on Chrome/Safari/Firefox.
- [x] Ran relevant linters or unit tests (`npm run lint` / `npm test`).

## 📋 Checklist
Before submitting, please make sure you check the following:
- [x] My code follows the code style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation accordingly.
- [x] My changes generate no new warnings or console errors.
- [x] I have deleted any temporary or debugging console logs.
