### PR TITLE
fix(attendance): prevent duplicate attendance records during retry/sync flows (#1233)

### DIFF
--- a/app/api/attendance/record/route.js
+++ b/app/api/attendance/record/route.js
@@ -34,7 +34,7 @@ export const POST = withErrorHandler(async (request) => {
   const normalizedConfidence = parsedConfidence / 100;
 
   // 4. Write attendance to Firestore (single source of truth).
-  // Use a deterministic doc id to prevent duplicates and match client duplicate checks.
+  // Use a deterministic doc id and a transaction to prevent duplicates and match client duplicate checks.
   initFirebaseAdmin();
   const db = getFirestore();
   const userProfile = await getUserProfile(decodedToken.uid);
@@ -42,10 +42,18 @@ export const POST = withErrorHandler(async (request) => {
   const resolvedName = userProfile?.fullName || userProfile?.displayName || studentName;
   const resolvedEmail = userProfile?.email || email;
 
-  await db
-    .collection("attendance_records")
-    .doc(`${userId}_${normalizedDate}`)
-    .set(
+  const docRef = db.collection("attendance_records").doc(`${userId}_${normalizedDate}`);
+
+  let alreadyRecorded = false;
+  await db.runTransaction(async (transaction) => {
+    const existingDoc = await transaction.get(docRef);
+    if (existingDoc.exists) {
+      alreadyRecorded = true;
+      return;
+    }
+
+    transaction.set(
+      docRef,
       {
         userId,
         studentName: resolvedName,
@@ -59,6 +67,11 @@ export const POST = withErrorHandler(async (request) => {
       },
       { merge: true },
     );
+  });
+
+  if (alreadyRecorded) {
+    return jsonSuccess({ alreadyRecorded: true }, 200);
+  }
 
   // Gamification is a side effect — failures must not block attendance recording
   try {

--- a/app/api/attendance/record/route.test.js
+++ b/app/api/attendance/record/route.test.js
@@ -14,6 +14,10 @@ jest.mock("@/lib/firebase-admin", () => ({
   getUserProfile: jest.fn(),
 }));
 
+jest.mock("@/lib/gamification-service", () => ({
+  awardXp: jest.fn(),
+}));
+
 jest.mock("firebase-admin/firestore", () => ({
   getFirestore: jest.fn(),
   FieldValue: {
@@ -35,7 +39,7 @@ describe("attendance record route", () => {
     jest.clearAllMocks();
   });
 
-  test("writes attendance to Firestore with canonical doc id + instituteId", async () => {
+  test("writes attendance to Firestore with canonical doc id + instituteId using transaction", async () => {
     authenticateRequest.mockResolvedValue({ uid: "user-123" });
     parseJSON.mockResolvedValue({
       userId: "user-123",
@@ -51,11 +55,15 @@ describe("attendance record route", () => {
       instituteId: "inst-999",
     });
 
-    const set = jest.fn().mockResolvedValue(undefined);
-    const docRef = { set };
+    const docRef = {};
     const collectionRef = { doc: jest.fn(() => docRef) };
+    const transactionSet = jest.fn();
+    const transactionGet = jest.fn().mockResolvedValue({ exists: false });
 
     getFirestore.mockReturnValue({
+      runTransaction: jest.fn(async (callback) => {
+        return callback({ get: transactionGet, set: transactionSet });
+      }),
       collection: jest.fn(() => collectionRef),
     });
 
@@ -71,7 +79,9 @@ describe("attendance record route", () => {
     });
 
     expect(collectionRef.doc).toHaveBeenCalledWith("user-123_2026-05-25");
-    expect(set).toHaveBeenCalledWith(
+    expect(transactionGet).toHaveBeenCalledWith(docRef);
+    expect(transactionSet).toHaveBeenCalledWith(
+      docRef,
       expect.objectContaining({
         userId: "user-123",
         studentName: "Server Name",
@@ -86,5 +96,48 @@ describe("attendance record route", () => {
       { merge: true },
     );
   });
-});
 
+  test("prevents duplicate check-in if document already exists", async () => {
+    authenticateRequest.mockResolvedValue({ uid: "user-123" });
+    parseJSON.mockResolvedValue({
+      userId: "user-123",
+      studentName: "Client Name",
+      email: "client@example.com",
+      confidenceScore: 80,
+      date: "2026-05-25",
+    });
+
+    getUserProfile.mockResolvedValue({
+      fullName: "Server Name",
+      email: "server@example.com",
+      instituteId: "inst-999",
+    });
+
+    const docRef = {};
+    const collectionRef = { doc: jest.fn(() => docRef) };
+    const transactionSet = jest.fn();
+    const transactionGet = jest.fn().mockResolvedValue({ exists: true });
+
+    getFirestore.mockReturnValue({
+      runTransaction: jest.fn(async (callback) => {
+        return callback({ get: transactionGet, set: transactionSet });
+      }),
+      collection: jest.fn(() => collectionRef),
+    });
+
+    const response = await POST({
+      headers: new Headers([["authorization", "Bearer test"]]),
+      cookies: { get: jest.fn() },
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      success: true,
+      data: { alreadyRecorded: true },
+    });
+
+    expect(collectionRef.doc).toHaveBeenCalledWith("user-123_2026-05-25");
+    expect(transactionGet).toHaveBeenCalledWith(docRef);
+    expect(transactionSet).not.toHaveBeenCalled();
+  });
+});

--- a/app/api/attendance/record/route.test.js
+++ b/app/api/attendance/record/route.test.js
@@ -140,4 +140,93 @@ describe("attendance record route", () => {
     expect(transactionGet).toHaveBeenCalledWith(docRef);
     expect(transactionSet).not.toHaveBeenCalled();
   });
+
+  test("simulates concurrent double-click requests and guarantees single write via OCC retry simulation", async () => {
+    authenticateRequest.mockResolvedValue({ uid: "user-123" });
+    parseJSON.mockResolvedValue({
+      userId: "user-123",
+      studentName: "Client Name",
+      email: "client@example.com",
+      confidenceScore: 75,
+      date: "2026-05-25",
+    });
+
+    getUserProfile.mockResolvedValue({
+      fullName: "Server Name",
+      email: "server@example.com",
+      instituteId: "inst-999",
+    });
+
+    const docRef = "user-123_2026-05-25";
+    const collectionRef = { doc: jest.fn(() => docRef) };
+
+    const dbStore = new Map();
+    const transactionSet = jest.fn();
+
+    // High-fidelity OCC Simulation:
+    // If two requests read concurrently, both see 'exists === false'.
+    // One succeeds, writes to the dbStore.
+    // The second transaction will detect that the store has been updated since its read phase,
+    // abort, retry, read again, see 'exists === true', and return without writing.
+    const runTransaction = jest.fn(async (callback) => {
+      let attempts = 0;
+      while (attempts < 5) {
+        attempts++;
+        // Interleave the operations with a small async tick
+        await new Promise((resolve) => setTimeout(resolve, 5));
+
+        const get = async (ref) => ({ exists: dbStore.has(ref) });
+
+        let pendingWrite = null;
+        const set = (ref, data) => {
+          pendingWrite = { ref, data };
+        };
+
+        await callback({ get, set });
+
+        if (pendingWrite) {
+          if (dbStore.has(pendingWrite.ref)) {
+            // Collision detected - retry callback!
+            continue;
+          }
+          // Successful transaction commit
+          dbStore.set(pendingWrite.ref, pendingWrite.data);
+          transactionSet(pendingWrite.ref, pendingWrite.data);
+        }
+        break;
+      }
+    });
+
+    getFirestore.mockReturnValue({
+      runTransaction,
+      collection: jest.fn(() => collectionRef),
+    });
+
+    // Execute double-click / rapid concurrent requests in parallel
+    const [response1, response2] = await Promise.all([
+      POST({
+        headers: new Headers([["authorization", "Bearer test"]]),
+        cookies: { get: jest.fn() },
+      }),
+      POST({
+        headers: new Headers([["authorization", "Bearer test"]]),
+        cookies: { get: jest.fn() },
+      }),
+    ]);
+
+    // One of the concurrent requests must succeed and create (201), the other should return alreadyRecorded (200)
+    const statusCodes = [response1.status, response2.status].sort();
+    expect(statusCodes).toEqual([200, 201]);
+
+    const resJson1 = await response1.json();
+    const resJson2 = await response2.json();
+
+    const results = [resJson1.data.alreadyRecorded, resJson2.data.alreadyRecorded].sort();
+    expect(results).toEqual([false, true]);
+
+    // Firestore must have exactly 1 record committed
+    expect(dbStore.size).toBe(1);
+    expect(dbStore.has(docRef)).toBe(true);
+    expect(transactionSet).toHaveBeenCalledTimes(1);
+  });
 });

--- a/services/attendanceService.js
+++ b/services/attendanceService.js
@@ -112,10 +112,13 @@ export async function recordAttendance({
     );
   }
 
-  const newRate = await recalculateAttendanceRate(userId);
+  const data = await response.json();
+  const isAlreadyRecorded = !!(data && data.alreadyRecorded);
+
+  const newRate = isAlreadyRecorded ? null : await recalculateAttendanceRate(userId);
 
   return {
-    alreadyRecorded: false,
+    alreadyRecorded: isAlreadyRecorded,
     newRate,
   };
 }


### PR DESCRIPTION
## 🎯 Purpose of this Pull Request

This PR resolves a backend attendance reliability issue where repeated submissions, offline replay synchronization, or rapid double-click requests could trigger duplicate attendance side effects and inconsistent attendance analytics.

The root cause was a non-atomic attendance persistence flow that allowed concurrent requests to bypass duplicate checks and execute reward/stat update logic multiple times in parallel.

The implementation now introduces transactional concurrency protection using Firestore transactions to guarantee a single attendance source of truth during concurrent check-in flows.

---

## 🔗 Related Issue / Link

Fixes #1233

---

## 🛠️ Description of Changes

### Backend Attendance Atomicity
- refactored attendance writes in `app/api/attendance/record/route.js`
- replaced direct `.set(..., { merge: true })` writes with `db.runTransaction(...)`
- added transactional existence checks before attendance creation
- prevented duplicate attendance writes during concurrent requests
- blocked duplicate `awardXp()` side-effect execution

### Frontend Attendance Consistency
- updated `services/attendanceService.js`
- added support for `alreadyRecorded` response handling
- prevented redundant attendance stats recalculations for duplicate submissions
- preserved existing attendance UX behavior

### Test Suite Improvements
- expanded `app/api/attendance/record/route.test.js`
- added high-fidelity optimistic concurrency control (OCC) retry simulation tests
- verified concurrent double-click/replay scenarios
- validated single-write guarantees under parallel execution

---

## 🧪 Verification / Testing Done

- [x] Fetched and rebased with the latest `main` branch before implementation
- [x] Reproduced duplicate attendance behavior before applying the fix
- [x] Verified concurrent requests no longer create duplicate logical attendance entries
- [x] Verified duplicate XP side-effects are suppressed
- [x] Verified offline replay synchronization still functions correctly
- [x] Verified analytics calculations remain consistent
- [x] Verified no unrelated attendance flows were affected

### Test Suites Executed

```bash
npm test -- app/api/attendance/record/route.test.js
npm test -- app/api/attendance/sync/route.test.js
npm test -- services/__tests__/statsService.test.js
```

### Runtime Scenarios Tested

- normal attendance submission
- repeated attendance submission
- rapid double-click requests
- offline replay synchronization
- optimistic concurrency retry simulation
- delayed retry flows

---

## 📸 Screenshots / GIFs

N/A — Backend attendance reliability and concurrency consistency fix

---

## 📋 Checklist

- [x] My code follows the code style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings or console errors.
- [x] I have deleted any temporary or debugging console logs.
- [x] Existing attendance flows and response contracts were preserved.
- [x] The implementation follows existing backend architecture patterns.
- [x] No unnecessary architectural rewrites were introduced.
- [x] Concurrency and replay flows were tested thoroughly.

---

This implementation intentionally keeps the fix localized and transaction-safe while preserving the existing attendance architecture and offline synchronization behavior.