### PR TITLE
Remove hardcoded mock data fallbacks from admin and institute stats routes

### DIFF
--- a/app/api/admin/stats/route.js
+++ b/app/api/admin/stats/route.js
@@ -10,18 +10,16 @@ export const GET = withErrorHandler(async (request) => {
 
   const db = admin.firestore();
 
-  // 1. Get total users count from Firestore users collection
-  let totalUsers = 52350;
+  let totalUsers = 0;
+  let institutes = [];
+  let systemMetrics = null;
+  let criticalAlerts = [];
+  let featureUsage = null;
+
   try {
     const usersCountSnap = await db.collection("users").count().get();
-    totalUsers = usersCountSnap.data().count || totalUsers;
-  } catch (err) {
-    console.error("Error fetching total users count from Firestore:", err);
-  }
+    totalUsers = usersCountSnap.data().count || 0;
 
-  // 2. Fetch institutes list, fallback if empty
-  let institutes = [];
-  try {
     const instSnapshot = await db.collection("institutes").get();
     if (!instSnapshot.empty) {
       institutes = instSnapshot.docs.map((doc) => ({
@@ -29,85 +27,12 @@ export const GET = withErrorHandler(async (request) => {
         ...doc.data(),
       }));
     }
-  } catch (err) {
-    console.error("Error fetching institutes from Firestore:", err);
-  }
 
-  if (institutes.length === 0) {
-    institutes = [
-      {
-        id: "dtu",
-        name: "Delhi Technical University",
-        status: "active",
-        students: 3500,
-        teachers: 120,
-        plan: "Premium",
-        storage: "1.2TB",
-        apiCalls: 125000,
-        lastActive: "2 mins ago",
-        healthScore: 98,
-        payment: "paid",
-        issues: 0,
-      },
-      {
-        id: "mit",
-        name: "Mumbai Institute of Technology",
-        status: "active",
-        students: 2800,
-        teachers: 95,
-        plan: "Professional",
-        storage: "980GB",
-        apiCalls: 98000,
-        lastActive: "5 mins ago",
-        healthScore: 95,
-        payment: "paid",
-        issues: 1,
-      },
-      {
-        id: "bsc",
-        name: "Bangalore Science College",
-        status: "suspended",
-        students: 1500,
-        teachers: 60,
-        plan: "Basic",
-        storage: "450GB",
-        apiCalls: 45000,
-        lastActive: "2 days ago",
-        healthScore: 45,
-        payment: "overdue",
-        issues: 3,
-      },
-    ];
-  }
-
-  // 3. Fetch system metrics, fallback if doc doesn't exist
-  let systemMetrics = null;
-  try {
     const metricsDoc = await db.collection("system_metrics").doc("current").get();
     if (metricsDoc.exists) {
       systemMetrics = metricsDoc.data();
     }
-  } catch (err) {
-    console.error("Error fetching system metrics from Firestore:", err);
-  }
 
-  if (!systemMetrics) {
-    systemMetrics = {
-      faceRecognitionAPI: {
-        status: "operational",
-        latency: "120ms",
-        uptime: "99.99%",
-      },
-      gpsService: { status: "operational", latency: "45ms", uptime: "99.95%" },
-      database: { status: "operational", connections: 234, load: "65%" },
-      storage: { total: "100TB", used: "78.4TB", available: "21.6TB" },
-      cdn: { status: "operational", bandwidth: "450 Mbps", cache: "92%" },
-    };
-  }
-
-  // 4. Fetch critical alerts, fallback if empty
-  let criticalAlerts = [];
-  try {
     const alertsSnapshot = await db.collection("critical_alerts").get();
     if (!alertsSnapshot.empty) {
       criticalAlerts = alertsSnapshot.docs.map((doc) => ({
@@ -115,59 +40,19 @@ export const GET = withErrorHandler(async (request) => {
         ...doc.data(),
       }));
     }
-  } catch (err) {
-    console.error("Error fetching critical alerts from Firestore:", err);
-  }
 
-  if (criticalAlerts.length === 0) {
-    criticalAlerts = [
-      {
-        id: 1,
-        type: "security",
-        message:
-          "Multiple failed face recognition attempts detected - Delhi Technical University",
-        severity: "high",
-        time: "10 mins ago",
-      },
-      {
-        id: 2,
-        type: "payment",
-        message: "Payment overdue - Bangalore Science College",
-        severity: "medium",
-        time: "2 days ago",
-      },
-      {
-        id: 3,
-        type: "performance",
-        message: "High API latency detected in Mumbai region",
-        severity: "low",
-        time: "1 hour ago",
-      },
-    ];
-  }
-
-  // 5. Fetch feature usage, fallback if doc doesn't exist
-  let featureUsage = null;
-  try {
     const usageDoc = await db.collection("feature_usage").doc("current").get();
     if (usageDoc.exists) {
       featureUsage = usageDoc.data();
     }
   } catch (err) {
-    console.error("Error fetching feature usage from Firestore:", err);
+    console.error("Error fetching admin stats from Firestore:", err);
+    return NextResponse.json(
+      { error: "Dashboard data temporarily unavailable" },
+      { status: 502 }
+    );
   }
 
-  if (!featureUsage) {
-    featureUsage = {
-      faceRecognition: { enabled: 42, total: 47, percentage: 89 },
-      gpsGeofencing: { enabled: 45, total: 47, percentage: 96 },
-      passcodeSystem: { enabled: 47, total: 47, percentage: 100 },
-      exceptionHandling: { enabled: 38, total: 47, percentage: 81 },
-      analyticsReports: { enabled: 35, total: 47, percentage: 74 },
-    };
-  }
-
-  // Calculate platform stats
   const totalInstitutes = institutes.length;
   const activeInstitutes = institutes.filter((inst) => inst.status === "active").length;
   const pendingIssues = institutes.reduce((sum, inst) => sum + (inst.issues || 0), 0);
@@ -177,12 +62,7 @@ export const GET = withErrorHandler(async (request) => {
     activeInstitutes,
     totalUsers,
     dailyActiveUsers: Math.round(totalUsers * 0.78),
-    faceRecognitionAPICalls: "2.3M",
-    storageUsed: "78.4 TB",
-    systemUptime: "99.97%",
-    revenue: "$124,500",
     pendingIssues,
-    serverLoad: 68,
   };
 
   return NextResponse.json({

--- a/app/api/institute/stats/route.js
+++ b/app/api/institute/stats/route.js
@@ -11,9 +11,12 @@ export const GET = withErrorHandler(async (request) => {
   const db = admin.firestore();
   const uid = decodedToken.uid;
 
-  // 1. Fetch students belonging to this institute
   let studentDocs = [];
   let teacherDocs = [];
+  let classes = [];
+  let attendanceRequests = [];
+  let todayAttendance = 0;
+
   try {
     const studentsSnap = await db
       .collection("users")
@@ -21,46 +24,20 @@ export const GET = withErrorHandler(async (request) => {
       .where("role", "==", "student")
       .get();
     studentDocs = studentsSnap.docs.map((doc) => ({ id: doc.id, ...doc.data() }));
-  } catch (err) {
-    console.error("Error fetching students from Firestore:", err);
-  }
 
-  try {
     const teachersSnap = await db
       .collection("users")
       .where("instituteId", "==", uid)
       .where("role", "==", "teacher")
       .get();
     teacherDocs = teachersSnap.docs.map((doc) => ({ id: doc.id, ...doc.data() }));
-  } catch (err) {
-    console.error("Error fetching teachers from Firestore:", err);
-  }
 
-  // 2. Fetch classes for this institute
-  let classes = [];
-  try {
     const classesSnap = await db
       .collection("classes")
       .where("instituteId", "==", uid)
       .get();
     classes = classesSnap.docs.map((doc) => ({ id: doc.id, ...doc.data() }));
-  } catch (err) {
-    console.error("Error fetching classes from Firestore:", err);
-  }
 
-  // Fallback mock classes if none found in DB
-  if (classes.length === 0) {
-    classes = [
-      { id: 1, name: "Computer Science A", students: 35, teacher: "Dr. Smith", room: "CS-101", time: "09:00-10:30", semester: "4th", section: "A" },
-      { id: 2, name: "Mathematics B", students: 42, teacher: "Prof. Johnson", room: "MATH-201", time: "10:45-12:15", semester: "6th", section: "B" },
-      { id: 3, name: "Physics C", students: 28, teacher: "Dr. Williams", room: "PHY-301", time: "13:30-15:00", semester: "5th", section: "A" },
-      { id: 4, name: "Chemistry A", students: 31, teacher: "Prof. Brown", room: "CHEM-101", time: "15:15-16:45", semester: "3rd", section: "B" },
-    ];
-  }
-
-  // 3. Fetch today's attendance requests for this institute
-  let attendanceRequests = [];
-  try {
     const reqSnap = await db
       .collection("attendance_requests")
       .where("instituteId", "==", uid)
@@ -68,22 +45,7 @@ export const GET = withErrorHandler(async (request) => {
       .limit(20)
       .get();
     attendanceRequests = reqSnap.docs.map((doc) => ({ id: doc.id, ...doc.data() }));
-  } catch (err) {
-    console.error("Error fetching attendance requests from Firestore:", err);
-  }
 
-  // Fallback mock requests if none found
-  if (attendanceRequests.length === 0) {
-    attendanceRequests = [
-      { id: 1, student: "John Doe", rollNo: "CS21B1010", class: "Computer Science A", reason: "Medical emergency", time: "2 hours ago", status: "pending", location: "Home - GPS verified" },
-      { id: 2, student: "Jane Smith", rollNo: "CS21B1015", class: "Mathematics B", reason: "Family emergency", time: "4 hours ago", status: "pending", location: "Hospital - GPS verified" },
-      { id: 3, student: "Mike Johnson", rollNo: "PHY21B1008", class: "Physics C", reason: "Transportation issue", time: "6 hours ago", status: "approved", location: "Bus stop - GPS verified" },
-    ];
-  }
-
-  // 4. Compute today's attendance percentage
-  let todayAttendance = 89.2;
-  try {
     const today = new Date().toISOString().slice(0, 10);
     const attSnap = await db
       .collection("attendance_records")
@@ -94,35 +56,29 @@ export const GET = withErrorHandler(async (request) => {
     const totalStudents = studentDocs.length || 1;
     todayAttendance = Math.round((presentCount / totalStudents) * 1000) / 10;
   } catch (err) {
-    console.error("Error computing today attendance:", err);
+    console.error("Error fetching institute stats from Firestore:", err);
+    return NextResponse.json(
+      { error: "Dashboard data temporarily unavailable" },
+      { status: 502 }
+    );
   }
 
-  // Build teachers list from Firestore or fallback
-  const teachers =
-    teacherDocs.length > 0
-      ? teacherDocs.map((t) => ({
-          id: t.id,
-          name: t.fullName || t.name || "Unknown",
-          email: t.email || "",
-          classes: t.classCount || 0,
-          attendance: t.attendanceRate || "N/A",
-          status: t.status || "active",
-          department: t.department || "General",
-        }))
-      : [
-          { id: 1, name: "Dr. Smith", email: "smith@institute.edu", classes: 3, attendance: "92.1%", status: "active", department: "Computer Science" },
-          { id: 2, name: "Prof. Johnson", email: "johnson@institute.edu", classes: 4, attendance: "88.7%", status: "active", department: "Mathematics" },
-          { id: 3, name: "Dr. Williams", email: "williams@institute.edu", classes: 2, attendance: "94.3%", status: "active", department: "Physics" },
-          { id: 4, name: "Prof. Brown", email: "brown@institute.edu", classes: 3, attendance: "87.9%", status: "active", department: "Chemistry" },
-        ];
+  const teachers = teacherDocs.map((t) => ({
+    id: t.id,
+    name: t.fullName || t.name || "Unknown",
+    email: t.email || "",
+    classes: t.classCount || 0,
+    attendance: t.attendanceRate || "N/A",
+    status: t.status || "active",
+    department: t.department || "General",
+  }));
 
   const dashboardData = {
-    totalStudents: studentDocs.length || 1247,
-    totalTeachers: teacherDocs.length || 45,
-    totalClasses: classes.length || 67,
+    totalStudents: studentDocs.length,
+    totalTeachers: teacherDocs.length,
+    totalClasses: classes.length,
     todayAttendance,
-    weeklyTrend: "+2.4%",
-    activeClasses: classes.filter((c) => c.status === "active").length || 12,
+    activeClasses: classes.filter((c) => c.status === "active").length,
     pendingRequests: attendanceRequests.filter((r) => r.status === "pending").length,
   };
 


### PR DESCRIPTION
## What this fixes

`app/api/admin/stats/route.js` and `app/api/institute/stats/route.js` silently returned hardcoded fabricated data whenever Firestore queries failed or returned empty results. Administrators saw 52,350 fake users, fabricated institutes (Delhi Technical University, Mumbai Institute of Technology) with made-up student counts and payment statuses, fake system metrics (99.99% uptime, $124,500 revenue), and in the institute dashboard, 1,247 students and 45 teachers that never existed.

## Root cause

Every data-fetch in both routes followed the same pattern: initialize a variable with a hardcoded mock value, wrap the Firestore call in a try/catch, and on any failure — silently keep the mock. Post-fetch checks then replaced empty results with realistic-looking fake objects (classes, teachers, attendance requests). The response carried zero indication that any of this data was fabricated.

## What changed

- **`app/api/admin/stats/route.js`**: Merged five individual try/catch blocks into one. Removed hardcoded fallback objects for institutes (DTU/MIT/BSC), system metrics (99.99% uptime, 78.4TB storage), critical alerts, and feature usage. Removed fabricated platformStats fields (`faceRecognitionAPICalls: "2.3M"`, `revenue: "$124,500"`, `systemUptime: "99.97%"`, `serverLoad: 68`). On any Firestore error, returns 502 with `{ error: "Dashboard data temporarily unavailable" }`.

- **`app/api/institute/stats/route.js`**: Merged four individual try/catch blocks into one. Removed hardcoded class fallback (Dr. Smith, Mathematics B, etc.), attendance requests fallback (John Doe, etc.), teachers fallback (four fake professors), and numeric fallbacks (`|| 1247`, `|| 45`, `|| 67`, `|| 12`). Removed fabricated `weeklyTrend: "+2.4%"`. On any Firestore error, returns 502 with `{ error: "Dashboard data temporarily unavailable" }`.

## How to verify

1. Deploy to any environment with Firestore configured.
2. Ensure the users collection has no count, or make Firestore queries transiently fail (e.g., revoke read permissions temporarily).
3. Log in as admin and navigate to `/admin/dashboard`.
4. Before: dashboard shows 52,350 users, 3 institutes, 99.99% uptime, $124,500 revenue.
   After: dashboard shows zeros, empty arrays, or a "Dashboard data temporarily unavailable" error.
5. Log in as an institute admin and navigate to the institute dashboard.
6. Before: dashboard shows 1,247 students, 45 teachers, hardcoded classes.
   After: dashboard shows real data or zeros for genuinely empty results.

## Edge cases considered

- **Transient Firestore failure**: Single catch block means any failed query returns 502 immediately — no partial fabricated data.
- **Genuinely empty database**: Zero values and empty arrays propagate naturally instead of being replaced with mock data.
- **Frontend compatibility**: The frontend dashboards already use initial state with zeros and "—" for missing fields. No frontend changes needed.
- **Existing tests**: 119 of 141 tests pass. The 22 failures are pre-existing and isolated to `settingsRoute.test.js` (MongoDB connection issues in test environment, unrelated to this change).

Closes #1324