### PR TITLE
fix: validate faceDescriptor to prevent NoSQL injection and database

### DIFF
--- a/app/api/images/route.js
+++ b/app/api/images/route.js
@@ -139,8 +139,13 @@ export const POST = withErrorHandler(async (request) => {
     const rawFaceDescriptor = formData.get("faceDescriptor");
     let faceDescriptor = null;
     if (rawFaceDescriptor) {
+      if (typeof rawFaceDescriptor !== "string" || rawFaceDescriptor.length > 20000) {
+        throw new ValidationError("Face descriptor payload too large");
+      }
       try {
-        faceDescriptor = JSON.parse(rawFaceDescriptor);
+        const parsed = JSON.parse(rawFaceDescriptor);
+        const faceDescriptorSchema = z.array(z.number()).length(128);
+        faceDescriptor = faceDescriptorSchema.parse(parsed);
       } catch {
         throw new ValidationError("Invalid face descriptor format");
       }


### PR DESCRIPTION
## Issue #1431

**Description:**
This PR resolves a critical vulnerability in the `/api/images` endpoint where `faceDescriptor` JSON payloads were parsed and inserted directly into MongoDB without any schema validation or size limits. This could allow an attacker to execute NoSQL injection via malicious object payloads or bloat the database up to the 16MB document limit by passing massively nested arrays.

To mitigate this, the route now enforces strict Zod validation ensuring `faceDescriptor` is an exact array of 128 numbers. A preliminary string length check has also been added before JSON parsing to prevent potential memory exhaustion from parsing excessively large payloads.

**Testing Performed:**
- [x] Verified that uploading an image with a valid 128-element face descriptor correctly parses and saves.
- [x] Verified that providing malformed JSON or arrays with invalid dimensions rejects the request.
- [x] Verified that extremely large payloads are instantly blocked before parsing.
