### PR TITLE
fix: prevent CPU exhaustion via unbounded Zod record in productivity 

### DIFF
--- a/app/api/productivity/route.js
+++ b/app/api/productivity/route.js
@@ -6,6 +6,7 @@ import { ValidationError } from "@/lib/errors";
 import { z } from "zod";
 
 const MAX_ITEMS = 500;
+const MAX_AGENDA_DAYS = 60;
 
 const taskSchema = z.object({
   id: z.union([z.string(), z.number()]),
@@ -28,6 +29,9 @@ const postSchema = z.object({
   agendaItems: z.record(
     z.string(),
     z.array(agendaItemSchema).max(MAX_ITEMS, `Agenda items per day cannot exceed ${MAX_ITEMS}`)
+  ).refine(
+    (record) => Object.keys(record).length <= MAX_AGENDA_DAYS,
+    { message: `Cannot sync more than ${MAX_AGENDA_DAYS} days of agenda items` }
   ),
 });
 


### PR DESCRIPTION
## Issue #1432

**Description:**
This PR mitigates a Denial of Service (DoS) vulnerability in the `/api/productivity` endpoint. The Zod schema for `agendaItems` previously used an unbounded `z.record()` that validated arrays, allowing an attacker to submit a payload with tens of thousands of unique date keys. While individual arrays were limited to 500 items, the sheer number of keys would cause Zod to consume massive amounts of CPU and memory, potentially crashing the serverless function.

To fix this, a `.refine()` rule was added to strictly limit the number of synced days to `MAX_AGENDA_DAYS` (set to 60). Any payload with more than 60 days of agenda items will now be instantly rejected.

**Testing Performed:**
- [x] Verified that syncing typical workloads (<60 days of agenda items) succeeds.
- [x] Verified that payloads containing more than 60 date keys in `agendaItems` are successfully rejected with a 400 Bad Request error without crashing the server.
