### PR TITLE
fix: clear pending notification timers on cleanup

### DIFF
--- a/contexts/NotificationContext.js
+++ b/contexts/NotificationContext.js
@@ -44,16 +44,20 @@ export function NotificationProvider({ children }) {
   };
 
   const clearNotifications = () => {
+    // Cancel any pending auto-remove timeouts so callbacks cannot fire
+    // after the notifications have already been cleared.
+    timersRef.current.forEach((timerId) => clearTimeout(timerId));
+    timersRef.current.clear();
     setNotifications([]);
   };
 
   const markAsRead = (id) => {
     setNotifications((prev) =>
-        prev.map((notification) =>
+      prev.map((notification) =>
         notification.id === id
-            ? { ...notification, read: true }
-            : notification
-        )
+          ? { ...notification, read: true }
+          : notification
+      )
     );
   };
 


### PR DESCRIPTION
## 🎯 Purpose of this Pull Request
Fixes stale timeout callbacks and pending timer leaks in `NotificationContext.js`.

## 🔗 Related Issue / Link
Fixes #1443

## 🛠️ Description of Changes
- cleared all pending notification timeouts inside `clearNotifications()`
- reset timer references after cleanup
- prevented stale auto-remove callbacks after notifications are cleared
- preserved existing notification behavior

## 🧪 Verification / Testing Done
- [x] Tested notification auto-remove flow
- [x] Tested manual clearNotifications behavior
- [x] Verified no stale callbacks execute after clearing notifications
- [x] Checked for regressions in notification removal flow

## 📸 Screenshots / GIFs
N/A — no UI changes introduced.

## 📋 Checklist
- [x] My code follows the code style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings or console errors.
- [x] I have deleted any temporary or debugging console logs.