### PR TITLE
chore: add standard github pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,29 +1,25 @@
-## 🎯 Purpose of this Pull Request
-Provide a brief summary of what this Pull Request introduces or resolves.
+## Description
+<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->
 
-## 🔗 Related Issue / Link
-Fixes #[Issue Number] (or links to the relevant GSSOC issue).
+Fixes # (issue)
 
-## 🛠️ Description of Changes
-List the major changes introduced by this PR:
-- 
-- 
-- 
+## Type of Change
+Please delete options that are not relevant.
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] This change requires a documentation update
 
-## 🧪 Verification / Testing Done
-How did you test your changes? Mention exact steps, browsers used, or automation test suites run:
-- [ ] Rendered locally and checked dark/light modes.
-- [ ] Tested on Chrome/Safari/Firefox.
-- [ ] Ran relevant linters or unit tests (`npm run lint` / `npm test`).
+## How Has This Been Tested?
+<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. -->
 
-## 📸 Screenshots / GIFs
-If this PR changes or introduces any UI components, please add screenshots or a short GIF showing the before and after states.
+- [ ] Manual test: (explain how you verified the changes)
+- [ ] Automated test suite
 
-## 📋 Checklist
-Before submitting, please make sure you check the following:
-- [ ] My code follows the code style guidelines of this project.
-- [ ] I have performed a self-review of my own code.
-- [ ] I have commented my code, particularly in hard-to-understand areas.
-- [ ] I have updated the documentation accordingly.
-- [ ] My changes generate no new warnings or console errors.
-- [ ] I have deleted any temporary or debugging console logs.
+## Checklist:
+- [ ] My code follows the style guidelines of this project
+- [ ] I have performed a self-review of my own code
+- [ ] I have commented my code, particularly in hard-to-understand areas
+- [ ] I have made corresponding changes to the documentation
+- [ ] My changes generate no new warnings
+- [ ] I have checked my code and corrected any misspellings


### PR DESCRIPTION
Fixes #1424

This PR adds a structured Pull Request Template (`.github/pull_request_template.md`) to guide contributors in providing comprehensive descriptions, test details, and checklists for their contributions.