### PR TITLE
docs: reference .env.example in setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,13 @@ npm install
 
 ### 3. Configure environment variables
 
-Create a `.env.local` file in the root directory and add your credentials:
+A `.env.example` file is included in the repo with all required keys. Copy it first:
+
+```bash
+cp .env.example .env.local
+```
+
+Then fill in your actual values:
 
 ```env
 # Firebase


### PR DESCRIPTION
#### Description
This PR updates the setup instructions in the `README.md` file under the "3. Configure environment variables" section. Instead of instructing users to manually create `.env.local` from scratch, it now guides them to copy the existing `.env.example` template file first (using `cp .env.example .env.local`), which contains all required environment variable keys.

This streamlines the developer onboarding experience and reduces configuration errors.

### Related Issues
Closes #1219 

### Checklist
- [x] I have read the Contributing Guidelines.
- [x] I have verified the changes in `README.md` locally.
- [x] The commit message follows the project guidelines (`docs: ...`).