### PR TITLE
fix: prevent UI loader flickering during background polling

### DIFF
--- a/components/TeacherDashboardComponent.js
+++ b/components/TeacherDashboardComponent.js
@@ -351,10 +351,10 @@ const TeacherDashboard = () => {
 
   // Fetch exception requests
   useEffect(() => {
-    const fetchExceptionRequests = async () => {
+    const fetchExceptionRequests = async (isBackground = false) => {
       if (!user) return;
 
-      setIsLoadingRequests(true);
+      if (!isBackground) setIsLoadingRequests(true);
       setRequestsError(null);
 
       try {
@@ -392,14 +392,14 @@ const TeacherDashboard = () => {
       } catch (error) {
         setRequestsError(error.message);
       } finally {
-        setIsLoadingRequests(false);
+        if (!isBackground) setIsLoadingRequests(false);
       }
     };
 
     fetchExceptionRequests();
 
     // Poll for updates every 30 seconds
-    const interval = setInterval(fetchExceptionRequests, 30000);
+    const interval = setInterval(() => fetchExceptionRequests(true), 30000);
     return () => clearInterval(interval);
   }, [user]);
 


### PR DESCRIPTION
## Description
Fixes an annoying UX bug in the Teacher Dashboard where the global loading spinner flashes repeatedly.

Previously, fetchExceptionRequests was called every 30 seconds by a setInterval for background polling. Because it always called setIsLoadingRequests(true), this caused the UI loader to repeatedly flicker and disrupt the user experience even when data was just being refreshed silently.

Fixes #1466 

## Type of Change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. -->

- [ ] Manual test: (explain how you verified the changes)
- [x] Automated test suite

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings
