### PR TITLE
fix(groq): resolve undefined GROQ_API_URL reference in chatbot api route

### DIFF
--- a/app/api/groq/route.js
+++ b/app/api/groq/route.js
@@ -7,6 +7,7 @@ export const dynamic = "force-dynamic";
 
 import { checkRateLimit } from "@/lib/rateLimit";
 import { detectInjection, sanitizeMessage, buildSecureMessages } from "@/utils/promptGuard";
+import { GROQ_API_URL } from "@/lib/ai/groq";
 
 const groqSchema = z.object({
   message: z.string().optional(),

--- a/lib/ai/groq.js
+++ b/lib/ai/groq.js
@@ -2,7 +2,7 @@ import { z } from "zod";
 import { AppError, ValidationError } from "@/lib/errors";
 import { fetchWithTimeout } from "@/lib/fetch-with-timeout";
 
-const GROQ_API_URL = "https://api.groq.com/openai/v1/chat/completions";
+export const GROQ_API_URL = "https://api.groq.com/openai/v1/chat/completions";
 const GROQ_SYSTEM_PROMPT = "You are Nova, the friendly AI assistant for Learnova - a Smart Student Engagement Ecosystem.";
 const GROQ_MODEL = "llama-3.1-8b-instant";
 


### PR DESCRIPTION
This pull request makes a small but important change to how the `GROQ_API_URL` constant is used across the codebase. The constant is now exported from `lib/ai/groq.js` and imported where needed, improving code modularity and maintainability.

Improvements to code modularity:

* [`lib/ai/groq.js`](diffhunk://#diff-325262ebab0a374fd773ff8408be0802f8ae93a12acc9a1aa45e3b3bd9923fcbL5-R5): Changed `GROQ_API_URL` from a file-local constant to an exported constant so it can be reused in other modules.
* [`app/api/groq/route.js`](diffhunk://#diff-c5a86e561e46489cca2bfdfab68013b8a8fa97ab227e08c626ea63f9a6219e18R10): Updated to import `GROQ_API_URL` from `lib/ai/groq.js` instead of defining it locally.


Closes #1497 