### PR TITLE
Fix EARLY_BIRD badge unlock issue with Firestore-MongoDB sync

### DIFF
--- a/lib/gamification-service.js
+++ b/lib/gamification-service.js
@@ -4,6 +4,7 @@ import {
   calculateNextLevelXp,
   calculateUnlockedBadges,
 } from "@/utils/gamification";
+import { getAdminDb } from "@/lib/firebase-admin";
 
 /** XP values awarded for each action type. */
 const XP_VALUES = {
@@ -101,6 +102,43 @@ export async function awardXp(firebaseUid, actionType, metadata = {}) {
     throw new Error("Student not found");
   }
 
+  // Fetch true attendance history from Firestore for accurate early bird & gamification analysis
+  let attendanceHistory = [];
+  try {
+    const firestoreDb = getAdminDb();
+    const snapshot = await firestoreDb
+      .collection("attendance_records")
+      .where("userId", "==", firebaseUid)
+      .get();
+
+    snapshot.forEach((doc) => {
+      const data = doc.data();
+      const dateObj = data.timestamp ? data.timestamp.toDate() : new Date();
+      const timeZone = process.env.NEXT_PUBLIC_TIMEZONE || "Asia/Kolkata";
+      let timeString;
+      try {
+        const formatter = new Intl.DateTimeFormat("en-GB", {
+          timeZone,
+          hour: "2-digit",
+          minute: "2-digit",
+          hour12: false,
+        });
+        timeString = formatter.format(dateObj);
+      } catch (_) {
+        const pad = (num) => String(num).padStart(2, "0");
+        timeString = `${pad(dateObj.getHours())}:${pad(dateObj.getMinutes())}`;
+      }
+
+      attendanceHistory.push({
+        date: data.date || dateObj.toISOString().slice(0, 10),
+        time: timeString,
+      });
+    });
+  } catch (error) {
+    console.error("Failed to sync attendance history from Firestore:", error);
+    attendanceHistory = student.attendanceHistory || [];
+  }
+
   const now = new Date();
   let totalXp = student.totalXp || 0;
   let currentStreak = student.currentStreak || 0;
@@ -141,7 +179,7 @@ export async function awardXp(firebaseUid, actionType, metadata = {}) {
     currentStreak,
     currentLevel,
     totalXp,
-    attendanceHistory: student.attendanceHistory || [],
+    attendanceHistory,
   };
 
   const newlyUnlocked = calculateUnlockedBadges(studentData);
@@ -154,6 +192,7 @@ export async function awardXp(firebaseUid, actionType, metadata = {}) {
     xpToNextLevel,
     unlockedBadges,
     lastXpAward: now.toISOString(),
+    attendanceHistory, // Keep MongoDB synchronized
   };
 
   if (actionType === "attendance_marked") {


### PR DESCRIPTION
This pull request enhances the accuracy and synchronization of attendance history used in the gamification service by integrating Firestore data. The main focus is to ensure that attendance-related gamification features use the most up-to-date and reliable attendance records from Firestore, and that this data is kept in sync with MongoDB.

**Attendance History Synchronization:**

- Attendance history is now fetched directly from Firestore (`attendance_records` collection) for the given user, ensuring that early bird and gamification calculations use authoritative data. If fetching fails, the system gracefully falls back to the existing attendance history in MongoDB.
- The fetched attendance history is formatted to include both the date and the local time (using the configured timezone), improving the accuracy of time-based gamification features.

**Code Integration and Data Consistency:**

- The Firestore admin database utility (`getAdminDb`) is imported to enable direct Firestore access.
- The up-to-date attendance history from Firestore is now consistently used in both the in-memory `studentData` object and the MongoDB update, ensuring both systems remain synchronized.


Closes #1501