### PR TITLE
test: resolve Jest ESM BSON syntax error by whitelisting bson and mon…

### DIFF
--- a/jest.config.mjs
+++ b/jest.config.mjs
@@ -13,6 +13,10 @@ const customJestConfig = {
     '^@/(.*)$': '<rootDir>/$1',
     '^.+\\.module\\.(css|sass|scss)$': 'identity-obj-proxy',
   },
+
+  transformIgnorePatterns: [
+    'node_modules/(?!(bson|mongodb)/)',
+  ],
 }
 
 export default createJestConfig(customJestConfig)


### PR DESCRIPTION
# Description

This Pull Request resolves critical runtime crashes on the Home page and configures Jest to support ES Module syntax within MongoDB/BSON dependencies, fixing several database unit test suites.

closes #1486 , @Premshaw23 , please approve this PR.

---

## Technical Details & Root Cause Resolutions

### 1. Home Tab / Chatbot Crash
* **Issue**: The `LearnovaChatbot` component made illegal references to `INITIAL_MESSAGE` (during state initialization) and `markdownComponents` (for message parsing) which were completely undefined in `components/ChatBot.js`.
* **Fix**: 
  * Defined `INITIAL_MESSAGE` with a valid static welcome message payload to prevent initial mount exceptions.
  * Configured `markdownComponents` with full support for paragraphs, lists, links, headers, and code block components (utilizing the pre-existing syntax-highlighted `CodeBlock` component) to enable safe rendering of markdown-enabled assistant responses.

### 2. Jest ES Module/BSON Syntax Errors
* **Issue**: When running database unit tests (`app/api/attendance/record/route.test.js` and `app/api/attendance/sync/route.test.js`), Jest would crash with `SyntaxError: Unexpected token 'export'` in `node_modules/bson`. This occurred because Jest skips compiling packages in `node_modules` by default, but the `mongodb` package relies on raw ESM `bson` files.
* **Fix**: Added whitelisting rules to `transformIgnorePatterns` in `jest.config.mjs`:
  ```javascript
  transformIgnorePatterns: [
    'node_modules/(?!(bson|mongodb)/)',
  ]