### PR TITLE
fix: allow existing users to get Firebase custom claims in set-role endpoint (#1513)

### DIFF
--- a/app/api/auth/set-role/route.js
+++ b/app/api/auth/set-role/route.js
@@ -32,10 +32,24 @@ export const POST = withErrorHandler(async (request) => {
   initializeFirebase();
   const db = admin.firestore();
 
-  // Prevent privilege escalation: reject if a role is already set
+  // Prevent privilege escalation: only block if the requested role CONFLICTS
+  // with an existing one. Existing users whose role matches still need their
+  // Firebase custom claim set (migration path), so we let them through.
   const existingProfile = await db.collection("users").doc(decodedToken.uid).get();
-  if (existingProfile.exists || decodedToken.role) {
-    return jsonError("Forbidden: Role has already been set", 403);
+  if (existingProfile.exists) {
+    const existingRole = existingProfile.data()?.role;
+    if (existingRole && existingRole !== role) {
+      return jsonError(
+        `Forbidden: Account is already registered as "${existingRole}". Role cannot be changed.`,
+        403
+      );
+    }
+  } else if (decodedToken.role && decodedToken.role !== role) {
+    // No Firestore profile yet, but token already carries a different custom claim
+    return jsonError(
+      `Forbidden: Token already carries role "${decodedToken.role}". Role cannot be changed.`,
+      403
+    );
   }
 
   // Cryptographically sign the role into the Firebase token so the


### PR DESCRIPTION
Fixes #1513

## What type of PR is this?
- [x] 🐛 Bug fix
- [x] 🔒 Security fix

## Description
Existing/legacy users were blocked from accessing 
dashboards because set-role endpoint returned 403 
for ALL existing profiles, even when the role matched.

## Root Cause
`app/api/auth/set-role/route.js` checked if profile 
exists and immediately returned 403, blocking the 
Firebase custom claim migration path for returning users.

## Changes Made
- Only block if requested role CONFLICTS with existing role
- Allow matching-role requests through to set Firebase custom claim
- Added clear error messages showing which role is already set
- Two-tier check: Firestore profile conflict + token claim conflict

## Scenarios Fixed
| Scenario | Before | After |
|---|---|---|
| New user | ✅ Works | ✅ Works |
| Existing user, same role | ❌ 403 blocked | ✅ Proceeds |
| Existing user, different role | ❌ 403 opaque | ❌ 403 with message |
| Token has different claim | ❌ 403 opaque | ❌ 403 with message |

## Testing
- [x] Tested locally
- [x] Tested different user roles

## Checklist
- [x] No hardcoded secrets or credentials
- [x] Code follows project style
- [x] No console errors/warnings