### PR TITLE
fix: resolve ReferenceError by removing undefined getAdminDb call

### DIFF
--- a/app/api/notices/route.js
+++ b/app/api/notices/route.js
@@ -25,7 +25,6 @@ async function publishNotice(request) {
 
   const body = await parseJSON(request, 1024 * 50);
   const validData = noticeSchema.parse(body);
-  const adminDb = getAdminDb();
 
   const newNotice = {
     ...validData,


### PR DESCRIPTION
## Description
This PR resolves a runtime reference crash in the notice publication API route.
Closes #1525 
### Problems Addressed:
1. **ReferenceError in Publish API**: The route in `app/api/notices/route.js` attempted to call `getAdminDb()`, which was neither defined nor imported. This caused all notice publishing requests (`POST /api/notices`) from teachers/admins/staff to fail with a HTTP 500 error.
2. **Unused Database Reference**: The `adminDb` variable returned from that call was never used in the function; the DB instance is accessed via `admin.firestore()` directly.

### Solutions Implemented:
- Removed the invalid `const adminDb = getAdminDb();` declaration, eliminating the reference crash and allowing the route to execute successfully.

### Affected Files:
- `app/api/notices/route.js` — Cleaned up the undefined function call.
