### PR TITLE
fix: resolve contact form cooldown timer memory leak on unmount

### DIFF
--- a/app/contact/page.js
+++ b/app/contact/page.js
@@ -38,9 +38,9 @@ export default function Contact() {
   const [errors, setErrors] = useState({});
   const [cooldown, setCooldown] = useState(false);
   const [cooldownTimer, setCooldownTimer] = useState(0);
+  const cooldownIntervalRef = useRef(null);
 
   useEffect(() => {
-    let interval; // Store interval reference securely
     const COOLDOWN_MS = 60 * 1000;
     const lastSubmit = localStorage.getItem('learnova_contact_last_submit');
     if (lastSubmit) {
@@ -49,10 +49,11 @@ export default function Contact() {
       if (remaining > 0) {
         setCooldown(true);
         setCooldownTimer(remaining);
-        interval = setInterval(() => {
+        cooldownIntervalRef.current = setInterval(() => {
           setCooldownTimer((prev) => {
             if (prev <= 1) {
-              clearInterval(interval);
+              clearInterval(cooldownIntervalRef.current);
+              cooldownIntervalRef.current = null;
               setCooldown(false);
               return 0;
             }
@@ -64,7 +65,9 @@ export default function Contact() {
     
     // CRITICAL FIX: Cleanup function to destroy the interval on component unmount
     return () => {
-      if (interval) clearInterval(interval);
+      if (cooldownIntervalRef.current) {
+        clearInterval(cooldownIntervalRef.current);
+      }
     };
   }, []);
 
@@ -153,11 +156,17 @@ export default function Contact() {
     setCooldown(true);
     let seconds = 60;
     setCooldownTimer(seconds);
-    const interval = setInterval(() => {
+
+    if (cooldownIntervalRef.current) {
+      clearInterval(cooldownIntervalRef.current);
+    }
+
+    cooldownIntervalRef.current = setInterval(() => {
       seconds -= 1;
       setCooldownTimer(seconds);
       if (seconds === 0) {
-        clearInterval(interval);
+        clearInterval(cooldownIntervalRef.current);
+        cooldownIntervalRef.current = null;
         setCooldown(false);
       }
     }, 1000);


### PR DESCRIPTION
## Description
This PR fixes a client-side state memory leak in the contact form's submit-time cooldown timer.
Closes #1526 
### Problems Addressed:
1. **Uncleaned Submit Timer**: In `app/contact/page.js`, submitting the contact form sets a 60-second cooldown interval using a local variable. If the user navigates away from the page while the cooldown is active, the interval is not cleared.
2. **Unmounted State Update Warning**: The background timer keeps firing and triggers `setCooldownTimer(seconds)` on the unmounted contact page component, causing a console error and memory leak.

### Solutions Implemented:
- Declared a `cooldownIntervalRef` using `useRef` to maintain a single reference to the active timer.
- Refactored both the page-load checks and the form-submit timer to use `cooldownIntervalRef.current`.
- Enforced a cleanup function in `useEffect` to safely clear the interval on component unmount.

### Affected Files:
- `app/contact/page.js` — Refactored cooldown interval instantiation and destruction.
