### PR TITLE
fix: resolve face recognizer toggle freeze by resetting isMounted status

### DIFF
--- a/components/FaceRecognizer.js
+++ b/components/FaceRecognizer.js
@@ -159,6 +159,8 @@ export default function FaceRecognizer({ authUser }) {
   };
 
   useEffect(() => {
+    isMounted.current = true;
+
     const loadModels = async () => {
       try {
         if (!isMounted.current) return;


### PR DESCRIPTION
## Description
This PR resolves an issue in the biometric attendance scanner where toggling between the front and rear cameras freezes the component.
Closes #1529 
### Problems Addressed:
1. **isMounted.current Trap**: When toggling cameras, `facingMode` changes, triggering the main `useEffect`'s cleanup function, which sets `isMounted.current = false`.
2. **Camera Reinitialization Freeze**: When the effect re-runs to bind the new camera stream, `isMounted.current` remains `false`. All subsequent asynchronous operations (loading weights, requesting media permission, matching descriptors) hit early-return guards and immediately abort.

### Solutions Implemented:
- Added `isMounted.current = true;` at the beginning of the setup `useEffect` handler to reset the mount status state on every re-initialization cycle.

### Affected Files:
- `components/FaceRecognizer.js` — Reset mount lifecycle ref during camera stream switches.
