### PR TITLE
fix(notices): import getAdminDb to resolve ReferenceError on POST /api/notices

### DIFF
--- a/app/api/notices/route.js
+++ b/app/api/notices/route.js
@@ -1,6 +1,5 @@
 import { NextResponse } from "next/server";
-import admin from "firebase-admin";
-import { initializeFirebase } from "@/lib/firebase-admin";
+import { getAdminDb } from "@/lib/firebase-admin";
 import { requireRole } from "@/lib/rbac";
 import { withErrorHandler, parseJSON } from "@/lib/error-handler";
 import { z } from "zod";
@@ -21,7 +20,6 @@ const noticeSchema = z.object({
 async function publishNotice(request) {
   const allowedRoles = ["teacher", "admin", "staff"];
   const { payload: decodedToken, profile } = await requireRole(request, allowedRoles);
-  initializeFirebase();
 
   const body = await parseJSON(request, 1024 * 50);
   const validData = noticeSchema.parse(body);
@@ -36,8 +34,7 @@ async function publishNotice(request) {
     updatedAt: new Date(),
   };
 
-  const result = await admin
-    .firestore()
+  const result = await adminDb
     .collection("notices")
     .add(newNotice);
 


### PR DESCRIPTION
## Summary

Fixes #1403

`publishNotice()` in `app/api/notices/route.js` called `getAdminDb()` but
the function was never imported, causing every `POST /api/notices` to throw
`ReferenceError: getAdminDb is not defined` and return a 500 to any teacher
or admin attempting to publish a notice.

### Root cause

The import line only pulled in `initializeFirebase` (and a bare
`firebase-admin` default) from `@/lib/firebase-admin`, while
`getAdminDb` (which initialises Firebase and returns `admin.firestore()`)
was left out.

### Changes

- Added `getAdminDb` to the named import from `@/lib/firebase-admin`
- Removed the bare `firebase-admin` default import (no longer needed)
- Removed the redundant manual `initializeFirebase()` call (`getAdminDb`
  already calls it internally)
- Switched the Firestore `.add()` call to use the `adminDb` reference
  returned by `getAdminDb()` for consistency

### Test plan

- [ ] `POST /api/notices` with a valid teacher/admin token and a correct
      payload returns 200 with `{ success: true, notice: { id, ... } }`
- [ ] `POST /api/notices` with a student token returns 403
- [ ] No 500 errors in server logs for the notices endpoint

---
**GSSoC '26**