### PR TITLE
fix(notifications): authenticate GET and PATCH endpoints to prevent IDOR

### DIFF
--- a/app/api/notifications/route.js
+++ b/app/api/notifications/route.js
@@ -1,5 +1,7 @@
 import clientPromise from "@/lib/mongodb";
 import { parseJSON } from "@/lib/error-handler";
+import { requireAuth } from "@/lib/rbac";
+import { jsonError } from "@/lib/api-response";
 
 export const dynamic = "force-dynamic";
 
@@ -11,11 +13,11 @@ function serializeNotification(notification) {
 }
 
 export async function GET(request) {
-  const { searchParams } = new URL(request.url);
-  const userId = searchParams.get("userId");
-
-  if (!userId) {
-    return Response.json({ notifications: [] });
+  let decodedToken;
+  try {
+    decodedToken = await requireAuth(request);
+  } catch {
+    return jsonError("Unauthorized", 401);
   }
 
   try {
@@ -23,7 +25,7 @@ export async function GET(request) {
     const db = client.db();
     const notifications = await db
       .collection("notifications")
-      .find({ userId })
+      .find({ userId: decodedToken.uid })
       .sort({ createdAt: -1 })
       .limit(10)
       .toArray();
@@ -37,18 +39,11 @@ export async function GET(request) {
 }
 
 export async function PATCH(request) {
-  let body = {};
-
+  let decodedToken;
   try {
-    body = await parseJSON(request, 1024);
+    decodedToken = await requireAuth(request);
   } catch {
-    body = {};
-  }
-
-  const { userId } = body;
-
-  if (!userId) {
-    return Response.json({ success: false });
+    return jsonError("Unauthorized", 401);
   }
 
   try {
@@ -56,7 +51,7 @@ export async function PATCH(request) {
     const db = client.db();
 
     await db.collection("notifications").updateMany(
-      { userId, read: false },
+      { userId: decodedToken.uid, read: false },
       { $set: { read: true } }
     );
 


### PR DESCRIPTION
## Summary

Fixes #1399

Both `GET /api/notifications` and `PATCH /api/notifications` accepted a
caller-supplied `userId` (query param / request body) with no authentication
check. Any unauthenticated client could read or bulk-mark-as-read another
user's notifications by supplying an arbitrary UID. This is a classic
Insecure Direct Object Reference (IDOR) vulnerability.

### Root cause

Neither handler called any auth helper before querying MongoDB. The
`userId` was trusted entirely from the request.

### Changes

- Added `requireAuth` (from `@/lib/rbac`) to both GET and PATCH handlers
- Token verification now runs before any database access
- `userId` is derived from the verified `decodedToken.uid` exclusively;
  the caller-supplied param is ignored and removed
- Added `jsonError` import for consistent 401 responses

### Before

```
GET /api/notifications?userId=<any-uid>   -> 200, returns their notifications
PATCH /api/notifications  { userId: "<any-uid>" } -> marks their notifications read
```

### After

```
GET /api/notifications                    -> 200, returns only the token owner's notifications
PATCH /api/notifications                  -> marks only the token owner's notifications read
Unauthenticated requests                  -> 401 Unauthorized
```

### Test plan

- [ ] Authenticated `GET /api/notifications` returns only the caller's notifications
- [ ] Authenticated `PATCH /api/notifications` marks only the caller's notifications as read
- [ ] Unauthenticated `GET` and `PATCH` return 401
- [ ] Passing a foreign `userId` param/body has no effect (ignored)

---
**GSSoC '26**