### PR TITLE
fix(labels): replace in-memory rate limiter and remove faceDescriptor biometric data from response

### DIFF
--- a/app/api/labels/route.js
+++ b/app/api/labels/route.js
@@ -1,47 +1,24 @@
 import { connectDb } from "@/lib/mongodb";
-
-import {
-  jsonSuccess,
-  jsonError,
-} from "@/lib/api-response";
-
+import { AppError } from "@/lib/errors";
+import { jsonSuccess } from "@/lib/api-response";
 import { requireRole } from "@/lib/rbac";
 import { withErrorHandler } from "@/lib/error-handler";
+import { checkRateLimit } from "@/lib/rateLimit";
 import { escapeRegex } from "@/utils/mongoUtils";
 
 export const dynamic = "force-dynamic";
 
-export const rateLimitMap = new Map();
-
-const RATE_LIMIT_WINDOW =
-  60 * 1000;
-
-const MAX_ATTEMPTS = 10;
-
 export const GET = withErrorHandler(async (request) => {
-  // Rate limiting
+  // Rate limiting — use the MongoDB-backed helper so state survives across
+  // serverless function instances and cold starts.
   const ip =
     request.headers.get("x-real-ip") ||
     request.headers.get("x-vercel-proxied-for") ||
-    request.ip ||
     request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ||
     "127.0.0.1";
 
-  const now = Date.now();
-
-  if (!rateLimitMap.has(ip)) {
-    rateLimitMap.set(ip, []);
-  }
-
-  const attempts = rateLimitMap
-    .get(ip)
-    .filter((timestamp) => now - timestamp < RATE_LIMIT_WINDOW);
-
-  attempts.push(now);
-  rateLimitMap.set(ip, attempts);
-
-  if (attempts.length > MAX_ATTEMPTS) {
-    const { AppError } = require("@/lib/errors");
+  const rateLimitResult = await checkRateLimit(`labels_${ip}`);
+  if (!rateLimitResult.allowed) {
     throw new AppError("Too many attempts. Please try again later.", 429);
   }
 
@@ -49,77 +26,41 @@ export const GET = withErrorHandler(async (request) => {
   await requireRole(request, ["admin", "teacher", "student"]);
 
   // Search query — escape metacharacters to prevent ReDoS
-  const { searchParams } =
-    new URL(request.url);
-
-  const rawSearch =
-    searchParams.get("search") || "";
-
-  const search =
-    escapeRegex(rawSearch);
+  const { searchParams } = new URL(request.url);
+  const rawSearch = searchParams.get("search") || "";
+  const search = escapeRegex(rawSearch);
 
   const query = search
     ? {
-      $or: [
-        {
-          name: {
-            $regex:
-              search,
-
-            $options:
-              "i",
-          },
-        },
-
-        {
-          email: {
-            $regex:
-              search,
-
-            $options:
-              "i",
-          },
-        },
-      ],
-    }
+        $or: [
+          { name: { $regex: search, $options: "i" } },
+          { email: { $regex: search, $options: "i" } },
+        ],
+      }
     : {};
 
-  // Database
-  const db =
-    await connectDb();
+  // Database — faceDescriptor is excluded from the projection.
+  // Biometric embeddings are sensitive personal data and must not be
+  // returned to arbitrary authenticated callers.
+  const db = await connectDb();
+  const users = db.collection("users");
 
-  const users =
-    db.collection("users");
+  const allUsers = await users
+    .find(query, {
+      projection: {
+        _id: 1,
+        name: 1,
+        email: 1,
+        image: 1,
+      },
+    })
+    .limit(50)
+    .toArray();
 
-  const allUsers =
-    await users
-      .find(query, {
-        projection: {
-          _id: 1,
-          name: 1,
-          email: 1,
-          image: 1,
-          faceDescriptor: 1,
-        },
-      })
-      .limit(50)
-      .toArray();
+  const sanitizedUsers = allUsers.map(({ image, ...rest }) => ({
+    ...rest,
+    hasImage: !!image,
+  }));
 
-  const sanitizedUsers =
-    allUsers.map(
-      ({
-        image,
-        ...rest
-      }) => ({
-        ...rest,
-        hasImage:
-          !!image,
-        faceDescriptor: rest.faceDescriptor || [],
-      })
-    );
-
-  return jsonSuccess(
-    sanitizedUsers,
-    200
-  );
+  return jsonSuccess(sanitizedUsers, 200);
 });


### PR DESCRIPTION
## Summary

Fixes #1407
Fixes #1408

Two bugs fixed in `app/api/labels/route.js`.

---

### Bug 1: In-memory rate limiter silently non-functional in serverless (fixes #1407)

The previous implementation stored rate-limit state in a module-level `Map`
(`rateLimitMap`). In a serverless/Vercel deployment, every cold-start creates
a fresh V8 isolate with an empty Map, so the 10-request cap was never actually
enforced — any client could call the endpoint without bound.

**Fix:** Replaced the in-memory Map with the existing MongoDB-backed
`checkRateLimit()` helper already used by every other rate-limited route in
the codebase (groq, complaints, register, passcode). State now persists across
all function instances.

---

### Bug 2: faceDescriptor biometric embeddings returned to all authenticated users (fixes #1408)

The response included the full 128-element face embedding vector for every
matched user — including to students querying other students' records. Face
embeddings are irreversible biometric data (GDPR Art. 9 special category).

**Fix:** Removed `faceDescriptor` from the MongoDB projection and from the
serialised response entirely. Consumers that need face matching should
retrieve their own descriptor via a dedicated, owner-scoped endpoint.

---

### Changes

- Remove module-level `rateLimitMap`, `RATE_LIMIT_WINDOW`, `MAX_ATTEMPTS`
- Import and call `checkRateLimit` with an IP-scoped key (`labels_<ip>`)
- Remove `faceDescriptor` from MongoDB projection and mapped output
- Import `AppError` directly at the top of the file (removed inline `require`)
- General code style cleanup (remove excessive line breaks from original)

### Test plan

- [ ] Authenticated `GET /api/labels` returns users without `faceDescriptor` field
- [ ] Sending more than 10 requests per minute from the same IP returns 429
- [ ] Rate limit remains effective after a cold start (checked via MongoDB `rate_limits` collection)
- [ ] Unauthenticated requests are still rejected with 403

---
**GSSoC '26**