### PR TITLE
fix: enforce 60% confidence threshold in offline sync and dismiss idle toast on unmount

### DIFF
--- a/app/api/attendance/sync/route.js
+++ b/app/api/attendance/sync/route.js
@@ -22,18 +22,30 @@ const syncSchema = z.object({
   ).min(1),
 });
 
+// Minimum face-match confidence required to record attendance.
+// Must stay in sync with the threshold enforced in app/api/attendance/record/route.js.
+const MIN_CONFIDENCE_THRESHOLD = 0.6;
+
 export function normalizeConfidenceScore(confidenceScore) {
   let parsedScore = Number(confidenceScore);
 
   if (!Number.isFinite(parsedScore)) {
-    return 0;
+    return null;
   }
 
+  // Accept both percentage form (60-100) and decimal form (0.0-1.0)
   if (parsedScore > 1) {
     parsedScore = parsedScore / 100;
   }
 
-  return Math.max(0, Math.min(1, parsedScore));
+  const clamped = Math.max(0, Math.min(1, parsedScore));
+
+  // Reject scores below the same threshold applied in the online attendance path
+  if (clamped < MIN_CONFIDENCE_THRESHOLD) {
+    return null;
+  }
+
+  return clamped;
 }
 
 function resolveAttendanceIdentity(decodedToken, userProfile) {
@@ -108,6 +120,16 @@ async function handleSync(request) {
       continue;
     }
 
+    // Reject records whose face-match confidence is below the minimum threshold.
+    // The online attendance path enforces >= 60%; offline sync must apply the same guard.
+    const normalizedConfidence = normalizeConfidenceScore(record.confidenceScore);
+    if (normalizedConfidence === null) {
+      console.warn(
+        `User ${decodedToken.uid} submitted offline attendance with confidence below threshold (raw: ${record.confidenceScore})`,
+      );
+      continue;
+    }
+
     // Atomic check-and-set using a Firestore transaction to prevent
     // duplicate records under concurrent sync requests from multiple tabs or devices.
     const newDocRef = db.collection("attendance_records").doc(`${decodedToken.uid}_${recordDate}`);
@@ -135,7 +157,7 @@ async function handleSync(request) {
         timestamp: FieldValue.serverTimestamp(),
         date: recordDate,
         status: "present",
-        confidenceScore: normalizeConfidenceScore(record.confidenceScore),
+        confidenceScore: normalizedConfidence,
         offlineSynced: true,
         queuedAt: new Date(record.queuedAt),
       });

--- a/hooks/useIdleTimeout.js
+++ b/hooks/useIdleTimeout.js
@@ -57,6 +57,13 @@ export function useIdleTimeout() {
     return () => {
       clearTimers();
       if (throttleTimer.current) clearTimeout(throttleTimer.current);
+      // Dismiss the warning toast if it is still visible when the component unmounts.
+      // react-hot-toast keeps a global store that outlives any single component, so
+      // without this the "You will be logged out" message persists across navigation.
+      if (warningToastId.current) {
+        toast.dismiss(warningToastId.current);
+        warningToastId.current = null;
+      }
       events.forEach((e) => window.removeEventListener(e, throttledReset));
     };
   }, []);


### PR DESCRIPTION
## Summary

Fixes #1406
Fixes #1401

Two independent bugs resolved in separate files.

---

### Fix 1: Offline attendance sync bypasses 60% confidence threshold (fixes #1406)

**Root cause:** `normalizeConfidenceScore()` in `app/api/attendance/sync/route.js`
normalized the value to the 0-1 range but applied no minimum check. The online
path (`app/api/attendance/record/route.js`) explicitly rejects scores below 60,
but that guard was absent from the offline sync path, allowing attendance to be
written with any confidence value including 0%.

**Changes in `app/api/attendance/sync/route.js`:**
- Added `MIN_CONFIDENCE_THRESHOLD = 0.6` constant (mirrors the 60 in `record/route.js`)
- `normalizeConfidenceScore` now returns `null` for scores below threshold instead of
  returning the unchecked low value
- The sync loop skips records where `normalizeConfidenceScore` returns `null` and logs
  a warning; these records are not written to Firestore
- The Firestore transaction uses the pre-computed `normalizedConfidence` value rather
  than calling `normalizeConfidenceScore` a second time inside the transaction

---

### Fix 2: Idle warning toast persists after component unmount (fixes #1401)

**Root cause:** The `useEffect` cleanup in `hooks/useIdleTimeout.js` cancelled
the two `setTimeout` refs (`logoutTimer`, `warningTimer`) but never called
`toast.dismiss`. Since `react-hot-toast` stores toast state globally, the
"You will be logged out in 2 minutes" warning survived page navigation and
sign-out, appearing on unrelated pages indefinitely.

**Change in `hooks/useIdleTimeout.js`:**
- Added `toast.dismiss(warningToastId.current)` and nulled the ref in the
  `useEffect` cleanup return function, consistent with the dismiss already
  present in `resetTimers()` and the logout timer callback

---

### Test plan

**Attendance sync:**
- [ ] `POST /api/attendance/sync` with `confidenceScore: 0` is rejected (record skipped, not written to Firestore)
- [ ] `POST /api/attendance/sync` with `confidenceScore: 55` (below 60%) is rejected
- [ ] `POST /api/attendance/sync` with `confidenceScore: 60` is accepted and written with `confidenceScore: 0.6`
- [ ] `POST /api/attendance/sync` with `confidenceScore: 0.75` (decimal form) is accepted

**Idle toast:**
- [ ] Trigger idle warning toast, then navigate to another page before timeout expires; verify toast is gone
- [ ] Trigger idle warning toast, then sign out; verify toast does not appear on `/auth` page

---
**GSSoC '26**