### PR TITLE
fix: prevent back-to-top button overlap with chatbot

### DIFF
--- a/components/ui/BackToTop.jsx
+++ b/components/ui/BackToTop.jsx
@@ -19,7 +19,7 @@ export default function BackToTop() {
 
     // Attach event listener using passive option for scroll performance
     window.addEventListener("scroll", handleScroll, { passive: true });
-    
+
     // Initial check in case page mounts pre-scrolled
     handleScroll();
 
@@ -40,11 +40,10 @@ export default function BackToTop() {
       onClick={scrollToTop}
       type="button"
       aria-label="Back to top"
-      className={`fixed bottom-8 right-8 z-[9999] p-3.5 rounded-2xl bg-slate-900/90 border border-slate-800 text-slate-100 hover:text-white shadow-2xl hover:shadow-indigo-500/20 active:scale-95 transition-all duration-500 ease-out backdrop-blur-md cursor-pointer hover:border-indigo-500/50 hover:bg-slate-850 ${
-        isVisible
-          ? "opacity-100 scale-100 pointer-events-auto translate-y-0"
-          : "opacity-0 scale-75 pointer-events-none translate-y-4"
-      }`}
+      className={`fixed bottom-24 right-7 z-[9999] p-3.5 rounded-2xl bg-slate-900/90 border border-slate-800 text-slate-100 hover:text-white shadow-2xl hover:shadow-indigo-500/20 active:scale-95 transition-all duration-500 ease-out backdrop-blur-md cursor-pointer hover:border-indigo-500/50 hover:bg-slate-850 ${isVisible
+        ? "opacity-100 scale-100 pointer-events-auto translate-y-0"
+        : "opacity-0 scale-75 pointer-events-none translate-y-4"
+        }`}
     >
       <ChevronUp className="w-5 h-5 transition-transform duration-300 group-hover:-translate-y-0.5" />
     </button>


### PR DESCRIPTION
## Description
Fixed the bug where the back to top button overlaps with the chatbot button

Fixes #1564 

## Type of Change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- [x] Manual test: (explain how you verified the changes) (Run the project locally and tested)
- [ ] Automated test suite

<img width="724" height="465" alt="image" src="https://github.com/user-attachments/assets/ce148c10-53c8-437e-9e95-a1447614c522" />


## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings
