### PR TITLE
fix(attendance/sync): surface rejectedIds for expired timestamp records

### DIFF
--- a/app/api/attendance/sync/route.js
+++ b/app/api/attendance/sync/route.js
@@ -86,7 +86,8 @@ async function handleSync(request) {
   const instituteId = userProfile?.instituteId || null;
   
   const successfulIds = [];
-  
+  const rejectedIds = [];
+
   // We use a Set to keep track of processed user-dates to prevent duplicate attendance
   // even within the same batch.
   const processedUserDates = new Set();
@@ -104,7 +105,7 @@ async function handleSync(request) {
     // Validate timestamp: must be within the last 48 hours and not in the future (allowing 5 min clock skew)
     if (record.queuedAt > now + 5 * 60 * 1000 || record.queuedAt < now - MAX_OFFLINE_WINDOW_MS) {
       console.warn(`User ${decodedToken.uid} attempted to sync record with invalid queuedAt timestamp ${record.queuedAt}`);
-      successfulIds.push(record.id); // Acknowledge to clear from client DB and prevent endless retry loop
+      rejectedIds.push(record.id);
       continue;
     }
 
@@ -170,6 +171,10 @@ async function handleSync(request) {
   return NextResponse.json({
     success: true,
     syncedIds: successfulIds,
+    rejectedIds,
+    ...(rejectedIds.length > 0 && {
+      warning: "Some records were not synced because they exceeded the 48-hour offline window. These records have been removed from your local queue.",
+    }),
   });
 }
 

--- a/app/api/attendance/sync/route.test.js
+++ b/app/api/attendance/sync/route.test.js
@@ -88,6 +88,7 @@ describe("attendance sync route", () => {
     await expect(response.json()).resolves.toEqual({
       success: true,
       syncedIds: [1],
+      rejectedIds: [],
     });
 
     expect(getUserProfile).toHaveBeenCalledWith("user-123");
@@ -150,10 +151,14 @@ describe("attendance sync route", () => {
   });
 
   test("normalizes confidence scores into the valid range", () => {
-    expect(normalizeConfidenceScore(-2)).toBe(0);
-    expect(normalizeConfidenceScore(0.42)).toBe(0.42);
+    // Values below the 60% minimum threshold are rejected
+    expect(normalizeConfidenceScore(-2)).toBeNull();
+    expect(normalizeConfidenceScore(0.42)).toBeNull();
+    expect(normalizeConfidenceScore(Number.NaN)).toBeNull();
+
+    // Valid scores above threshold
     expect(normalizeConfidenceScore(75)).toBe(0.75);
     expect(normalizeConfidenceScore(150)).toBe(1);
-    expect(normalizeConfidenceScore(Number.NaN)).toBe(0);
+    expect(normalizeConfidenceScore(0.85)).toBe(0.85);
   });
 });

--- a/lib/syncService.js
+++ b/lib/syncService.js
@@ -31,13 +31,19 @@ export async function syncAttendanceQueue() {
 
     if (response.ok) {
       const data = await response.json();
-      if (data.success && data.syncedIds) {
-        // Remove successfully synced records from IDB
-        for (const id of data.syncedIds) {
-          await removeFromOutbox(id);
+      if (data.success) {
+        if (data.syncedIds?.length) {
+          for (const id of data.syncedIds) {
+            await removeFromOutbox(id);
+          }
+          window.dispatchEvent(new CustomEvent("attendance-sync-complete", { detail: { count: data.syncedIds.length } }));
         }
-        // Emit a custom event so the UI can update its offline indicators
-        window.dispatchEvent(new CustomEvent("attendance-sync-complete", { detail: { count: data.syncedIds.length } }));
+        if (data.rejectedIds?.length) {
+          for (const id of data.rejectedIds) {
+            await removeFromOutbox(id);
+          }
+          window.dispatchEvent(new CustomEvent("attendance-sync-rejected", { detail: { count: data.rejectedIds.length, warning: data.warning } }));
+        }
       }
     } else {
       console.error("Attendance sync failed with status:", response.status);

--- a/worker/index.js
+++ b/worker/index.js
@@ -39,11 +39,14 @@ async function syncAttendanceSW() {
 
       if (response.ok) {
         const data = await response.json();
-        if (data.success && data.syncedIds) {
-          for (const id of data.syncedIds) {
+        if (data.success) {
+          for (const id of data.syncedIds ?? []) {
             await removeFromOutbox(id);
           }
-          totalSynced += data.syncedIds.length;
+          totalSynced += data.syncedIds?.length ?? 0;
+          for (const id of data.rejectedIds ?? []) {
+            await removeFromOutbox(id);
+          }
         }
       } else {
         throw new Error(`Failed to sync batch: ${response.status} ${response.statusText}`);


### PR DESCRIPTION
## Problem

Expired-timestamp records (older than 48 hours or in the future) were silently pushed into `syncedIds`, causing the client to permanently delete them from IndexedDB without any user-facing indication. Users had no way to know that their attendance record was dropped.

## Root cause

`route.js` line 107 (before this fix):
```js
successfulIds.push(record.id); // Acknowledge to clear from client DB
```
Expired records were treated identically to successfully synced records in the API response.

## Changes

**`app/api/attendance/sync/route.js`**
- Collect expired records into a separate `rejectedIds` array
- Include `rejectedIds` and a `warning` string in the response when any records are rejected

**`lib/syncService.js`** and **`worker/index.js`**
- Clear `rejectedIds` from IndexedDB (prevents endless retry loop)
- Dispatch an `attendance-sync-rejected` custom event with the warning so the UI layer can surface a notification to the user

**`app/api/attendance/sync/route.test.js`**
- Fix three broken assertions that still expected the pre-threshold `normalizeConfidenceScore` behavior (`0` instead of `null` for sub-threshold and non-finite inputs)
- Add assertion that `rejectedIds: []` is present in the success response

## Testing

The existing test suite covers the main sync path. The broken test assertions from the confidence-threshold changes (merged in #1551) are corrected here.

Could you please add the relevant labels to this PR? It would help with tracking.

Closes #1404