### PR TITLE
fix(auth): proactively refresh Firebase ID token to prevent stale session cookie

### DIFF
--- a/hooks/useAuth.js
+++ b/hooks/useAuth.js
@@ -50,17 +50,35 @@ export const useAuth = () => {
     }
 
     let unsubscribeSnapshot = null;
+    let tokenRefreshInterval = null;
 
     const unsubscribeAuth = onAuthStateChanged(auth, async (firebaseUser) => {
-      // Clean up previous snapshot listener if active
+      // Clean up previous snapshot listener and token refresh interval if active
       if (unsubscribeSnapshot) {
         unsubscribeSnapshot();
         unsubscribeSnapshot = null;
+      }
+      if (tokenRefreshInterval) {
+        clearInterval(tokenRefreshInterval);
+        tokenRefreshInterval = null;
       }
 
       try {
         if (firebaseUser) {
           setUser(firebaseUser);
+
+          // Proactively refresh the Firebase ID token every 55 minutes so the
+          // authToken cookie never goes stale before the middleware rejects it.
+          // Firebase tokens expire after 60 minutes; 55-minute interval gives a
+          // 5-minute buffer for network latency and clock drift.
+          tokenRefreshInterval = setInterval(async () => {
+            try {
+              const freshToken = await firebaseUser.getIdToken(true);
+              setCookie("authToken", freshToken, 7);
+            } catch {
+              // Network error during background refresh; the next interval will retry.
+            }
+          }, 55 * 60 * 1000);
 
           // Listen to the user profile document in real-time
           const userDocRef = doc(db, "users", firebaseUser.uid);
@@ -128,6 +146,9 @@ export const useAuth = () => {
       unsubscribeAuth();
       if (unsubscribeSnapshot) {
         unsubscribeSnapshot();
+      }
+      if (tokenRefreshInterval) {
+        clearInterval(tokenRefreshInterval);
       }
     };
   }, []);


### PR DESCRIPTION
## Problem

Firebase ID tokens expire after 60 minutes. The `authToken` cookie in `useAuth.js` was only updated when the Firestore `onSnapshot` listener fired, which depends on database activity. On a quiet session (no Firestore writes for 60+ minutes), the cookie holds an expired token, and the Next.js middleware's `verifyIdToken` call rejects it, silently redirecting the user to `/auth`.

## Root cause

`hooks/useAuth.js` line 74 (`getIdToken()`) is only called inside `onSnapshot`, not on a time-based schedule. There is no proactive refresh.

## Fix

Add a `setInterval` (55-minute cadence) inside the `onAuthStateChanged` callback that calls `getIdToken(true)` (force-refresh) and updates the cookie. The 5-minute buffer relative to the 60-minute expiry accounts for network latency and clock drift.

The interval is:
- Cleared in the `useEffect` cleanup to prevent memory leaks
- Re-initialised on each auth state change (handles sign-out/sign-in cycles correctly)
- Silent on network failures, so a transient refresh error does not interrupt the session (the next interval fires 55 minutes later)

## No new dependencies

This is a pure logic change inside `hooks/useAuth.js`. No packages added.

Could you please add the relevant labels to this PR? It would help with tracking.

Closes #1400