### PR TITLE
fix: rewrite SSE connection manager to fix 6 resource leak flaws

### DIFF
--- a/app/api/notices/stream/route.js
+++ b/app/api/notices/stream/route.js
@@ -4,64 +4,143 @@ import { connectDbForSSE } from "@/lib/mongodb";
 
 export const dynamic = "force-dynamic";
 
-const userStreams = new Map();
-const streamListeners = new Map();
-let connectionCount = 0;
-let nextConnId = 0;
-const MAX_CONNECTIONS = 50;
+const MAX_PER_USER = 3;
 const IDLE_TIMEOUT_MS = 30 * 60 * 1000;
+const HEARTBEAT_INTERVAL_MS = 15000;
+const POLL_INTERVAL_MS = 10000;
+const STREAM_RECONNECT_BASE_MS = 1000;
+const STREAM_RECONNECT_MAX_MS = 30000;
 
+// ── Connection Registry ────────────────────────────────────────────────────────
+const connections = new Map();
+const userConnectionCount = new Map();
+let nextConnId = 1;
+
+function registerConnection(userId) {
+  const current = userConnectionCount.get(userId) || 0;
+  if (current >= MAX_PER_USER) return null;
+  const connId = nextConnId++;
+  connections.set(connId, userId);
+  userConnectionCount.set(userId, current + 1);
+  return connId;
+}
+
+function unregisterConnection(connId) {
+  const userId = connections.get(connId);
+  if (!userId) return;
+  connections.delete(connId);
+  const count = userConnectionCount.get(userId) || 0;
+  if (count <= 1) {
+    userConnectionCount.delete(userId);
+  } else {
+    userConnectionCount.set(userId, count - 1);
+  }
+}
+
+// ── Shared Notice Listener Bus ─────────────────────────────────────────────────
+const noticeListeners = new Map();
+
+function addNoticeListener(userId, cb) {
+  if (!noticeListeners.has(userId)) {
+    noticeListeners.set(userId, new Set());
+  }
+  noticeListeners.get(userId).add(cb);
+}
+
+function removeNoticeListener(userId, cb) {
+  const cbs = noticeListeners.get(userId);
+  if (!cbs) return;
+  cbs.delete(cb);
+  if (cbs.size === 0) noticeListeners.delete(userId);
+}
+
+function broadcastNotice(doc) {
+  for (const [, cbs] of noticeListeners) {
+    for (const cb of cbs) cb(doc);
+  }
+}
+
+// ── MongoDB Change Stream (single per process, auto-reconnect) ─────────────────
 let sharedStream = null;
 let sharedDb = null;
+let streamReconnectTimer = null;
+let streamReconnectRetryCount = 0;
 
-async function getSharedStream() {
-  if (sharedStream) return true;
+async function startChangeStream() {
+  stopChangeStream();
   try {
     sharedDb = await connectDbForSSE();
     const coll = sharedDb.collection("notices");
     sharedStream = coll.watch([{ $match: { operationType: "insert" } }]);
     sharedStream.on("change", (change) => {
       const doc = change.fullDocument;
-      if (!doc) return;
-      for (const [, cbs] of streamListeners) {
-        for (const cb of cbs) cb(doc);
-      }
+      if (doc) broadcastNotice(doc);
     });
-    sharedStream.on("error", () => {
-      sharedStream?.close().catch(() => {});
-      sharedStream = null;
-      sharedDb = null;
-    });
-    sharedStream.on("close", () => {
-      sharedStream = null;
-      sharedDb = null;
-    });
-    return true;
+    sharedStream.on("error", () => scheduleChangeStreamReconnect());
+    sharedStream.on("close", () => scheduleChangeStreamReconnect());
+    streamReconnectRetryCount = 0;
   } catch {
-    return false;
+    scheduleChangeStreamReconnect();
   }
 }
 
-function addListener(userId, cb) {
-  if (!streamListeners.has(userId)) {
-    streamListeners.set(userId, new Set());
+function stopChangeStream() {
+  if (streamReconnectTimer) {
+    clearTimeout(streamReconnectTimer);
+    streamReconnectTimer = null;
   }
-  streamListeners.get(userId).add(cb);
-}
-
-function removeListener(userId, cb) {
-  const cbs = streamListeners.get(userId);
-  if (!cbs) return;
-  cbs.delete(cb);
-  if (cbs.size === 0) {
-    streamListeners.delete(userId);
-  }
-  if (streamListeners.size === 0 && sharedStream) {
-    sharedStream.close().catch(() => {});
+  if (sharedStream) {
+    try { sharedStream.close(); } catch {}
     sharedStream = null;
-    sharedDb = null;
+  }
+  sharedDb = null;
+}
+
+function scheduleChangeStreamReconnect() {
+  const delay = Math.min(
+    STREAM_RECONNECT_BASE_MS * Math.pow(2, streamReconnectRetryCount),
+    STREAM_RECONNECT_MAX_MS
+  );
+  streamReconnectRetryCount++;
+  streamReconnectTimer = setTimeout(() => {
+    streamReconnectTimer = null;
+    startChangeStream();
+  }, delay);
+}
+
+// ── Shared Polling Fallback ────────────────────────────────────────────────────
+let pollingInterval = null;
+let pollingLastCheck = new Date();
+
+function startPollingIfNeeded() {
+  if (pollingInterval || noticeListeners.size === 0) return;
+  pollingInterval = setInterval(async () => {
+    if (noticeListeners.size === 0) {
+      stopPolling();
+      return;
+    }
+    try {
+      if (!sharedDb) sharedDb = await connectDbForSSE();
+      const newNotices = await sharedDb
+        .collection("notices")
+        .find({ createdAt: { $gt: pollingLastCheck } })
+        .toArray();
+      if (newNotices.length > 0) {
+        pollingLastCheck = new Date();
+        newNotices.forEach((n) => broadcastNotice(n));
+      }
+    } catch {}
+  }, POLL_INTERVAL_MS);
+}
+
+function stopPolling() {
+  if (pollingInterval) {
+    clearInterval(pollingInterval);
+    pollingInterval = null;
   }
 }
+
+// ── Request Handler ────────────────────────────────────────────────────────────
 
 export async function GET(request) {
   try {
@@ -70,31 +149,55 @@ export async function GET(request) {
     const userRole = profile?.role || "student";
     const userId = decodedToken.uid;
 
-    if (connectionCount >= MAX_CONNECTIONS) {
-      return new Response(JSON.stringify({ error: "Too many connections" }), {
-        status: 503,
-        headers: { "Content-Type": "application/json" },
-      });
-    }
-
-    const existing = userStreams.get(userId);
-    if (existing) {
-      existing.close();
-    }
-
-    const connId = nextConnId++;
     let isConnected = true;
-    let heartbeatInterval;
-    let pollInterval;
+    let heartbeatTimer;
     let idleTimer;
+    let connId;
 
     const stream = new ReadableStream({
       async start(controller) {
         const encoder = new TextEncoder();
         const sendEvent = (event, data) => {
           if (!isConnected) return;
-          controller.enqueue(encoder.encode(`event: ${event}\ndata: ${JSON.stringify(data)}\n\n`));
+          try {
+            controller.enqueue(
+              encoder.encode(
+                `event: ${event}\ndata: ${JSON.stringify(data)}\n\n`
+              )
+            );
+          } catch {
+            cleanup();
+          }
         };
+
+        const cleanup = () => {
+          if (!isConnected) return;
+          isConnected = false;
+          clearInterval(heartbeatTimer);
+          if (idleTimer) clearTimeout(idleTimer);
+          if (connId) {
+            unregisterConnection(connId);
+            connId = null;
+          }
+          removeNoticeListener(userId, onNotice);
+          if (noticeListeners.size === 0) {
+            stopChangeStream();
+            stopPolling();
+          }
+          try { controller.close(); } catch {}
+        };
+
+        connId = registerConnection(userId);
+        if (connId === null) {
+          sendEvent("error", {
+            message:
+              "Too many connections. Close other tabs and try again.",
+          });
+          cleanup();
+          return;
+        }
+
+        request.signal.addEventListener("abort", cleanup);
 
         const db = await connectDbForSSE();
         const noticesCollection = db.collection("notices");
@@ -105,11 +208,13 @@ export async function GET(request) {
             .sort({ isPinned: -1, createdAt: -1 })
             .limit(50)
             .toArray();
-
-          const formattedNotices = initialNotices.map(n => ({ ...n, id: n._id.toString() }));
+          const formattedNotices = initialNotices.map((n) => ({
+            ...n,
+            id: n._id.toString(),
+          }));
           sendEvent("initial", formattedNotices);
-        } catch (error) {
-          console.error("Initial fetch error:", error);
+        } catch (err) {
+          console.error("Initial fetch error:", err);
           sendEvent("error", { message: "Failed to fetch initial notices" });
           cleanup();
           return;
@@ -117,71 +222,34 @@ export async function GET(request) {
 
         const onNotice = (doc) => {
           if (!isConnected) return;
-          if (doc.targetAudience && doc.targetAudience.includes(userRole)) {
-            sendEvent("new-notice", { ...doc, id: doc._id.toString() });
+          if (
+            doc.targetAudience &&
+            doc.targetAudience.includes(userRole)
+          ) {
+            sendEvent("new-notice", {
+              ...doc,
+              id: doc._id.toString(),
+            });
           }
         };
 
-        const cleanup = () => {
-          const current = userStreams.get(userId);
-          if (current && current.id === connId) {
-            userStreams.delete(userId);
-            connectionCount = Math.max(0, connectionCount - 1);
-          }
-          isConnected = false;
-          clearInterval(heartbeatInterval);
-          if (pollInterval) clearInterval(pollInterval);
-          if (idleTimer) clearTimeout(idleTimer);
-          removeListener(userId, onNotice);
-          try { controller.close(); } catch {}
-        };
+        addNoticeListener(userId, onNotice);
 
-        const entry = {
-          id: connId,
-          close() {
-            cleanup();
-          },
-        };
-
-        userStreams.set(userId, entry);
-        connectionCount++;
-        request.signal.addEventListener("abort", cleanup);
-
-        addListener(userId, onNotice);
-        const hasStream = await getSharedStream();
-
-        if (!hasStream) {
-          let lastCheckTime = new Date();
-          pollInterval = setInterval(async () => {
-            if (!isConnected) return clearInterval(pollInterval);
-            try {
-              const newNotices = await noticesCollection
-                .find({ targetAudience: userRole, createdAt: { $gt: lastCheckTime } })
-                .toArray();
-
-              if (newNotices.length > 0) {
-                lastCheckTime = new Date();
-                newNotices.forEach(notice => {
-                  sendEvent("new-notice", { ...notice, id: notice._id.toString() });
-                });
-              }
-            } catch (e) {
-              console.error("Polling error:", e);
-            }
-          }, 10000);
+        if (!sharedStream) {
+          startChangeStream();
         }
+        startPollingIfNeeded();
 
         const resetIdle = () => {
           if (idleTimer) clearTimeout(idleTimer);
-          idleTimer = setTimeout(() => {
-            cleanup();
-          }, IDLE_TIMEOUT_MS);
+          idleTimer = setTimeout(() => cleanup(), IDLE_TIMEOUT_MS);
         };
         resetIdle();
 
-        heartbeatInterval = setInterval(() => {
+        heartbeatTimer = setInterval(() => {
           sendEvent("ping", { time: new Date().toISOString() });
-        }, 15000);
+        }, HEARTBEAT_INTERVAL_MS);
+
       },
     });
 
@@ -193,7 +261,6 @@ export async function GET(request) {
         "X-Accel-Buffering": "no",
       },
     });
-
   } catch (error) {
     console.error("SSE stream auth error:", error);
     return new Response(JSON.stringify({ error: "Unauthorized" }), {


### PR DESCRIPTION
## Summary

Rewrites `app/api/notices/stream/route.js` to fix all 6 resource leak flaws identified in #1583. The original implementation used a single global `connectionCount` (max 50), a `userStreams` Map, per-client MongoDB polling, and a fragile single Change Stream cursor with no cleanup guarantees.

## Flaws Fixed

| # | Flaw | Fix |
|---|------|-----|
| 1 | Global connection count lets one user exhaust the pool | Per-user connection registry (max 3 per user) via `registerConnection`/`unregisterConnection` |
| 2 | `userStreams` Map leaks entries on abort races | Cleanup always runs on abort, removing the entry from the registry |
| 3 | Change Stream cursor leaks on error | `stopChangeStream()` calls `cursor.close()` in cleanup; auto-reconnect with exponential backoff (1s–30s) |
| 4 | Closure memory leak via `onNotice` | `removeNoticeListener(userId, onNotice)` always called in cleanup |
| 5 | Per-client polling: 50 clients × 1 query/10s = 5 QPS | Single shared `startPollingIfNeeded()` broadcasts to all listeners |
| 6 | Orphaned timers on abrupt disconnect | All timers cleared in `cleanup()`; abort handler always registered |

## Changes

- **No new dependencies** — zero-install fix, only one file changed
- **Matching style** — function-based module state (no classes), `Map`/`Set`, existing imports
- **Build verified** — `next build` succeeds with no errors

Closes #1583