### PR TITLE
fix: sync user profile to MongoDB on registration for gamification an…

### DIFF
--- a/app/api/auth/set-role/route.js
+++ b/app/api/auth/set-role/route.js
@@ -2,6 +2,7 @@ import { jsonError, jsonSuccess } from "@/lib/api-response";
 import { withErrorHandler, authenticateRequest } from "@/lib/error-handler";
 import { initializeFirebase } from "@/lib/firebase-admin";
 import admin from "firebase-admin";
+import { connectDb } from "@/lib/mongodb";
 
 import { withValidation } from "@/lib/validations/withValidation";
 import { setRoleSchema } from "@/lib/validations/auth";
@@ -74,6 +75,41 @@ export const POST = withValidation(
       .collection("users")
       .doc(decodedToken.uid)
       .set(userProfile, { merge: true });
+
+    // Sync user to MongoDB so gamification (awardXp) and biometric labels
+    // endpoints can locate the student by their Firebase UID.
+    try {
+      const mongoDB = await connectDb();
+      const now = new Date().toISOString();
+
+      await mongoDB.collection("users").updateOne(
+        { firebaseUid: decodedToken.uid },
+        {
+          $set: {
+            firebaseUid: decodedToken.uid,
+            email: decodedToken.email,
+            name: fullName,
+            fullName,
+            role,
+            lastLogin: now,
+          },
+          $setOnInsert: {
+            totalXp: 0,
+            currentLevel: 1,
+            xpToNextLevel: 100,
+            currentStreak: 0,
+            unlockedBadges: [],
+            attendanceHistory: [],
+            createdAt: now,
+          },
+        },
+        { upsert: true }
+      );
+    } catch (mongoErr) {
+      // MongoDB sync is non-blocking — Firestore is the primary store.
+      // Log the error but do not fail the registration flow.
+      console.error("[set-role] MongoDB user sync failed:", mongoErr.message);
+    }
 
     return jsonSuccess({ userProfile }, 201);
   })


### PR DESCRIPTION
## Description
Fixes a cross-database sync gap where new user registrations were written to Firestore but never to MongoDB, causing downstream service failures.
Closes #1538 
### Problem
The `set-role` POST handler writes user profiles exclusively to Firestore (`admin.firestore()`). However, the gamification engine (`awardXp` in `lib/gamification-service.js`) and the biometric labels endpoint (`api/labels/route.js`) query MongoDB's `users` collection using `{ firebaseUid }`. This means every newly registered student immediately hits a `"Student not found"` error on their first attendance check-in and cannot appear in face recognition search results.

### Solution
After the Firestore profile write completes, the route now upserts the user into MongoDB's `users` collection:
- **`$set`** syncs mutable identity fields (name, email, role, lastLogin) on every call
- **`$setOnInsert`** initializes gamification defaults (totalXp=0, currentLevel=1, currentStreak=0, empty badges/history) only on first insert — preserving existing XP data for re-registrations
- The MongoDB write is **non-blocking**: if it fails, the registration still succeeds and the error is logged

### Affected Files
- `app/api/auth/set-role/route.js` — Added `connectDb` import and MongoDB upsert block
