### PR TITLE
fix: align teacher dashboard attendance queries with localized timezo…

### DIFF
--- a/components/TeacherDashboardComponent.js
+++ b/components/TeacherDashboardComponent.js
@@ -70,6 +70,7 @@ import { AttendancePasscodeModal } from "./dashboard/AttendancePasscodeModal";
 import { ExceptionRequestsList } from "./dashboard/ExceptionRequestsList";
 import { db } from "@/lib/firebaseConfig";
 import { collection, getDocs, query, where, onSnapshot, doc, getDoc } from "firebase/firestore";
+import { getTodayKeyLocal } from "@/lib/dateUtils";
 
 const AttendanceTrendsChart = dynamic(
   () => import("@/components/charts/AttendanceTrendsChart"),
@@ -99,7 +100,7 @@ const TeacherDashboard = () => {
 
   const fetchTodayAttendanceStats = useCallback(async () => {
     try {
-      const today = new Date().toISOString().slice(0, 10);
+      const today = getTodayKeyLocal();
 
       const attendanceQuery = query(
         collection(db, "attendance_records"),
@@ -307,7 +308,7 @@ const TeacherDashboard = () => {
           email: doc.data().email,
         }));
 
-        const today = new Date().toISOString().slice(0, 10);
+        const today = getTodayKeyLocal();
         const attendanceQuery = query(
           collection(db, "attendance_records"),
           where("date", "==", today)


### PR DESCRIPTION
## Description
Fixes a timezone mismatch where the teacher dashboard silently dropped student check-ins recorded between 12:00 AM and 5:30 AM IST.
Closes #1539 
### Problem
The student attendance recording pipeline (`attendanceService.js`, `attendance/record/route.js`, `attendance/sync/route.js`) was upgraded to use `getLocalDateKey()` / `getTodayKeyLocal()` from `lib/dateUtils.js`, which produces timezone-aware `YYYY-MM-DD` keys localized to `Asia/Kolkata`. However, the teacher dashboard still derived today's date using `new Date().toISOString().slice(0, 10)`, which returns the **UTC** date. Between 12:00 AM and 5:30 AM IST, UTC is one calendar day behind IST — so Firestore queries returned zero matching records, and check-ins appeared missing.

### Solution
- Imported `getTodayKeyLocal` from `@/lib/dateUtils`
- Replaced both UTC date derivations (attendance stats query and student roster snapshot query) with `getTodayKeyLocal()`

### Affected Files
- `components/TeacherDashboardComponent.js` — Two date key derivations aligned to localized timezone
