### PR TITLE
fix: isolate sync transaction failures to prevent batch-wide crash an…

### DIFF
--- a/app/api/attendance/sync/route.js
+++ b/app/api/attendance/sync/route.js
@@ -136,34 +136,46 @@ async function handleSync(request) {
     // duplicate records under concurrent sync requests from multiple tabs or devices.
     const newDocRef = db.collection("attendance_records").doc(`${decodedToken.uid}_${recordDate}`);
 
-    await db.runTransaction(async (transaction) => {
-      const existingAttendance = await transaction.get(newDocRef);
-      if (existingAttendance.exists) {
-        return;
-      }
+    // Wrap each transaction individually so a single Firestore failure
+    // (write lock, network blip) does not crash the entire batch.
+    // Only successfully written records are acknowledged to the client.
+    try {
+      await db.runTransaction(async (transaction) => {
+        const existingAttendance = await transaction.get(newDocRef);
+        if (existingAttendance.exists) {
+          return;
+        }
 
-      if (
-        (record.studentName && record.studentName !== serverIdentity.studentName) ||
-        (record.email && record.email !== serverIdentity.email)
-      ) {
-        console.warn(
-          `User ${decodedToken.uid} submitted offline attendance metadata that does not match the server profile`,
-        );
-      }
+        if (
+          (record.studentName && record.studentName !== serverIdentity.studentName) ||
+          (record.email && record.email !== serverIdentity.email)
+        ) {
+          console.warn(
+            `User ${decodedToken.uid} submitted offline attendance metadata that does not match the server profile`,
+          );
+        }
 
-      transaction.set(newDocRef, {
-        userId: decodedToken.uid,
-        studentName: serverIdentity.studentName,
-        email: serverIdentity.email,
-        instituteId,
-        timestamp: FieldValue.serverTimestamp(),
-        date: recordDate,
-        status: "present",
-        confidenceScore: normalizedConfidence,
-        offlineSynced: true,
-        queuedAt: new Date(record.queuedAt),
+        transaction.set(newDocRef, {
+          userId: decodedToken.uid,
+          studentName: serverIdentity.studentName,
+          email: serverIdentity.email,
+          instituteId,
+          timestamp: FieldValue.serverTimestamp(),
+          date: recordDate,
+          status: "present",
+          confidenceScore: normalizedConfidence,
+          offlineSynced: true,
+          queuedAt: new Date(record.queuedAt),
+        });
       });
-    });
+    } catch (txnError) {
+      console.error(
+        `[sync] Transaction failed for record ${decodedToken.uid}_${recordDate}:`,
+        txnError.message,
+      );
+      // Skip this record — do NOT acknowledge it so the client retries later
+      continue;
+    }
 
     successfulIds.push(record.id);
     processedUserDates.add(userDateKey);


### PR DESCRIPTION
## Description
Fixes a reliability issue where a single Firestore transaction failure during offline attendance sync would crash the entire batch, causing data loss.
Closes #1540 
### Problem
The `POST /api/attendance/sync` endpoint iterates over queued offline records and executes a Firestore transaction (`db.runTransaction()`) for each one. The `await` call inside the `for` loop had **no surrounding try/catch**. If any single transaction failed (write lock contention, network timeout, permission error), the unhandled rejection propagated to the top-level `withErrorHandler`, which returned a 500 response. Records that were already successfully written in earlier iterations were never acknowledged back to the client — so the client kept them in its IndexedDB outbox and retried them indefinitely, creating duplicate sync attempts.

### Solution
Wrapped the individual `db.runTransaction()` call in a try/catch block:
- **Success path**: Record ID is pushed to `successfulIds` and returned to the client for purging
- **Failure path**: Error is logged with the specific record key, `continue` skips to the next record, and the failed ID is omitted from `syncedIds` so the client retries it on the next sync cycle

### Affected Files
- `app/api/attendance/sync/route.js` — Added per-record transaction error isolation
