### PR TITLE
fix: attach Firebase auth token to attendance record API call to reso…

### DIFF
--- a/services/attendanceService.js
+++ b/services/attendanceService.js
@@ -8,7 +8,7 @@ import {
   limit,
 } from "firebase/firestore";
 
-import { db } from "@/lib/firebaseConfig";
+import { auth, db } from "@/lib/firebaseConfig";
 
 import { recalculateAttendanceRate } from "./statsService";
 import { saveToOutbox } from "@/lib/offlineStore";
@@ -93,10 +93,16 @@ export async function recordAttendance({
   }
 
   // SECURE SERVER RECORDING
+  const token = await auth?.currentUser?.getIdToken();
+  if (!token) {
+    throw new Error("Authentication token unavailable. Please sign in again.");
+  }
+
   const response = await fetch("/api/attendance/record", {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
+      "Authorization": `Bearer ${token}`,
     },
     body: JSON.stringify({
       userId,


### PR DESCRIPTION
## Description
Fixes all online student attendance check-ins failing with `401 Unauthorized`.
Closes #1541 
### Problem
The client-side `recordAttendance()` in `services/attendanceService.js` issues a POST to `/api/attendance/record`, which is protected by `authenticateRequest()` (Firebase Admin token verification). However, the fetch call only sent a `Content-Type` header — no `Authorization` header was included. Every online check-in attempt was rejected with a 401.

### Solution
- Imported `auth` from `@/lib/firebaseConfig`
- Before the fetch call, retrieves the current user's Firebase ID token via `auth.currentUser.getIdToken()`
- Attaches the token as `Authorization: Bearer <token>` in the request headers
- Added a guard that throws a descriptive error if no token is available (user signed out mid-flow)

### Affected Files
- `services/attendanceService.js` — Added auth token retrieval and Authorization header
