### PR TITLE
chore: add .editorconfig for consistent coding style across IDEs

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,24 @@
+# EditorConfig helps maintain consistent coding styles across different editors and IDEs
+# https://editorconfig.org
+
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.py]
+indent_size = 4
+
+[*.md]
+trim_trailing_whitespace = false
+
+[*.{yml,yaml}]
+indent_size = 2
+
+[Makefile]
+indent_style = tab


### PR DESCRIPTION
## Description

Adds a `.editorconfig` file to the repository root to enforce consistent coding styles (indentation, charset, line endings) across different editors and IDEs for all contributors.

## Related Issue

Closes #1558

## Type of Change

- [x] 🔧 Chore / Tooling / Config

## Changes Made

- Added `.editorconfig` with:
  - `indent_style = space`, `indent_size = 2` (global default)
  - Python files: `indent_size = 4`
  - Markdown files: preserve trailing whitespace
  - `end_of_line = lf` for cross-platform consistency
  - `charset = utf-8`
  - `trim_trailing_whitespace = true`
  - `insert_final_newline = true`

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings or errors
