### PR TITLE
chore: add .gitattributes file to manage line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,8 @@
+* text=auto
+*.js text eol=lf
+*.jsx text eol=lf
+*.ts text eol=lf
+*.tsx text eol=lf
+*.json text eol=lf
+*.css text eol=lf
+*.md text eol=lf


### PR DESCRIPTION
Fixes #1662. Added .gitattributes to ensure consistent LF line endings across OSs.