### PR TITLE
fix: add .gitattributes file to manage line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,8 +1,19 @@
+# Auto-detect text files and normalize line endings to LF
 * text=auto
+
+# Explicitly specify line endings for different file extensions
 *.js text eol=lf
 *.jsx text eol=lf
 *.ts text eol=lf
 *.tsx text eol=lf
 *.json text eol=lf
 *.css text eol=lf
+*.html text eol=lf
 *.md text eol=lf
+
+# Mark binary files to prevent normalization
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.ico binary


### PR DESCRIPTION
## What does this PR do?

This PR adds a standard `.gitattributes` file to the project.

## Why is this change needed?

Currently, cross-platform developers may commit files with CRLF endings.
This causes git tracking issues and line ending conflicts in PRs.

## What changes were made?

* Added `.gitattributes` to automatically normalize line endings to LF

## How to test

1. Verify that text files are auto-normalized to LF line endings upon commit

## Screenshots (if UI)

N/A

## Checklist

* [x] Code follows project style
* [x] Tested locally
* [x] No breaking changes

Fixes #1662