### PR TITLE
fix: add stale workflow to automate issue management

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,19 +1,26 @@
-name: Mark stale issues and pull requests
+name: "Close stale issues and PRs"
 
 on:
   schedule:
-  - cron: '30 1 * * *'
+    - cron: '0 0 * * *'
+  workflow_dispatch:
 
 jobs:
   stale:
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
     steps:
-    - uses: actions/stale@v9
-      with:
-        repo-token: ${{ secrets.GITHUB_TOKEN }}
-        stale-issue-message: 'This issue is stale because it has been open for 30 days with no activity.'
-        stale-pr-message: 'This PR is stale because it has been open for 45 days with no activity.'
-        stale-issue-label: 'stale'
-        stale-pr-label: 'stale'
-        days-before-stale: 30
-        days-before-close: 7
+      - uses: actions/stale@v9
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          stale-issue-message: 'This issue is stale because it has been open 30 days with no activity. Remove stale label or comment or this will be closed in 5 days.'
+          stale-pr-message: 'This PR is stale because it has been open 45 days with no activity. Remove stale label or comment or this will be closed in 10 days.'
+          close-issue-message: 'This issue was closed because it has been stalled for 5 days with no activity.'
+          close-pr-message: 'This PR was closed because it has been stalled for 10 days with no activity.'
+          stale-issue-label: 'stale'
+          stale-pr-label: 'stale'
+          days-before-stale: 30
+          days-before-pr-stale: 45
+          days-before-close: 5


### PR DESCRIPTION
## What does this PR do?

This PR adds a standard `.github/workflows/stale.yml` file to the project.

## Why is this change needed?

Currently, inactive issues and PRs remain open indefinitely without updates.
This causes cluttered issue tracker and developer overhead.

## What changes were made?

* Added `.github/workflows/stale.yml` workflow configured with days before stale

## How to test

1. Check the newly created `.github/workflows/stale.yml` file

## Screenshots (if UI)

N/A

## Checklist

* [x] Code follows project style
* [x] Tested locally
* [x] No breaking changes

Fixes #1664