### PR TITLE
fix: use dynamic contact telephone link on contact page

### DIFF
--- a/app/contact/page.js
+++ b/app/contact/page.js
@@ -190,7 +190,7 @@ export default function Contact() {
       icon: Phone,
       label: "Phone",
       value: CONTACT_INFO.phone,
-      href: "tel:+919310243800",
+      href: `tel:${CONTACT_INFO.phone.replace(/\s+/g, "")}`,
       gradient: "from-green-500 to-emerald-500",
     },
     {


### PR DESCRIPTION
## What does this PR do?
This PR updates the contact page telephone link to reference the global contact info configuration dynamically rather than using a hardcoded string.

## Why is this change needed?
Currently, if the contact phone number is updated in the constants, the text changes but the clickable dial link still calls the old hardcoded number.

## What changes were made?
* Replaced hardcoded `"tel:+919310243800"` with dynamc ``tel:${CONTACT_INFO.phone.replace(/\s+/g, "")}``

## How to test
1. Go to the Contact Page
2. Click the Phone link or inspect the anchor href
3. Verify that the dial link correctly points to the configured phone number

## Checklist
* [x] Code follows project style
* [x] Tested locally
* [x] No breaking changes

Fixes #1699