### PR TITLE
fix: add fallback avatar rendering when profile image fails to load

### DIFF
--- a/components/Navbar.js
+++ b/components/Navbar.js
@@ -427,18 +427,17 @@ export function Navbar() {
                       aria-label="Toggle profile menu"
                     >
                       <div className="relative w-7 h-7 shrink-0">
-                        {getUserPhoto() ? (
+                        {getUserPhoto() && (
                           <Image
                             src={getUserPhoto()} alt={`${getUserDisplayName()} profile photo`}
                             width={28} height={28}
                             className="rounded-full object-cover ring-2 ring-blue-500/30"
                             onError={handleImageError}
                           />
-                        ) : (
-                          <div className="absolute inset-0 rounded-full bg-gradient-to-br from-blue-500 to-violet-600 flex items-center justify-center text-white text-xs font-bold">
-                            {getUserInitials(getUserDisplayName())}
-                          </div>
                         )}
+                        <div className="fallback-avatar absolute inset-0 rounded-full bg-gradient-to-br from-blue-500 to-violet-600 flex items-center justify-center text-white text-xs font-bold" style={{ display: getUserPhoto() ? "none" : "flex" }}>
+                          {getUserInitials(getUserDisplayName())}
+                        </div>
                         <span className="absolute -bottom-0.5 -right-0.5 h-2.5 w-2.5 bg-emerald-400 rounded-full ring-2 ring-white dark:ring-zinc-950" />
                       </div>
 
@@ -588,13 +587,12 @@ export function Navbar() {
               {isAuthenticated && (
                 <div className="flex items-center gap-3 p-2.5 bg-zinc-50/60 dark:bg-white/4 rounded-xl border border-zinc-100/60 dark:border-white/6">
                   <div className="relative w-9 h-9 shrink-0">
-                    {getUserPhoto() ? (
+                    {getUserPhoto() && (
                       <Image src={getUserPhoto()} alt={`${getUserDisplayName()} profile photo`} width={36} height={36} className="rounded-full object-cover" onError={handleImageError} />
-                    ) : (
-                      <div className="absolute inset-0 rounded-full bg-gradient-to-br from-blue-500 to-violet-600 flex items-center justify-center text-white text-xs font-bold">
-                        {getUserInitials(getUserDisplayName())}
-                      </div>
                     )}
+                    <div className="fallback-avatar absolute inset-0 rounded-full bg-gradient-to-br from-blue-500 to-violet-600 flex items-center justify-center text-white text-xs font-bold" style={{ display: getUserPhoto() ? "none" : "flex" }}>
+                      {getUserInitials(getUserDisplayName())}
+                    </div>
                     <span className="absolute -bottom-0.5 -right-0.5 h-2.5 w-2.5 bg-emerald-400 rounded-full ring-2 ring-white dark:ring-zinc-950" />
                   </div>
                   <div className="min-w-0">


### PR DESCRIPTION
## What does this PR do?
This PR fixes the avatar loading failure behavior by ensuring that the fallback initials placeholder with class `fallback-avatar` is always rendered in both desktop and mobile user strips.

## Why is this change needed?
Currently, if a user's profile image fails to load, the error handler cannot display the fallback initials because they are conditionally omitted from the DOM, causing a broken image icon to appear.

## What changes were made?
* Render initials wrapper always, setting `display: getUserPhoto() ? "none" : "flex"`
* Enabled `handleImageError` to toggling layout display cleanly

## How to test
1. Login with a user profile
2. Emulate a broken image url or block the image load request in DevTools
3. Verify that the fallback initials display automatically instead of a broken image placeholder

## Checklist
* [x] Code follows project style
* [x] Tested locally
* [x] No breaking changes

Fixes #1701