### PR TITLE
fix: align hover translations for footer CTA buttons

### DIFF
--- a/components/Footer.js
+++ b/components/Footer.js
@@ -125,7 +125,7 @@ export default function Footer() {
               </Link>
               <Link
                 href="/contact"
-                className="inline-flex items-center gap-2 rounded-full border border-white/15 bg-white/5 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-white/10"
+                className="inline-flex items-center gap-2 rounded-full border border-white/15 bg-white/5 px-4 py-2 text-sm font-medium text-white transition-all hover:bg-white/10 hover:-translate-y-0.5"
               >
                 Contact Team
               </Link>


### PR DESCRIPTION
## What does this PR do?
This PR aligns the hover interactions of the primary and secondary CTA buttons in the footer.

## Why is this change needed?
Currently, "Get Started" has a nice hover translation animation, while "Contact Team" stays static, which feels visually disjointed to the user.

## What changes were made?
* Added `hover:-translate-y-0.5` and `transition-all` to the secondary CTA button

## How to test
1. Scroll down to the Footer
2. Hover over "Get Started" and "Contact Team"
3. Verify that both animate consistently on hover

## Checklist
* [x] Code follows project style
* [x] Tested locally
* [x] No breaking changes

Fixes #1704