### PR TITLE
fix: adjust navigation link underline position to avoid descender overlap

### DIFF
--- a/components/Navbar.js
+++ b/components/Navbar.js
@@ -73,7 +73,7 @@ function NavLink({ href, label, isActive }) {
     <Link
       href={href}
       aria-current={isActive ? "page" : undefined}
-      className="relative text-sm font-semibold tracking-wide px-4 py-2 rounded-xl group after:content-[''] after:absolute after:bottom-1 after:left-3 after:right-3 after:h-[3px] after:rounded-full after:bg-gradient-to-r after:from-blue-500 after:via-cyan-400 after:to-violet-500 after:shadow-sm after:shadow-blue-500/30 after:pointer-events-none after:will-change-transform after:origin-left after:transition-transform after:duration-300 after:ease-[cubic-bezier(0.4,0,0.2,1)] after:scale-x-0 group-hover:after:scale-x-100"
+      className="relative text-sm font-semibold tracking-wide px-4 py-2 rounded-xl group after:content-[''] after:absolute after:bottom-0 after:left-3 after:right-3 after:h-[3px] after:rounded-full after:bg-gradient-to-r after:from-blue-500 after:via-cyan-400 after:to-violet-500 after:shadow-sm after:shadow-blue-500/30 after:pointer-events-none after:will-change-transform after:origin-left after:transition-transform after:duration-300 after:ease-[cubic-bezier(0.4,0,0.2,1)] after:scale-x-0 group-hover:after:scale-x-100"
     >
       {isActive && (
         <motion.span


### PR DESCRIPTION
## What does this PR do?
This PR adjusts the vertical position of the active/hover underline indicator in the Navbar navigation links.

## Why is this change needed?
Currently, the line is positioned slightly too high, overlapping with the descenders of letters (e.g. 'y' in 'Activities', 'g' in 'Settings').

## What changes were made?
* Shifted line position class from `after:bottom-1` to `after:bottom-0`

## How to test
1. Hover over the navigation links in the Navbar (Focus, Activities, etc.)
2. Check that the underline renders cleanly below the letter bounds without crossing the bottom of descender glyphs

## Checklist
* [x] Code follows project style
* [x] Tested locally
* [x] No breaking changes

Fixes #1706