### PR TITLE
fix(gamification): prevent concurrent XP overwrite during parallel reward execution (#1604)

### DIFF
--- a/lib/__tests__/gamificationRace.test.js
+++ b/lib/__tests__/gamificationRace.test.js
@@ -1,0 +1,98 @@
+import { connectDb } from "@/lib/mongodb";
+import { awardXp } from "@/lib/gamification-service";
+
+jest.setTimeout(30000);
+
+describe("Gamification Concurrency Race Condition Test", () => {
+  let db;
+  const testFirebaseUid = "race-test-student-999";
+
+  beforeAll(async () => {
+    try {
+      db = await connectDb();
+      console.log("Connected to MongoDB successfully!");
+    } catch (err) {
+      console.error("Failed to connect to MongoDB:", err);
+      throw err;
+    }
+  });
+
+  beforeEach(async () => {
+    // Reset test user document
+    await db.collection("users").deleteOne({ firebaseUid: testFirebaseUid });
+    await db.collection("users").insertOne({
+      firebaseUid: testFirebaseUid,
+      email: "racetest@example.com",
+      name: "Race Test Student",
+      totalXp: 0,
+      currentLevel: 1,
+      xpToNextLevel: 100,
+      currentStreak: 0,
+      unlockedBadges: [],
+      attendanceHistory: [],
+      createdAt: new Date().toISOString(),
+    });
+  });
+
+  afterAll(async () => {
+    // Cleanup
+    if (db) {
+      await db.collection("users").deleteOne({ firebaseUid: testFirebaseUid });
+    }
+  });
+
+  test("reproduces the concurrent XP overwrite race condition", async () => {
+    const concurrentRequests = 5; // 5 concurrent focus sessions
+    // Each focus session completed awards 50 XP (XP_VALUES.focus_session_completed)
+    // Expected total XP after 5 sessions: 250 XP.
+
+    const promises = [];
+    for (let i = 0; i < concurrentRequests; i++) {
+      promises.push(awardXp(testFirebaseUid, "focus_session_completed", {}));
+    }
+
+    // Run them in parallel
+    const results = await Promise.all(promises);
+
+    // Fetch the final document from the database
+    const finalStudent = await db.collection("users").findOne({ firebaseUid: testFirebaseUid });
+
+    console.log("CONCURRENCY RESULTS:");
+    console.log("Individual returned totalXp values:", results.map(r => r.totalXp));
+    console.log("Final database totalXp value:", finalStudent.totalXp);
+
+    // If there is a race condition, the final totalXp in the database will be less than 250
+    // (typically 50, because they all read 0, compute 50, and write 50).
+    expect(finalStudent.totalXp).toBe(250);
+  });
+
+  test("handles mixed concurrent rewards aggressively without loss or corruption", async () => {
+    // We will fire 5 focus sessions (50 XP each) and 5 course completions (100 XP each) in parallel
+    // Expected total XP: 5 * 50 + 5 * 100 = 750 XP.
+    // Starting XP is 0 (reset in beforeEach).
+
+    const promises = [];
+    for (let i = 0; i < 5; i++) {
+      promises.push(awardXp(testFirebaseUid, "focus_session_completed", {}));
+      promises.push(awardXp(testFirebaseUid, "course_completed", {}));
+    }
+
+    // Fire all 10 concurrent reward updates in parallel
+    const results = await Promise.all(promises);
+
+    // Fetch the final document from the database
+    const finalStudent = await db.collection("users").findOne({ firebaseUid: testFirebaseUid });
+
+    console.log("MIXED CONCURRENCY RESULTS:");
+    console.log("Final database totalXp:", finalStudent.totalXp);
+    console.log("Final database currentLevel:", finalStudent.currentLevel);
+
+    // Expected total XP: 750 XP
+    expect(finalStudent.totalXp).toBe(750);
+
+    // Verify correct level recalculation
+    // Level = floor(sqrt(XP / 50)) + 1
+    // floor(sqrt(750 / 50)) + 1 = floor(sqrt(15)) + 1 = 3 + 1 = 4.
+    expect(finalStudent.currentLevel).toBe(4);
+  });
+});

--- a/lib/gamification-service.js
+++ b/lib/gamification-service.js
@@ -98,128 +98,158 @@ export async function awardXp(firebaseUid, actionType, metadata = {}) {
 
   const db = await connectDb();
 
-  const student = await db.collection("users").findOne({ firebaseUid });
-  if (!student) {
-    throw new Error("Student not found");
-  }
+  const MAX_RETRIES = 5;
+  let attempt = 0;
+  let cachedAttendanceHistory = null;
 
-  // Fetch true attendance history from Firestore for accurate early bird & gamification analysis
-  let attendanceHistory = student.attendanceHistory || [];
-  if (actionType === "attendance_marked") {
-    try {
-      const firestoreDb = getAdminDb();
-      const snapshot = await firestoreDb
-        .collection("attendance_records")
-        .where("userId", "==", firebaseUid)
-        .get();
+  while (attempt < MAX_RETRIES) {
+    attempt++;
 
-      attendanceHistory = [];
-      snapshot.forEach((doc) => {
-        const data = doc.data();
-        const dateObj = data.timestamp ? data.timestamp.toDate() : new Date();
-        const timeZone = process.env.NEXT_PUBLIC_TIMEZONE || "Asia/Kolkata";
-        let timeString;
+    const student = await db.collection("users").findOne({ firebaseUid });
+    if (!student) {
+      throw new Error("Student not found");
+    }
+
+    // Fetch true attendance history from Firestore for accurate early bird & gamification analysis
+    let attendanceHistory = student.attendanceHistory || [];
+    if (actionType === "attendance_marked") {
+      if (cachedAttendanceHistory !== null) {
+        attendanceHistory = cachedAttendanceHistory;
+      } else {
         try {
-          const formatter = new Intl.DateTimeFormat("en-GB", {
-            timeZone,
-            hour: "2-digit",
-            minute: "2-digit",
-            hour12: false,
+          const firestoreDb = getAdminDb();
+          const snapshot = await firestoreDb
+            .collection("attendance_records")
+            .where("userId", "==", firebaseUid)
+            .get();
+
+          attendanceHistory = [];
+          snapshot.forEach((doc) => {
+            const data = doc.data();
+            const dateObj = data.timestamp ? data.timestamp.toDate() : new Date();
+            const timeZone = process.env.NEXT_PUBLIC_TIMEZONE || "Asia/Kolkata";
+            let timeString;
+            try {
+              const formatter = new Intl.DateTimeFormat("en-GB", {
+                timeZone,
+                hour: "2-digit",
+                minute: "2-digit",
+                hour12: false,
+              });
+              timeString = formatter.format(dateObj);
+            } catch (_) {
+              const pad = (num) => String(num).padStart(2, "0");
+              timeString = `${pad(dateObj.getHours())}:${pad(dateObj.getMinutes())}`;
+            }
+
+            attendanceHistory.push({
+              date: data.date || dateObj.toISOString().slice(0, 10),
+              time: timeString,
+            });
           });
-          timeString = formatter.format(dateObj);
-        } catch (_) {
-          const pad = (num) => String(num).padStart(2, "0");
-          timeString = `${pad(dateObj.getHours())}:${pad(dateObj.getMinutes())}`;
+          cachedAttendanceHistory = attendanceHistory;
+        } catch (error) {
+          console.error("Failed to sync attendance history from Firestore:", error);
+          attendanceHistory = student.attendanceHistory || [];
         }
-
-        attendanceHistory.push({
-          date: data.date || dateObj.toISOString().slice(0, 10),
-          time: timeString,
-        });
-      });
-    } catch (error) {
-      console.error("Failed to sync attendance history from Firestore:", error);
-      attendanceHistory = student.attendanceHistory || [];
+      }
     }
+
+    const now = new Date();
+    let totalXp = student.totalXp || 0;
+    let currentStreak = student.currentStreak || 0;
+    const previousLevel = student.currentLevel || calculateLevel(totalXp);
+    const previousBadges = student.unlockedBadges || [];
+
+    let xpAwarded = XP_VALUES[actionType];
+    let earlyBird = false;
+    let streakMilestones = [];
+
+    if (actionType === "attendance_marked") {
+      const streakResult = processStreak(student, now);
+      currentStreak = streakResult.currentStreak;
+
+      if (streakResult.streakContinued) {
+        xpAwarded += XP_VALUES.streak_continued;
+      }
+
+      for (const milestoneAction of streakResult.milestones) {
+        xpAwarded += XP_VALUES[milestoneAction];
+        streakMilestones.push(milestoneAction);
+      }
+
+      const hour = metadata.attendanceHour ?? now.getHours();
+      if (hour < EARLY_BIRD_HOUR) {
+        xpAwarded += XP_VALUES.early_bird;
+        earlyBird = true;
+      }
+    }
+
+    totalXp += xpAwarded;
+
+    const currentLevel = calculateLevel(totalXp);
+    const xpToNextLevel = calculateNextLevelXp(currentLevel);
+    const levelUp = currentLevel > previousLevel;
+
+    const studentData = {
+      currentStreak,
+      currentLevel,
+      totalXp,
+      attendanceHistory,
+    };
+
+    const newlyUnlocked = calculateUnlockedBadges(studentData);
+    const newBadges = newlyUnlocked.filter((id) => !previousBadges.includes(id));
+    const unlockedBadges = [...new Set([...previousBadges, ...newlyUnlocked])];
+
+    const currentVersion = student.version || 0;
+
+    const updateFields = {
+      totalXp,
+      currentLevel,
+      xpToNextLevel,
+      unlockedBadges,
+      lastXpAward: now.toISOString(),
+      attendanceHistory, // Keep MongoDB synchronized
+      version: currentVersion + 1,
+    };
+
+    if (actionType === "attendance_marked") {
+      updateFields.currentStreak = currentStreak;
+      updateFields.lastAttendanceDate = now.toISOString();
+    }
+
+    const updateResult = await db.collection("users").updateOne(
+      {
+        firebaseUid,
+        $or: [
+          { version: currentVersion },
+          { version: { $exists: false } }
+        ]
+      },
+      { $set: updateFields }
+    );
+
+    if (updateResult.matchedCount > 0) {
+      return {
+        xpAwarded,
+        totalXp,
+        currentLevel,
+        xpToNextLevel,
+        levelUp,
+        newBadges,
+        currentStreak,
+        earlyBird,
+        streakMilestones,
+      };
+    }
+
+    console.warn(`[awardXp] Concurrency collision detected for user ${firebaseUid} on attempt ${attempt}. Retrying...`);
+    // Add brief jitter delay before retry to allow other concurrent process to complete
+    await new Promise((resolve) => setTimeout(resolve, Math.random() * 50 + 10));
   }
 
-  const now = new Date();
-  let totalXp = student.totalXp || 0;
-  let currentStreak = student.currentStreak || 0;
-  const previousLevel = student.currentLevel || calculateLevel(totalXp);
-  const previousBadges = student.unlockedBadges || [];
-
-  let xpAwarded = XP_VALUES[actionType];
-  let earlyBird = false;
-  let streakMilestones = [];
-
-  if (actionType === "attendance_marked") {
-    const streakResult = processStreak(student, now);
-    currentStreak = streakResult.currentStreak;
-
-    if (streakResult.streakContinued) {
-      xpAwarded += XP_VALUES.streak_continued;
-    }
-
-    for (const milestoneAction of streakResult.milestones) {
-      xpAwarded += XP_VALUES[milestoneAction];
-      streakMilestones.push(milestoneAction);
-    }
-
-    const hour = metadata.attendanceHour ?? now.getHours();
-    if (hour < EARLY_BIRD_HOUR) {
-      xpAwarded += XP_VALUES.early_bird;
-      earlyBird = true;
-    }
-  }
-
-  totalXp += xpAwarded;
-
-  const currentLevel = calculateLevel(totalXp);
-  const xpToNextLevel = calculateNextLevelXp(currentLevel);
-  const levelUp = currentLevel > previousLevel;
-
-  const studentData = {
-    currentStreak,
-    currentLevel,
-    totalXp,
-    attendanceHistory,
-  };
-
-  const newlyUnlocked = calculateUnlockedBadges(studentData);
-  const newBadges = newlyUnlocked.filter((id) => !previousBadges.includes(id));
-  const unlockedBadges = [...new Set([...previousBadges, ...newlyUnlocked])];
-
-  const updateFields = {
-    totalXp,
-    currentLevel,
-    xpToNextLevel,
-    unlockedBadges,
-    lastXpAward: now.toISOString(),
-    attendanceHistory, // Keep MongoDB synchronized
-  };
-
-  if (actionType === "attendance_marked") {
-    updateFields.currentStreak = currentStreak;
-    updateFields.lastAttendanceDate = now.toISOString();
-  }
-
-  await db.collection("users").updateOne(
-    { firebaseUid },
-    { $set: updateFields }
-  );
-
-  return {
-    xpAwarded,
-    totalXp,
-    currentLevel,
-    xpToNextLevel,
-    levelUp,
-    newBadges,
-    currentStreak,
-    earlyBird,
-    streakMilestones,
-  };
+  throw new Error(`Failed to award XP for user ${firebaseUid} after ${MAX_RETRIES} concurrent retry attempts.`);
 }
 
 /** Exported for use in the award API route's Zod validation. */


### PR DESCRIPTION
## Description

This PR resolves a critical concurrency issue in the gamification reward system where simultaneous XP-awarding operations could overwrite each other and silently lose earned XP during parallel activity execution.

The issue originated from a non-atomic read-modify-write persistence flow that allowed multiple concurrent reward handlers to read stale XP values before persisting updates back to the database.

This affected reward-triggering flows such as:

- attendance rewards
- Pomodoro focus session rewards
- streak rewards
- course completion rewards
- mixed parallel gamification activity execution

The final implementation introduces optimistic concurrency control (OCC) safeguards with version-aware updates and retry handling to ensure XP accumulation, level progression, and badge recalculation remain transactionally consistent under concurrent execution conditions.

Fixes #1604

---

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

---

## How Has This Been Tested?

### Manual Verification
- [x] Simulated concurrent reward-triggering operations using parallel Promise-based execution
- [x] Verified XP totals remain mathematically correct under simultaneous reward updates
- [x] Verified no silent XP loss occurs during high-frequency concurrent execution
- [x] Verified level progression and badge recalculation remain deterministic

### Automated Concurrency Testing
- [x] Added aggressive concurrency-focused stress tests
- [x] Tested mixed reward storms with:
  - concurrent Pomodoro rewards
  - concurrent course completion rewards
  - simultaneous mixed activity execution
- [x] Verified OCC retry handling resolves write collisions safely
- [x] Verified final XP state converges correctly after contention

### Regression Testing
- [x] Verified attendance rewards still function correctly
- [x] Verified streak rewards remain functional
- [x] Verified existing gamification flows remain backward compatible
- [x] Verified legacy/unversioned user documents continue working safely

---

## Technical Notes

### Root Cause
The original XP persistence flow relied on:

1. reading current XP state
2. recalculating progression in memory
3. persisting updated values back to MongoDB

Under concurrency, multiple executions could read the same stale XP snapshot before writes completed, causing last-write-wins overwrites and silent XP loss.

### Why `$inc` Alone Was Insufficient
A simple atomic `$inc` was not enough because gamification progression also recalculates:

- levels
- badges
- derived progression state
- streak transitions

These recalculations depend on synchronized absolute XP state and could still overwrite newer progression metadata if stale reads persisted.

### Final Implementation
This PR introduces:

- optimistic concurrency control (OCC)
- version-aware conditional updates
- deterministic retry handling with jitter
- safe collision recovery behavior
- backward-compatible version handling for older documents

The implementation intentionally avoids unnecessary architectural rewrites while ensuring production-safe concurrency correctness.

---

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings
- [x] I verified concurrency correctness through aggressive stress testing