### PR TITLE
Fix dynamic import race condition and error handling in firestorePool

### DIFF
--- a/contexts/FirestoreContext.js
+++ b/contexts/FirestoreContext.js
@@ -56,6 +56,9 @@ function usePooledCollection(key, buildQuery, enabled = true) {
     // Build the Firestore query (may be null if db isn't ready)
     const q = buildQuery();
     if (!q) {
+      if (!db) {
+        setError(new Error("Firestore is not initialized. Check your Firebase configuration."));
+      }
       setLoading(false);
       return;
     }

--- a/lib/firestorePool.js
+++ b/lib/firestorePool.js
@@ -1,3 +1,5 @@
+import { onSnapshot } from "firebase/firestore";
+
 /**
  * lib/firestorePool.js
  *
@@ -30,7 +32,6 @@ const firestorePool = (() => {
    */
   function subscribe(key, query, onData, onError) {
     if (!pool.has(key)) {
-      // First subscriber — create the real Firestore listener
       const entry = {
         unsub: null,
         data: null,
@@ -40,46 +41,39 @@ const firestorePool = (() => {
       };
       pool.set(key, entry);
 
-      // Lazily import onSnapshot to avoid SSR issues
-      import("firebase/firestore").then(({ onSnapshot }) => {
-        if (!pool.has(key)) return; // entry was cleaned up before import resolved
-
-        const firestoreUnsub = onSnapshot(
-          query,
-          (snapshot) => {
-            const docs = snapshot.docs.map((doc) => ({
-              id: doc.id,
-              ...doc.data(),
-            }));
-            const e = pool.get(key);
-            if (!e) return;
-            e.data = docs;
-            e.error = null;
-            e.listeners.forEach((cb) => cb(docs));
-          },
-          (err) => {
-            const e = pool.get(key);
-            if (!e) return;
-            e.error = err;
-            e.errorListeners.forEach((cb) => cb(err));
-          }
-        );
-
-        const e = pool.get(key);
-        if (e) {
-          e.unsub = firestoreUnsub;
-        } else {
-          // All consumers unsubscribed while we were loading — clean up immediately
-          firestoreUnsub();
+      const firestoreUnsub = onSnapshot(
+        query,
+        (snapshot) => {
+          const docs = snapshot.docs.map((doc) => ({
+            id: doc.id,
+            ...doc.data(),
+          }));
+          const e = pool.get(key);
+          if (!e) return;
+          e.data = docs;
+          e.error = null;
+          e.listeners.forEach((cb) => cb(docs));
+        },
+        (err) => {
+          const e = pool.get(key);
+          if (!e) return;
+          e.error = err;
+          e.errorListeners.forEach((cb) => cb(err));
         }
-      });
+      );
+
+      const e = pool.get(key);
+      if (e) {
+        e.unsub = firestoreUnsub;
+      } else {
+        firestoreUnsub();
+      }
     }
 
     const entry = pool.get(key);
     entry.listeners.add(onData);
     if (onError) entry.errorListeners.add(onError);
 
-    // If we already have cached data, deliver it immediately (instant render)
     if (entry.data !== null) {
       onData(entry.data);
     }
@@ -87,7 +81,6 @@ const firestorePool = (() => {
       onError(entry.error);
     }
 
-    // Return unsubscribe handle
     return () => {
       const e = pool.get(key);
       if (!e) return;
@@ -95,7 +88,6 @@ const firestorePool = (() => {
       e.listeners.delete(onData);
       if (onError) e.errorListeners.delete(onError);
 
-      // When no consumers remain, tear down the Firestore listener
       if (e.listeners.size === 0) {
         if (e.unsub) e.unsub();
         pool.delete(key);


### PR DESCRIPTION
Closes #1680

## What this fixes

`lib/firestorePool.js:44` used a lazy dynamic `import("firebase/firestore")` inside the `subscribe()` function to avoid SSR issues. This created a critical race window: if components subscribed and unsubscribed before the import resolved, the Firestore listener would either be assigned to a stale query reference (third consumer gets wrong data), or the promise rejection on import failure would go completely unhandled, leaving components in a permanent loading state.

`contexts/FirestoreContext.js:58` silently returned empty data when `buildQuery()` returned `null` due to `db` being uninitialized — no error state was surfaced to consumers, so UI components showed blank content with no indication anything was wrong.

## Root cause

The dynamic `import()` in `firestorePool.js` is an asynchronous operation that creates a temporal gap between `subscribe()` being called and the `onSnapshot` listener being registered. During this gap, the pool entry can be deleted (all subscribers left) and re-created (new subscriber arrives), but the `.then()` callback still runs with the original `query` reference from the first call — not the query from the re-created entry. The missing `.catch()` meant any import failure was silently swallowed, with the rejected promise becoming an unhandled rejection.

In `FirestoreContext.js`, the `usePooledCollection` hook treated a null return from `buildQuery()` as a no-op, setting `loading = false` without setting any error. This masked the case where Firebase was never initialized (missing config).

## What changed

- **`lib/firestorePool.js`**: Replaced the dynamic `import("firebase/firestore")` with a static `import { onSnapshot } from "firebase/firestore"` at module level. The file is only imported by `FirestoreContext.js` which already has `"use client"` and already statically imports from `firebase/firestore`, so the lazy import was adding complexity without benefit. This eliminates the race condition at the root — `onSnapshot` is available synchronously when `subscribe()` is called. Removed the async `.then()` wrapper and all pending-state tracking that would have been needed to fix the race within the dynamic import pattern.

- **`contexts/FirestoreContext.js`**: In `usePooledCollection`, when `buildQuery()` returns `null` and `db` is also null, set an `Error` state via `setError()` so that consumers receive an initialization error instead of silently empty data.

## How to verify

1. Run the existing build: `npm run build` — confirms no import errors from the static firebase/firestore import.
2. To test the race scenario (manual): mount a component using `useNotices()` and unmount it within 50ms in a tight loop. Before this fix, the second mount would sometimes receive data from a stale listener. After this fix, every subscribe creates the listener synchronously — no race window exists.
3. To test the error surface: set `NEXT_PUBLIC_FIREBASE_API_KEY` to an empty string and load a page with `useNotices()`. Before this fix, the component rendered empty content silently. After this fix, the `error` field from `useNotices()` contains an "Firestore is not initialized" Error object that components can render.

## Edge cases considered

- **Static import with no `"use client"` guard**: `firestorePool.js` does not have `"use client"`, but it is only imported by `FirestoreContext.js` which does. Next.js treats the entire import chain as client-side — the module is never evaluated during SSR. Verified via grep that no other file imports firestorePool.
- **Component mounts before db is ready**: The `enabled` prop (tied to `isReady`) prevents subscription until auth is ready and db is initialized. The new error path only fires when `enabled` is true but `db` is still null — which is the misconfiguration case.
- **Import chunk loading failure**: With a static import, a Firebase SDK chunk failure would prevent the module from loading at all, which is caught at build time or as a runtime module error rather than a silent unhandled rejection.
- **Cleanup on unsubscribe during snapshot delivery**: The `onSnapshot` unsubscribe function is returned synchronously and stored on the entry. If all listeners unsubscribe, the listener is torn down immediately — no more async race where the import resolves after cleanup.