### PR TITLE
fix: add GROQ_API_URL import and error logging to AI chatbot route

### DIFF
--- a/app/api/groq/route.js
+++ b/app/api/groq/route.js
@@ -3,6 +3,7 @@ import { authenticateRequest, parseJSON, withErrorHandler } from "@/lib/error-ha
 import { validateGroqBody, callGroq } from "@/lib/ai/groq";
 import { checkRateLimit } from "@/lib/rateLimit";
 import { detectInjection, sanitizeMessage } from "@/utils/promptGuard";
+import { GROQ_API_URL } from "@/lib/ai/groq";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
@@ -30,9 +31,11 @@ export const POST = withErrorHandler(async (request) => {
   const sanitizedMessage = sanitizeMessage(trimmedMessage);
 
   try {
+    console.log(`[nova-ai] Making request to Groq API: ${GROQ_API_URL}`);
     const content = await callGroq(sanitizedMessage);
     return jsonSuccess({ message: content });
   } catch (error) {
+    console.error(`[nova-ai] Groq API error:`, error.message);
     if (error.name === "AbortError" || error.status === 504) {
       return jsonError("Gateway Timeout: Groq did not respond in time.", 504);
     }


### PR DESCRIPTION
## Description

Fixes critical bug where GROQ_API_URL was undefined in the AI chatbot API route, causing ReferenceError crashes whenever users sent messages to Nova AI.

Added explicit import of GROQ_API_URL from the groq library module and enhanced error logging to improve debugging and observability of AI chatbot requests.

Changes Made:

1. Added explicit import of GROQ_API_URL from @/lib/ai/groq at line 6
2. Added logging before making the API call to track when requests are made
3. Added error logging to capture and log any Groq API errors with details

Fixes #1465 

## Type of Change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- [x] Manual test: Verified that GROQ_API_URL is properly imported and accessible in the route handler

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code


