### PR TITLE
fix: prevent privilege escalation by enforcing strict no-overwrite policy on user roles

### DIFF
--- a/app/api/auth/set-role/route.js
+++ b/app/api/auth/set-role/route.js
@@ -48,13 +48,13 @@ export const POST = withValidation(
     if (existingProfile.exists) {
       const existingRole = existingProfile.data()?.role;
 
-      if (existingRole && existingRole !== role) {
+      if (existingRole) {
         return jsonError(
           `Forbidden: Account is already registered as "${existingRole}". Role cannot be changed.`,
           403
         );
       }
-    } else if (decodedToken.role && decodedToken.role !== role) {
+    } else if (decodedToken.role) {
       return jsonError(
         `Forbidden: Token already carries role "${decodedToken.role}". Role cannot be changed.`,
         403


### PR DESCRIPTION
## Description
This pull request addresses a vulnerability in the /api/auth/set-role endpoint where the system did not properly enforce restrictions if an existing role was already set on the user's profile. This oversight could potentially be exploited by a malicious actor repeatedly calling the endpoint to alter their account details or inadvertently escalate privileges in certain conditions.

Fixes #1463 

## Type of Change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- [ ] Manual test: (explain how you verified the changes)
- [x] Automated test suite

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings
