### PR TITLE
fix: use crypto.randomUUID() for notification IDs to prevent collisions

### DIFF
--- a/contexts/NotificationContext.js
+++ b/contexts/NotificationContext.js
@@ -10,7 +10,11 @@ export function NotificationProvider({ children }) {
   const timersRef = useRef(new Map());
 
   const addNotification = (notification) => {
-    const id = Date.now();
+    // Use crypto.randomUUID() to guarantee unique IDs even when notifications
+    // are added simultaneously (prevents ID collision with Date.now())
+    const id = typeof crypto !== 'undefined' && crypto.randomUUID 
+      ? crypto.randomUUID() 
+      : `notif_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;
 
     const newNotification = {
       id,


### PR DESCRIPTION
## Description

fix: use crypto.randomUUID() for notification IDs to prevent collisions

- Replace Date.now() with crypto.randomUUID() for guaranteed unique IDs
- Add fallback for environments without crypto.randomUUID() support
- Fix bug where simultaneous notifications shared the same ID
- Prevent notifications from disappearing prematurely when auto-remove timers fire

Fixes: Multiple notifications with same ID causing unexpected removal

Changes Made:

1. Replaced Date.now() with crypto.randomUUID() at line 13
2. Guarantees globally unique IDs even when multiple notifications are added in the same millisecond
3. Includes a fallback for environments where crypto.randomUUID() is not available (uses Date.now() + random string)
4. Added explanatory comment documenting why we use crypto.randomUUID() instead of Date.now()

Fixes #1536 

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [ ] Manual test: (explain how you verified the changes)

## Checklist:
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have checked my code and corrected any misspellings
