### PR TITLE
Fix XP being re-awarded on every offline sync retry of already-recorded attendance

### DIFF
--- a/app/api/attendance/sync/route.js
+++ b/app/api/attendance/sync/route.js
@@ -145,18 +145,14 @@ async function handleSync(request) {
       continue;
     }
 
-    // Atomic check-and-set using a Firestore transaction to prevent
-    // duplicate records under concurrent sync requests from multiple tabs or devices.
     const newDocRef = db.collection("attendance_records").doc(`${decodedToken.uid}_${recordDate}`);
 
-    // Wrap each transaction individually so a single Firestore failure
-    // (write lock, network blip) does not crash the entire batch.
-    // Only successfully written records are acknowledged to the client.
+    let wasWritten = false;
     try {
-      await db.runTransaction(async (transaction) => {
+      wasWritten = await db.runTransaction(async (transaction) => {
         const existingAttendance = await transaction.get(newDocRef);
         if (existingAttendance.exists) {
-          return;
+          return false;
         }
 
         if (
@@ -180,17 +176,23 @@ async function handleSync(request) {
           offlineSynced: true,
           queuedAt: new Date(record.queuedAt),
         });
+
+        return true;
       });
     } catch (txnError) {
       console.error(
         `[sync] Transaction failed for record ${decodedToken.uid}_${recordDate}:`,
         txnError.message,
       );
-      // Skip this record — do NOT acknowledge it so the client retries later
       continue;
     }
 
     successfulIds.push(record.id);
+
+    if (!wasWritten) {
+      continue;
+    }
+
     processedUserDates.add(userDateKey);
 
     try {

--- a/app/api/attendance/sync/route.test.js
+++ b/app/api/attendance/sync/route.test.js
@@ -211,6 +211,62 @@ describe("attendance sync route", () => {
     });
   });
 
+  test("acknowledges duplicate records without awarding XP when attendance already exists in Firestore", async () => {
+    requireAuth.mockResolvedValue({
+      uid: "user-123",
+      email: "auth@example.com",
+    });
+
+    parseJSON.mockResolvedValue({
+      records: [
+        {
+          id: 5,
+          userId: "user-123",
+          confidenceScore: 85,
+          queuedAt: Date.now(),
+        },
+      ],
+    });
+
+    getUserProfile.mockResolvedValue({
+      fullName: "Server Name",
+      email: "server@example.com",
+    });
+
+    let transactionGet;
+    let transactionSet;
+
+    const docRef = {};
+    const collectionRef = {
+      doc: jest.fn(() => docRef),
+    };
+
+    getFirestore.mockReturnValue({
+      runTransaction: jest.fn(async (callback) => {
+        transactionGet = jest.fn().mockResolvedValue({ exists: true });
+        transactionSet = jest.fn();
+        return callback({ get: transactionGet, set: transactionSet });
+      }),
+      collection: jest.fn(() => collectionRef),
+    });
+
+    const response = await POST({
+      headers: {
+        get: jest.fn().mockReturnValue(null),
+      },
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      success: true,
+      syncedIds: [5],
+      rejectedIds: [],
+    });
+
+    expect(transactionGet).toHaveBeenCalledTimes(1);
+    expect(transactionSet).not.toHaveBeenCalled();
+  });
+
   test("normalizes confidence scores into the valid range", () => {
     // Values below the 60% minimum threshold are rejected
     expect(normalizeConfidenceScore(-2)).toBeNull();


### PR DESCRIPTION
close #1736 
## What this fixes

Every offline attendance record that gets re-synced — from a second device, a page reload, or a service worker retry — inflates the student's XP, streak counter, and badge progress even though the Firestore attendance document already existed. The sync route's transaction correctly detected duplicates but had no path to communicate that to the caller, so `awardXp()` in `sync/route.js:197` ran unconditionally after every successful transaction.

## Root cause

The Firestore transaction callback in `sync/route.js:156` returned early with a bare `return` when the document already existed. Since `runTransaction` returns the callback's return value, this was silently swallowed. The code after the transaction (`sync/route.js:193-202`) then pushed the record to `successfulIds` and called `awardXp()` for every record, regardless of whether the transaction actually wrote a new document or skipped an existing one.

The online attendance path in `record/route.js:55-81` handles this correctly — it sets a `let alreadyRecorded` variable inside the transaction and returns early before `awardXp()` at `record/route.js:80-82`.

## What changed

**`app/api/attendance/sync/route.js`** — The transaction callback now returns `false` when the document already exists and `true` when a new record was written. The outer code uses this return value to gate `processedUserDates.add()` and `awardXp()`. Already-existing records are still acknowledged in `successfulIds` so the client removes them from the local queue, but no XP is awarded.

**`app/api/attendance/sync/route.test.js`** — Added a test that mocks an existing Firestore document and verifies the transaction get is called, no write is performed, and the record is acknowledged without triggering a Firestore write.

## How to verify

1. The existing test suite confirms backward compatibility:
   ```
   npx jest app/api/attendance/sync/route.test.js
   ```
   5 tests pass, including the new duplicate-attendance scenario.
2. Manual reproduction: submit two sync requests with the same `userId` + `date` combination. The first awards XP; the second acknowledges the record (returns it in `syncedIds`) but skips the XP award entirely. The console will show no second `Failed to award XP` error from MongoDB because `awardXp()` is never called.

## Edge cases considered

- **In-batch duplicates**: Records with the same `userId` + `date` within a single sync request are still handled by the existing `processedUserDates` set check before the transaction. No behavioral change.
- **Transaction failure**: If the Firestore transaction itself fails (network blip, write contention), the `catch` block continues before reaching the `wasWritten` gate — identical to the original behavior.
- **Client queue cleanup**: Existing records still appear in `syncedIds` so the IndexedDB queue removes them. The client doesn't retry forever.
- **Concurrent cross-device sync**: Two devices syncing the same date at the same time will race through the Firestore transaction. One wins and writes; the other finds the doc exists and skips XP. This is correct — the attendance existed from the first write.