### PR TITLE
Allow Firebase Admin and SSE MongoDB to recover from transient failures

### DIFF
--- a/lib/firebase-admin.js
+++ b/lib/firebase-admin.js
@@ -9,10 +9,7 @@ export const initializeFirebase = () => {
     return;
   }
 
-  // Prevent repeated failed initialization attempts
-  if (initializationError) {
-    throw initializationError;
-  }
+  initializationError = null;
 
   try {
     const projectId = process.env.FIREBASE_PROJECT_ID;

--- a/lib/mongodb.js
+++ b/lib/mongodb.js
@@ -80,6 +80,11 @@ export async function connectDbForSSE() {
     const connectedClient = await sseClientPromise;
     return connectedClient.db(dbName);
   } catch (error) {
+    sseClientPromise = null;
+    sseClient = null;
+    if (process.env.NODE_ENV === "development") {
+      global._mongoSseClientPromise = null;
+    }
     throw new Error(`Failed to establish database connection: ${error.message}`);
   }
 }


### PR DESCRIPTION
close #1742 
## What this fixes

Two stuck-error-state patterns made the backend unrecoverable after a single transient failure until a manual restart. The Firebase Admin SDK would never retry initialization after any failure, permanently killing all auth and Firestore operations. The SSE MongoDB connection pool cached a rejected connection promise with no reset path, making change streams and polling permanently dead after the first connection blip.

## Root cause

**Bug A — `lib/firebase-admin.js`:** The `initializationError` variable (line 4) is set once in the catch handler (line 39) and checked with an early throw at the top of `initializeFirebase()` (line 13). No code path ever clears it. After any single failure (env var load race, transient network timeout), every subsequent call to `initializeFirebase()`, `verifyFirebaseToken()`, `getUserProfile()`, or `getAdminDb()` either throws immediately or returns an init-failed response.

**Bug B — `lib/mongodb.js`:** The `sseClientPromise` variable (line 29) is assigned the result of `sseClient.connect()` (line 75) inside an `if (!sseClientPromise)` guard (line 66). When the connection rejects, the promise settles as rejected and is never reassigned. Every subsequent call to `connectDbForSSE()` skips the connection block (the guard is false) and awaits the same permanently-rejected promise. The change-stream reconnect loop in `stream/route.js:70-110` and the polling fallback at `stream/route.js:124` both call `connectDbForSSE()` and always hit the same dead promise.

## What changed

**`lib/firebase-admin.js`** — Removed the `if (initializationError) throw` guard. The `initializationError` is now reset to `null` at the top of `initializeFirebase()` on every call, so a subsequent invocation retries initialization instead of immediately throwing.

**`lib/mongodb.js`** — The catch handler in `connectDbForSSE()` now resets `sseClientPromise` and `sseClient` to `null`, and in development mode also clears `global._mongoSseClientPromise`. The next call to `connectDbForSSE()` sees an empty promise slot and creates a fresh `MongoClient`.

## How to verify

1. The existing test suite passes:
   ```
   npx jest
   ```
   (The pre-existing failures in `settingsRoute.test.js` and `gamificationRace.test.js` are unrelated — the first requires real Audit Log infrastructure, the second requires a live MongoDB.)

2. Simulate Bug A: Temporarily set an invalid `FIREBASE_PROJECT_ID`, call `verifyFirebaseToken()`, observe the init failure. Restore the correct env var, call `verifyFirebaseToken()` again. Before the fix, it would return `init_failed` permanently. After the fix, it retries initialization and succeeds.

3. Simulate Bug B: Start with MongoDB unreachable, call `connectDbForSSE()`, observe the rejection. Bring MongoDB online, call `connectDbForSSE()` again. Before the fix, the same rejected promise is returned. After the fix, a new connection is established.

## Edge cases considered

- **Rapid repeated failures:** If the underlying cause is permanent (e.g., bad credentials), `initializeFirebase()` will fail on every request and `connectDbForSSE()` will create and discard a client on every call. This is the same failure rate as any other per-request error and produces clear console error output for debugging.
- **Development mode:** The `global._mongoSseClientPromise` global is properly cleared alongside the module-level promise, preventing stale globals in hot-reload scenarios.
- **Concurrent calls during recovery:** Both `initializeFirebase()` and the `MongoClient` constructor are safe to call concurrently — the first successful call wins.
- **No changes to `stream/route.js`:** On investigation, `sharedDb` was not the issue — `stopChangeStream()` already nulls it (line 97) before every reconnection attempt, and the bare `catch {}` in the polling function (line 133) allows the next poll interval to retry with a fresh `connectDbForSSE()` call.