### PR TITLE
fix: enforce email verification check on all API routes

### DIFF
--- a/app/api/auth/cleanup/route.js
+++ b/app/api/auth/cleanup/route.js
@@ -1,5 +1,5 @@
 import { jsonSuccess, jsonError } from "@/lib/api-response";
-import { withErrorHandler } from "@/lib/error-handler";
+import { authenticateRequest, withErrorHandler } from "@/lib/error-handler";
 import { initializeFirebase } from "@/lib/firebase-admin";
 import admin from "firebase-admin";
 
@@ -15,11 +15,17 @@ export const runtime = "nodejs";
  * needs to be cleaned up to prevent orphaned accounts.
  */
 export const POST = withErrorHandler(async (request) => {
+  const decodedToken = await authenticateRequest(request);
+
   const body = await request.json();
   const { uid } = body;
 
   if (!uid || typeof uid !== "string") {
     return jsonError("Invalid or missing UID parameter", 400);
+  }
+
+  if (decodedToken.uid !== uid) {
+    return jsonError("You can only clean up your own account", 403);
   }
 
   try {

--- a/lib/error-handler.js
+++ b/lib/error-handler.js
@@ -59,10 +59,16 @@ export async function authenticateRequest(request) {
       if (!authResult.valid) {
         throw new UnauthorizedError("Unauthorized");
       }
+      if (authResult.decodedToken && authResult.decodedToken.email_verified === false) {
+        throw new AppError("Email not verified", 403);
+      }
       return authResult.decodedToken;
     }
     // Directly mock returned object, e.g., { uid, email }
     if (authResult.uid) {
+      if (authResult.email_verified === false) {
+        throw new AppError("Email not verified", 403);
+      }
       return authResult;
     }
   }


### PR DESCRIPTION
Resolves #1766. This ensures that unverified users cannot access authenticated API endpoints by enforcing the \email_verified\ claim during \uthenticateRequest\.