### PR TITLE
"Improve attendance API error handling"

### DIFF
--- a/services/attendanceService.js
+++ b/services/attendanceService.js
@@ -114,9 +114,20 @@ export async function recordAttendance({
   });
 
   if (!response.ok) {
-    throw new Error(
-      "Failed to record attendance securely on the server."
-    );
+    let errorMessage =
+      "Failed to record attendance securely on the server.";
+
+    try {
+      const errorData = await response.json();
+
+      if (errorData?.message) {
+        errorMessage = errorData.message;
+      }
+    } catch {
+    // Ignore invalid JSON responses
+    }
+
+    throw new Error(errorMessage);
   }
 
   const data = await response.json();


### PR DESCRIPTION
Description

Improved attendance API error handling by surfacing backend-provided error messages instead of always throwing a generic error message.

Previously, failed API requests always returned:
"Failed to record attendance securely on the server."

This change safely parses failed API responses and uses the backend "message" field when available, while still keeping a fallback generic error message for unexpected cases.

Fixes #1743 

Type of Change

-  Bug fix (non-breaking change which fixes an issue)

How Has This Been Tested?

- Manual test: Verified that the application still runs correctly and confirmed that backend error messages are surfaced properly when API requests fail.


Checklist:

- My code follows the style guidelines of this project
-I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- My changes generate no new warnings
-  I have checked my code and corrected any misspellings