### PR TITLE
fix(api): validate statField allowlist and activity fields before Firestore writes

### DIFF
--- a/app/api/activities/route.js
+++ b/app/api/activities/route.js
@@ -2,6 +2,32 @@ import { jsonError, jsonSuccess } from "@/lib/api-response";
 import { withErrorHandler, authenticateRequest, parseJSON } from "@/lib/error-handler";
 import { initFirebaseAdmin } from "@/lib/firebase-admin";
 import { getFirestore, FieldValue } from "firebase-admin/firestore";
+import { checkRateLimit } from "@/lib/rateLimit";
+import { AppError } from "@/lib/errors";
+import { z } from "zod";
+
+// Allowed values for the type field. Any string outside this set would produce
+// unexpected behaviour in downstream rendering logic that switches on type.
+const ALLOWED_TYPES = ["course", "quiz", "assignment"];
+
+const activitySchema = z.object({
+  title: z
+    .string({ required_error: "title is required" })
+    .min(1, "title cannot be empty")
+    .max(200, "title cannot exceed 200 characters")
+    .trim(),
+  type: z
+    .enum(ALLOWED_TYPES, {
+      errorMap: () => ({ message: `type must be one of: ${ALLOWED_TYPES.join(", ")}` }),
+    })
+    .default("course"),
+  progress: z
+    .number({ invalid_type_error: "progress must be a number" })
+    .int("progress must be an integer")
+    .min(0, "progress cannot be negative")
+    .max(100, "progress cannot exceed 100")
+    .default(0),
+});
 
 export const GET = withErrorHandler(async (request) => {
   const decodedToken = await authenticateRequest(request);
@@ -25,8 +51,24 @@ export const GET = withErrorHandler(async (request) => {
 
 export const POST = withErrorHandler(async (request) => {
   const decodedToken = await authenticateRequest(request);
+
+  // Rate-limit writes per user to prevent activity flooding
+  const ip = request.headers.get("x-forwarded-for") || "127.0.0.1";
+  const rateLimitResult = await checkRateLimit(`activities_post_${ip}_${decodedToken.uid}`);
+  if (!rateLimitResult.allowed) {
+    throw new AppError("Too many requests. Please try again later.", 429);
+  }
+
   const body = await parseJSON(request, 1024);
-  const { title, type, progress } = body;
+
+  // Validate and sanitize fields before any Firestore write
+  const parsed = activitySchema.safeParse(body);
+  if (!parsed.success) {
+    const firstError = parsed.error.issues?.[0]?.message || "Invalid request payload";
+    throw new AppError(firstError, 400);
+  }
+
+  const { title, type, progress } = parsed.data;
 
   initFirebaseAdmin();
   const db = getFirestore();
@@ -34,8 +76,8 @@ export const POST = withErrorHandler(async (request) => {
   const docRef = await db.collection("activities").add({
     userId: decodedToken.uid,
     title,
-    type: type || "course",
-    progress: progress || 0,
+    type,
+    progress,
     timestamp: FieldValue.serverTimestamp(),
   });
 

--- a/app/api/stats/route.js
+++ b/app/api/stats/route.js
@@ -41,7 +41,32 @@ export const POST = withErrorHandler(async (request) => {
   }
 
   if (action === "update" && statField) {
-    const incValue = typeof value === "number" ? value : 1;
+    // Allowlist: only permit the four known numeric stat fields.
+    // Accepting an arbitrary caller-supplied string as a Firestore document key
+    // lets any authenticated user inject fake fields (e.g. "isAdmin": 1) or
+    // corrupt dashboards visible to teachers and admins.
+    const ALLOWED_STAT_FIELDS = new Set([
+      "Courses Enrolled",
+      "Assignments Done",
+      "Study Hours",
+    ]);
+
+    if (!ALLOWED_STAT_FIELDS.has(statField)) {
+      return jsonError(
+        `Invalid statField. Allowed values: ${[...ALLOWED_STAT_FIELDS].join(", ")}`,
+        400
+      );
+    }
+
+    // Clamp the increment to a safe integer range so a single request cannot
+    // teleport a counter to an unrealistic value. Infinity and NaN are also
+    // rejected by the isFinite check below.
+    const MAX_INCREMENT = 100;
+    const rawIncrement = typeof value === "number" ? value : 1;
+    if (!Number.isFinite(rawIncrement)) {
+      return jsonError("value must be a finite number", 400);
+    }
+    const incValue = Math.max(-MAX_INCREMENT, Math.min(MAX_INCREMENT, rawIncrement));
 
     const statsSnap = await statsRef.get();
     if (!statsSnap.exists) {


### PR DESCRIPTION
## Summary

Fixes two validation gaps in the stats and activities API routes.

### Fix 1 - statField injection in POST /api/stats (#1626)

The `action: "update"` path accepted any caller-supplied string as a Firestore document key with no allowlist and no bounds on the increment value.

**Changes in `app/api/stats/route.js`:**
- Added an explicit `ALLOWED_STAT_FIELDS` Set containing only `"Courses Enrolled"`, `"Assignments Done"`, and `"Study Hours"`. Any other key returns 400.
- Added `Number.isFinite` check to reject `Infinity` and `NaN`.
- Clamped the increment to `[-100, 100]` so a single request cannot teleport a counter to an unrealistic value.

### Fix 2 - Unvalidated POST /api/activities (#1627)

`POST /api/activities` wrote `title`, `type`, and `progress` directly to Firestore with no schema validation, no type checks, no length limits, and no rate limiting.

**Changes in `app/api/activities/route.js`:**
- Added a Zod schema (`activitySchema`) matching the same pattern used in `POST /api/complaints` and `POST /api/productivity`:
  - `title`: required, non-empty, max 200 characters
  - `type`: enum of `"course" | "quiz" | "assignment"` with default `"course"`
  - `progress`: integer in range `[0, 100]` with default `0`
- Added per-user rate limiting via the existing `checkRateLimit` helper to prevent write flooding.

## Test Plan

- [ ] `POST /api/stats` with `statField: "isAdmin"` returns 400
- [ ] `POST /api/stats` with `value: 999999` increments by at most 100
- [ ] `POST /api/activities` with `progress: -1` or `progress: "50%"` returns 400
- [ ] `POST /api/activities` with `type: "invalid"` returns 400
- [ ] Valid activity payloads still create documents correctly

> [!IMPORTANT]
> **GSSoC'26 contribution** - Please add labels (type:bug, type:security, level:intermediate) to help with point tracking. Thank you!