### PR TITLE
fix: add statField allowlist and increment bounds to stats API

### DIFF
--- a/app/api/stats/route.js
+++ b/app/api/stats/route.js
@@ -41,7 +41,24 @@ export const POST = withErrorHandler(async (request) => {
   }
 
   if (action === "update" && statField) {
-    const incValue = typeof value === "number" ? value : 1;
+    const ALLOWED_STAT_FIELDS = new Set([
+      "Courses Enrolled",
+      "Assignments Done",
+      "Study Hours",
+    ]);
+    if (!ALLOWED_STAT_FIELDS.has(statField)) {
+      return jsonError(
+        `Invalid statField. Allowed values: ${[...ALLOWED_STAT_FIELDS].join(", ")}`,
+        400
+      );
+    }
+
+    const MAX_INCREMENT = 100;
+    const rawIncrement = typeof value === "number" ? value : 1;
+    if (!Number.isFinite(rawIncrement)) {
+      return jsonError("value must be a finite number", 400);
+    }
+    const incValue = Math.max(-MAX_INCREMENT, Math.min(MAX_INCREMENT, rawIncrement));
 
     const statsSnap = await statsRef.get();
     if (!statsSnap.exists) {


### PR DESCRIPTION
## Summary

Closes #1626

The `POST /api/stats` route accepted a free-form `statField` string and wrote it directly as a Firestore document key with no validation. This allowed any authenticated user to:

- Create arbitrary document fields (including prototype-polluting keys)
- Supply unbounded increment values (positive or negative)

## Changes

- `app/api/stats/route.js`: Added an explicit `ALLOWED_STAT_FIELDS` set (`Courses Enrolled`, `Assignments Done`, `Study Hours`). Requests with any other value return `400`.
- Added a `MAX_INCREMENT` clamp of `[-100, 100]` and a `Number.isFinite` guard so `Infinity`, `-Infinity`, and `NaN` are rejected early.

## Test plan

- [ ] `POST /api/stats` with `action: "update"`, `statField: "Courses Enrolled"`, `value: 1` returns 200
- [ ] Same request with `statField: "__proto__"` returns 400
- [ ] Same request with `value: Infinity` returns 400
- [ ] Same request with `value: 9999` is clamped and stored as 100

Could you please add the appropriate GSSoC labels (`gssoc26`, `type:security`, `level:intermediate`) when you get a chance? Thank you!