### PR TITLE
fix: add Zod validation and rate limiting to activities POST

### DIFF
--- a/app/api/activities/route.js
+++ b/app/api/activities/route.js
@@ -1,7 +1,30 @@
+import { z } from "zod";
 import { jsonError, jsonSuccess } from "@/lib/api-response";
 import { withErrorHandler, authenticateRequest, parseJSON } from "@/lib/error-handler";
 import { initFirebaseAdmin } from "@/lib/firebase-admin";
 import { getFirestore, FieldValue } from "firebase-admin/firestore";
+import { checkRateLimit } from "@/lib/rateLimit";
+
+const ALLOWED_TYPES = ["course", "quiz", "assignment"];
+
+const activitySchema = z.object({
+  title: z
+    .string({ required_error: "title is required" })
+    .min(1, "title cannot be empty")
+    .max(200, "title must be 200 characters or fewer")
+    .trim(),
+  type: z
+    .enum(ALLOWED_TYPES, {
+      errorMap: () => ({ message: `type must be one of: ${ALLOWED_TYPES.join(", ")}` }),
+    })
+    .default("course"),
+  progress: z
+    .number({ invalid_type_error: "progress must be a number" })
+    .int("progress must be an integer")
+    .min(0, "progress must be at least 0")
+    .max(100, "progress must be at most 100")
+    .default(0),
+});
 
 export const GET = withErrorHandler(async (request) => {
   const decodedToken = await authenticateRequest(request);
@@ -25,8 +48,21 @@ export const GET = withErrorHandler(async (request) => {
 
 export const POST = withErrorHandler(async (request) => {
   const decodedToken = await authenticateRequest(request);
+
+  const limited = await checkRateLimit(decodedToken.uid);
+  if (!limited.allowed) {
+    return jsonError("Too many requests. Please slow down.", 429);
+  }
+
   const body = await parseJSON(request, 1024);
-  const { title, type, progress } = body;
+
+  const parsed = activitySchema.safeParse(body);
+  if (!parsed.success) {
+    const message = parsed.error.errors.map((e) => e.message).join("; ");
+    return jsonError(message, 400);
+  }
+
+  const { title, type, progress } = parsed.data;
 
   initFirebaseAdmin();
   const db = getFirestore();
@@ -34,8 +70,8 @@ export const POST = withErrorHandler(async (request) => {
   const docRef = await db.collection("activities").add({
     userId: decodedToken.uid,
     title,
-    type: type || "course",
-    progress: progress || 0,
+    type,
+    progress,
     timestamp: FieldValue.serverTimestamp(),
   });
 


### PR DESCRIPTION
## Summary

Closes #1627

The `POST /api/activities` handler accepted arbitrary request bodies with no input validation. This allowed:

- Storing empty or oversized titles in Firestore
- Writing arbitrary strings as the `type` field (should be `course`, `quiz`, or `assignment`)
- Storing `progress` values outside 0-100 or non-integer numbers
- Unlimited writes per user (no rate limiting)

## Changes

- `app/api/activities/route.js`: Added a `zod` schema (`activitySchema`) that enforces:
  - `title`: required string, 1-200 characters, trimmed
  - `type`: enum of `course | quiz | assignment`, defaults to `"course"`
  - `progress`: integer 0-100, defaults to `0`
- Invalid requests return `400` with joined validation error messages
- Added `checkRateLimit(uid)` call before processing; returns `429` when limit exceeded
- Firestore write now uses the parsed (sanitized) data instead of raw body values

## Test plan

- [ ] Valid POST `{ title: "Learn React", type: "course", progress: 50 }` returns 201
- [ ] POST with empty title returns 400
- [ ] POST with `type: "hack"` returns 400
- [ ] POST with `progress: 150` returns 400
- [ ] Exceeding rate limit returns 429

Could you please add the appropriate GSSoC labels (`gssoc26`, `type:security`, `level:intermediate`) when you get a chance? Thank you!