### PR TITLE
Fix/exceptions all redos prevention

### DIFF
--- a/utils/__tests__/mongoUtils.test.js
+++ b/utils/__tests__/mongoUtils.test.js
@@ -14,6 +14,12 @@ describe('MongoDB Safety Utilities - ReDoS & Injection Prevention', () => {
       expect(escapeRegex(maliciousInput)).toBe(expected);
     });
 
+    test('escapes additional special characters like dash, slash, hash, space and comma', () => {
+      const input = '- / # , ';
+      const expected = '\\-\\ \\/\\ \\#\\ \\,\\ ';
+      expect(escapeRegex(input)).toBe(expected);
+    });
+
     test('truncates strings exceeding the default max length (100)', () => {
       const longInput = 'a'.repeat(150);
       const output = escapeRegex(longInput);

--- a/utils/mongoUtils.js
+++ b/utils/mongoUtils.js
@@ -19,7 +19,7 @@
 export function escapeRegex(raw, maxLength = 100) {
   if (typeof raw !== "string") return "";
   // Truncate first so the escape pass operates on a bounded string
-  return raw.slice(0, maxLength).replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  return raw.slice(0, maxLength).replace(/[-[\]{}()*+?.,\\^$|#\s/]/g, "\\$&");
 }
 
 /**


### PR DESCRIPTION
### What type of PR is this?
- [x] 🔒 Security fix

### Description
- Upgraded `escapeRegex` in `utils/mongoUtils.js` to escape the full Lodash/standard character set including `-`, `#`, `/` and spaces.
- Added comprehensive test coverage to `mongoUtils.test.js` validating the escaping behavior on these additional characters.

### Related Issues
Closes #1811 