### PR TITLE
security(attendance): mitigate attendance impersonation by ignoring client-body fallbacks

### DIFF
--- a/app/api/attendance/record/route.js
+++ b/app/api/attendance/record/route.js
@@ -47,8 +47,10 @@ export const POST = withErrorHandler(async (request) => {
   const db = getFirestore();
   const userProfile = await getUserProfile(decodedToken.uid);
   const instituteId = userProfile?.instituteId || null;
-  const resolvedName = userProfile?.fullName || userProfile?.displayName || studentName;
-  const resolvedEmail = userProfile?.email || email;
+
+  // Use authoritative, verified data from JWT token (decodedToken) to prevent impersonation/spoofing
+  const resolvedName = userProfile?.fullName || decodedToken.name || decodedToken.displayName || decodedToken.email?.split("@")[0] || "Unknown User";
+  const resolvedEmail = userProfile?.email || decodedToken.email || "unknown@learnova.edu";
 
   const docRef = db.collection("attendance_records").doc(`${userId}_${normalizedDate}`);
 

--- a/app/api/attendance/record/route.js
+++ b/app/api/attendance/record/route.js
@@ -48,7 +48,8 @@ export const POST = withErrorHandler(async (request) => {
   const userProfile = await getUserProfile(decodedToken.uid);
   const instituteId = userProfile?.instituteId || null;
 
-  // Use authoritative, verified data from JWT token (decodedToken) to prevent impersonation/spoofing
+  // Use authoritative, verified data from Firebase JWT token (decodedToken) to completely prevent
+  // client-supplied parameter spoofing and impersonation attacks.
   const resolvedName = userProfile?.fullName || decodedToken.name || decodedToken.displayName || decodedToken.email?.split("@")[0] || "Unknown User";
   const resolvedEmail = userProfile?.email || decodedToken.email || "unknown@learnova.edu";
 


### PR DESCRIPTION
### What type of PR is this?
- [x] 🔒 Security fix
- [x] 🐛 Bug fix

### Description
Removes trust in client-supplied `studentName` and `email` fallbacks inside `/api/attendance/record`. If the Firestore profile is missing, resolved values default securely to JWT token properties (`decodedToken.email`, `decodedToken.name`), completely eliminating spoofing channels.

### Related Issues
Closes #1814 