### PR TITLE
fix(workflow): exclude pull requests from contributor guidelines issue count & paginate pulls query

### DIFF
--- a/.github/workflows/contributor-guidelines.yml
+++ b/.github/workflows/contributor-guidelines.yml
@@ -24,7 +24,9 @@ jobs:
             const eventType = context.payload.issue ? 'issue' : 'pull_request';
             const issue_number = context.payload.issue?.number || context.payload.pull_request?.number;
 
-            // Query open issues by this contributor
+            // Query open issues by this contributor.
+            // Note: GitHub's issues.listForRepo API returns both issues and pull requests,
+            // so we must filter out pull request objects afterwards.
             const issues = await github.rest.issues.listForRepo({
               owner: context.repo.owner,
               repo: context.repo.repo,

--- a/.github/workflows/contributor-guidelines.yml
+++ b/.github/workflows/contributor-guidelines.yml
@@ -41,7 +41,8 @@ jobs:
               state: 'open',
               per_page: 100
             });
-            const allPRs = { data: allPRsData };
+            // Authoritative fallback: explicitly filter for only open PRs to prevent any API edge-case leakage of closed/merged PRs
+            const allPRs = { data: allPRsData.filter(pr => pr.state === 'open') };
 
             // Filter open PRs by this contributor
             const prs = { data: allPRs.data.filter(pr => pr.user && pr.user.login === author) };

--- a/.github/workflows/contributor-guidelines.yml
+++ b/.github/workflows/contributor-guidelines.yml
@@ -46,7 +46,7 @@ jobs:
 
             const PER_PERSON_LIMIT = 3;
             const GLOBAL_PR_LIMIT = 30;
-            const issueCount = issues.data.length;
+            const issueCount = issues.data.filter(issue => !issue.pull_request).length;
             const prCount = prs.data.length;
             const totalOpenPRs = allPRs.data.length;
 

--- a/.github/workflows/contributor-guidelines.yml
+++ b/.github/workflows/contributor-guidelines.yml
@@ -34,12 +34,14 @@ jobs:
               state: 'open'
             });
 
-            // Query ALL open PRs in the repository
-            const allPRs = await github.rest.pulls.list({
+            // Query ALL open PRs in the repository using pagination to prevent 30-item default limits
+            const allPRsData = await github.paginate(github.rest.pulls.list, {
               owner: context.repo.owner,
               repo: context.repo.repo,
-              state: 'open'
+              state: 'open',
+              per_page: 100
             });
+            const allPRs = { data: allPRsData };
 
             // Filter open PRs by this contributor
             const prs = { data: allPRs.data.filter(pr => pr.user && pr.user.login === author) };


### PR DESCRIPTION
### What type of PR is this?
- [x] 🐛 Bug fix

### Description
This PR resolves two logical/limiting bugs inside the Contributor Guidelines workflow:
1. GitHub treats Pull Requests as issues internally, causing `issues.listForRepo()` to return both. We now filter out entries containing a `pull_request` property, ensuring that open PRs are not counted as open issues.
2. GitHub's `pulls.list()` default returns at most 30 entries due to pagination. We now utilize the standard `github.paginate` helper, ensuring the global open PR limit is calculated on the true, entire set of open PRs in the repository.

### Related Issues
Closes #1819 