### PR TITLE
Fix/enforce strict HTML entity escaping to prevent stored XSS

### DIFF
--- a/app/api/conversations/route.js
+++ b/app/api/conversations/route.js
@@ -11,8 +11,10 @@ import { checkRateLimit } from "@/lib/rateLimit";
 export const dynamic = "force-dynamic";
 
 /**
- * Sanitizes incoming text streams to eliminate malicious script or markup tags 
- * while maintaining Markdown symbols for UI representation.
+ * Escapes HTML tag brackets and dangerous special characters inside incoming 
+ * text streams to completely eliminate malicious script or markup execution,
+ * while maintaining standard Markdown symbols for UI representation.
+ * Follows OWASP recommendations by escaping &, <, >, ", ', and /.
  */
 const sanitizeText = (text) => {
   if (typeof text !== "string") return "";

--- a/app/api/conversations/route.js
+++ b/app/api/conversations/route.js
@@ -1,7 +1,7 @@
 import { connectDb } from "@/lib/mongodb";
 import { jsonSuccess } from "@/lib/api-response";
 import { z } from "zod";
-import xss from "xss";
+
 import { withErrorHandler } from "@/lib/error-handler";
 import { requireAuth } from "@/lib/rbac";
 import { AppError, ValidationError } from "@/lib/errors";
@@ -16,11 +16,14 @@ export const dynamic = "force-dynamic";
  */
 const sanitizeText = (text) => {
   if (typeof text !== "string") return "";
-  return xss(text, {
-    whiteList: {}, // Strip all standard HTML tags completely
-    stripIgnoreTag: true,
-    stripIgnoreTagBody: ["script", "style", "iframe", "object", "embed"],
-  }).trim();
+  return text
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#x27;")
+    .replace(/\//g, "&#x2F;")
+    .trim();
 };
 
 const conversationSchema = z.object({


### PR DESCRIPTION
## Description

Replaces the custom `xss` library configuration in `sanitizeText` with standard HTML entity escaping (`&`, `<`, `>`, `"`, `'`, `/`). Since message history is stored and rendered as plain text/markdown, escaping HTML tag characters prevents XSS injection while preserving markdown formatting.

Fixes #1823

## Type of Change

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] This change requires a documentation update

## How Has This Been Tested?

* [x] Manual test: Verified that HTML/script tags are escaped correctly and markdown formatting remains unaffected.
* [ ] Automated test suite

## Checklist:

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my own code
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [x] I have checked my code and corrected any misspellings
