### PR TITLE
chore: add pull request template (Fixes #1830)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,15 @@
+## Description
+Please include a summary of the change and which issue it fixes.
+
+Fixes # (issue)
+
+## Type of change
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] This change requires a documentation update
+
+## Checklist:
+- [ ] My code follows the style guidelines of this project
+- [ ] My changes generate no new warnings
+- [ ] I have performed a self-review of my own code


### PR DESCRIPTION
This pull request adds the missing `.github/PULL_REQUEST_TEMPLATE.md` file.

Closes #1830.