### PR TITLE
feat: enhance Face Recognition initialization UX with clear loading and error states

### DIFF
--- a/components/FaceRecognizer.js
+++ b/components/FaceRecognizer.js
@@ -52,7 +52,7 @@ export default function FaceRecognizer({ authUser }) {
     error,
   } = useLabels(authUser);
 
-  const [message, setMessage] = useState("Loading models...");
+  const [message, setMessage] = useState("Loading AI models...");
   const [finished, setFinished] = useState(false);
   const [detectedPerson, setDetectedPerson] = useState(null);
   const [isLoading, setIsLoading] = useState(true);
@@ -104,6 +104,8 @@ export default function FaceRecognizer({ authUser }) {
         cancelAnimationFrame(animationFrameId.current);
       }
 
+      setMessage("Requesting camera permission...");
+
       const stream = await navigator.mediaDevices.getUserMedia({
         video: { facingMode },
       });
@@ -146,7 +148,7 @@ export default function FaceRecognizer({ authUser }) {
       setIsLoading(false);
       if (err.name === "NotAllowedError") {
         setMessage(
-          "Camera access is blocked! Enable camera permissions in browser settings.",
+          "Camera access denied. Please enable camera permissions in browser settings.",
         );
       } else {
         setMessage("Cannot access camera ❌");
@@ -166,7 +168,7 @@ export default function FaceRecognizer({ authUser }) {
     const loadModels = async () => {
       try {
         if (!isMounted.current || abortControllerRef.current.signal.aborted) return;
-        setMessage("Downloading ML models...");
+        setMessage("Loading AI models...");
         const faceapi = await import("face-api.js");
         faceapiRef.current = faceapi;
 
@@ -190,6 +192,7 @@ export default function FaceRecognizer({ authUser }) {
     const startVideo = async () => {
       try {
         if (!isMounted.current || abortControllerRef.current.signal.aborted) return;
+        setMessage("Requesting camera permission...");
         const stream = await navigator.mediaDevices.getUserMedia({
           video: { facingMode },
         });
@@ -224,9 +227,13 @@ export default function FaceRecognizer({ authUser }) {
         }
       } catch (err) {
         if (!isMounted.current || abortControllerRef.current.signal.aborted) return;
-        setMessage("Cannot access webcam ❌");
-        setFinished(true);
         setIsLoading(false);
+        if (err.name === "NotAllowedError" || err.message?.includes("Permission denied")) {
+          setMessage("Camera access denied. Please enable camera permissions in browser settings.");
+        } else {
+          setMessage("Cannot access webcam ❌");
+        }
+        setFinished(true);
       }
     };
 


### PR DESCRIPTION
**Description:**
This PR significantly improves the user experience during the face recognition initialization phase in `FaceRecognizer.js`. Previously, users were left with static "Loading models..." messages that did not accurately reflect the background processes (like requesting camera permissions), leading to confusion on slower devices or when permissions were denied.

## fixes : #1642 

Key improvements introduced:
* **Dynamic Loading States:** The initialization message now accurately updates from `"Loading AI models..."` to `"Requesting camera permission..."` right before the browser prompts the user for webcam access.
* **Clear Error Messaging:** Replaced generic camera access errors with specific guidance when a user denies the permission (`NotAllowedError`), explicitly instructing them to "enable camera permissions in browser settings".
* **Refined Retry Logic:** The "Scan Again" retry flow now correctly re-triggers the permission request state and displays the correct error messages if the user denies it a second time.

**Testing Performed:**
- [x] Verified that the "Loading AI models..." and "Requesting camera permission..." messages appear sequentially during initialization.
- [x] Verified that denying camera access correctly displays the specific permission guidance error message instead of a generic error.
- [x] Verified that the "Scan Again" button resets the flow and accurately re-reports errors if permissions remain denied.
- [x] Confirmed that all existing test suites pass.
