### PR TITLE
fix: show toast warning when TeacherDashboard falls back to mock schedule data

### DIFF
--- a/components/TeacherDashboardComponent.js
+++ b/components/TeacherDashboardComponent.js
@@ -259,6 +259,7 @@ const TeacherDashboard = () => {
         }
       } catch (error) {
         console.error("Error fetching schedule, falling back to mock:", error);
+        toast.error("Could not load your schedule. Showing sample data instead.");
       }
       
       // Fallback Mock Schedule


### PR DESCRIPTION
Fixes #1839

## Description
Added a `toast.error()` notification when the schedule fetch fails and falls back to mock data, so teachers are clearly informed they are viewing sample data and not their real schedule.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] My changes generate no new warnings
- [x] I have performed a self-review of my own code