### PR TITLE
fix: strip unsafe markup from conversations

### DIFF
--- a/app/api/conversations/route.js
+++ b/app/api/conversations/route.js
@@ -1,6 +1,7 @@
 import { connectDb } from "@/lib/mongodb";
 import { jsonSuccess } from "@/lib/api-response";
 import { z } from "zod";
+import { filterXSS } from "xss";
 
 import { withErrorHandler } from "@/lib/error-handler";
 import { requireAuth } from "@/lib/rbac";
@@ -10,22 +11,19 @@ import { checkRateLimit } from "@/lib/rateLimit";
 // Force dynamic rendering to prevent build-time database connection errors
 export const dynamic = "force-dynamic";
 
+const textSanitizeOptions = {
+  whiteList: {},
+  stripIgnoreTag: true,
+  stripIgnoreTagBody: ["script", "style", "iframe", "object", "embed", "template"],
+};
+
 /**
- * Escapes HTML tag brackets and dangerous special characters inside incoming 
- * text streams to completely eliminate malicious script or markup execution,
- * while maintaining standard Markdown symbols for UI representation.
- * Follows OWASP recommendations by escaping &, <, >, ", ', and /.
+ * Stores chat content as plain text/Markdown by stripping HTML markup instead of
+ * persisting escaped tags that later appear in conversation history.
  */
 const sanitizeText = (text) => {
   if (typeof text !== "string") return "";
-  return text
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;")
-    .replace(/"/g, "&quot;")
-    .replace(/'/g, "&#x27;")
-    .replace(/\//g, "&#x2F;")
-    .trim();
+  return filterXSS(text, textSanitizeOptions).trim();
 };
 
 const conversationSchema = z.object({

--- a/components/__tests__/conversationsRoute.test.js
+++ b/components/__tests__/conversationsRoute.test.js
@@ -209,6 +209,39 @@ describe("POST /api/conversations - Authentication and Validation Security Tests
     expect(response.status).toBe(200);
     expect(body.success).toBe(true);
     expect(body.data.userMessage).toBe("Hello World"); // <script> tag stripped
+    expect(mockInsertOne).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userMessage: "Hello World",
+      })
+    );
+  });
+
+  test("strips HTML tags while preserving safe Markdown syntax", async () => {
+    const mockDecodedToken = { uid: "user-123", email: "user@example.com" };
+    verifyFirebaseToken.mockResolvedValue(mockDecodedToken);
+    mockInsertOne.mockResolvedValue({ insertedId: "conv-123" });
+
+    const req = createMockRequest(
+      { authorization: "Bearer valid-token" },
+      {
+        userMessage: "**Hello** <b>World</b> [docs](/courses)",
+        botMessage: "<style>body{display:none}</style>Safe **reply**",
+      }
+    );
+
+    const response = await POST(req);
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.success).toBe(true);
+    expect(body.data.userMessage).toBe("**Hello** World [docs](/courses)");
+    expect(body.data.botMessage).toBe("Safe **reply**");
+    expect(mockInsertOne).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userMessage: "**Hello** World [docs](/courses)",
+        botMessage: "Safe **reply**",
+      })
+    );
   });
 });
 
@@ -340,4 +373,3 @@ describe("GET /api/conversations - History Retrieval Security and Performance Te
     expect(body.error).toBe("Internal server error");
   });
 });
-


### PR DESCRIPTION
## Summary
- Replace manual HTML entity escaping in `POST /api/conversations` with the existing `xss` sanitizer configured to strip unsafe HTML tags and script/style-like bodies.
- Keep safe plain text and Markdown syntax in stored chat history.
- Add regression coverage proving script payloads are stripped before the conversation document is inserted.

## Root cause
The previous `sanitizeText()` implementation escaped `<`, `>`, quotes, and `/`, so unsafe markup was persisted as visible escaped text instead of being removed. This contradicted the route comment and the existing test expectation for script injection sanitization.

## Verification
- `npm test -- components/__tests__/conversationsRoute.test.js --runInBand`
- `git diff --check`

## Notes
- `npm run build` is currently blocked by an unrelated upstream App Router issue: `components/ui/DashboardSkeleton.js` uses `styled-jsx` through `app/institute/dashboard/loading.jsx`, which is treated as a Server Component path.

Fixes #1870
