### PR TITLE
fix: replace document.title with Next.js metadata in streaks page

### DIFF
--- a/app/streaks/layout.js
+++ b/app/streaks/layout.js
@@ -1,0 +1,8 @@
+export const metadata = {
+  title: "Consistency Streaks | Learnova",
+  description: "Track your daily learning streak on Learnova",
+};
+
+export default function StreaksLayout({ children }) {
+  return children;
+}

--- a/app/streaks/page.js
+++ b/app/streaks/page.js
@@ -64,10 +64,7 @@ export default function StreaksPage() {
     loadStreakData();
   }, [userProfile]);
 
-  useEffect(() => {
-    document.title = "Consistency Streaks | Learnova";
-  }, []);
-
+ 
   const triggerToast = (msg) => {
     setNotificationMsg(msg);
     setShowNotification(true);


### PR DESCRIPTION
Fixes #1843

## Problem
app/streaks/page.js used document.title directly:

useEffect(() => {
  document.title = "Consistency Streaks | Learnova";
}, []);

This is incorrect in Next.js 15 because:
- document.title doesn't work with SSR
- Page title won't appear in search engines
- Inconsistent with rest of the app

## Fix
- Removed document.title from useEffect in page.js
- Created app/streaks/layout.js with proper 
  Next.js metadata export

## Tested
✅ Page title shows correctly
✅ SSR compatible
✅ Better SEO