### PR TITLE
Add Interactive Skeleton Loader Components for Dashboard Analytics Cards

### DIFF
--- a/app/dashboard/loading.jsx
+++ b/app/dashboard/loading.jsx
@@ -1,5 +1,6 @@
 import React from "react";
 import Skeleton from "@/components/ui/Skeleton";
+import SkeletonCard from "@/components/SkeletonCard";
 
 /**
  * DashboardLoading Component
@@ -36,12 +37,14 @@ export default function DashboardLoading() {
             <div className="flex justify-between items-center">
               <Skeleton className="h-6 w-32 bg-slate-800/80" />
               <Skeleton className="h-4 w-16 bg-slate-800/60" />
-            </div>
-            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-              <Skeleton className="h-28 bg-slate-800/60 rounded-xl" />
-              <Skeleton className="h-28 bg-slate-800/60 rounded-xl" />
-            </div>
-          </div>
+           </div>
+         {/* 👇 Updated to a 3-column layout showcasing your beautiful skeleton cards */}
+         <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+            <SkeletonCard />
+            <SkeletonCard />
+            <SkeletonCard />
+         </div>
+        </div>
 
           {/* List panel */}
           <div className="bg-white/5 border border-white/10 rounded-2xl p-6 space-y-4">


### PR DESCRIPTION
## Description
Replaced the generic layout skeleton placeholders inside the dashboard loading state with our unified, interactive `SkeletonCard` dashboard analytics components. This prevents layout shifting and ensures an immediate, cohesive ghost-loading aesthetic across widgets and panels before the stats fetch finishes.

Closes #1568

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] My changes generate no new warnings
- [x] I have performed a self-review of my own code @Premshaw23 kindly review it