### PR TITLE
Add a responsive Share button utilizing the native Web Share API

### DIFF
--- a/components/ui/ShareButton.jsx
+++ b/components/ui/ShareButton.jsx
@@ -20,23 +20,37 @@ export default function ShareButton({ className = "" }) {
       if (!shareUrl) {
         throw new Error("Unable to retrieve window.location.href");
       }
+      if (navigator.share) {
+        await navigator.share({
+          title: "Learnova Project",
+          text: "Check out this article/link from Learnova!",
+          url: shareUrl,
+        });
+        toast.success("Shared successfully!");
+      } else {
+        // 2. Fallback: Use your existing clipboard functionality for desktop
+        await navigator.clipboard.writeText(shareUrl);
+        setIsCopied(true);
+        toast.success("Link copied to clipboard!");
 
-      await navigator.clipboard.writeText(shareUrl);
-      setIsCopied(true);
-      toast.success("Link copied to clipboard!");
+        // Clear any existing timeout to avoid race conditions
+        if (timeoutRef.current) {
+          clearTimeout(timeoutRef.current);
+        }
 
-      // Clear any existing timeout to avoid race conditions
-      if (timeoutRef.current) {
-        clearTimeout(timeoutRef.current);
+        // Revert copied state after 2 seconds
+        timeoutRef.current = setTimeout(() => {
+          setIsCopied(false);
+        }, 2000);
       }
-
-      // Revert copied state after 2 seconds
-      timeoutRef.current = setTimeout(() => {
-        setIsCopied(false);
-      }, 2000);
     } catch (error) {
-      console.error("Clipboard copy failed:", error);
-      toast.error("Failed to copy link. Please copy it manually.");
+      // Don't error out if the user simply cancels/closes the native share sheet
+      if (error.name === "AbortError") {
+        console.log("Share menu dismissed by user.");
+        return;
+      }
+      console.error("Sharing failed:", error);
+      toast.error("Failed to share link. Please copy it manually.");
     }
   };
 


### PR DESCRIPTION
## Description
Updated the `ShareButton` component to check for and utilize the native Web Share API (`navigator.share`) on compatible devices (like mobile Chrome and Safari). Included a robust fallback mechanism using the existing clipboard-copy functionality for desktop browsers, complete with micro-animations and status toasts.

Closes #1571

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] My changes generate no new warnings
- [x] I have performed a self-review of my own code @Premshaw23 kindly review this
