### PR TITLE
Fix cross-database consistency failures between Firestore and MongoDB

### DIFF
--- a/app/api/admin/reconcile/route.js
+++ b/app/api/admin/reconcile/route.js
@@ -1,0 +1,89 @@
+import { jsonError, jsonSuccess } from "@/lib/api-response";
+import { withErrorHandler } from "@/lib/error-handler";
+import { requireAdmin } from "@/lib/rbac";
+import { AppError } from "@/lib/errors";
+import admin from "firebase-admin";
+import { connectDb } from "@/lib/mongodb";
+
+export const dynamic = "force-dynamic";
+
+export const POST = withErrorHandler(async (request) => {
+  const { payload: decodedToken } = await requireAdmin(request);
+
+  const { uid } = await request.json();
+  if (!uid || typeof uid !== "string") {
+    return jsonError("Firebase UID is required", 400);
+  }
+
+  const db = admin.firestore();
+  const mongoDB = await connectDb();
+
+  const firestoreDoc = await db.collection("users").doc(uid).get();
+  const hasFirestore = firestoreDoc.exists;
+  const firestoreData = hasFirestore ? firestoreDoc.data() : null;
+
+  const mongoUser = await mongoDB.collection("users").findOne({ firebaseUid: uid });
+  const hasMongo = !!mongoUser;
+
+  if (hasFirestore && hasMongo) {
+    return jsonSuccess({
+      message: "User already exists in both databases",
+      firestore: true,
+      mongo: true,
+    });
+  }
+
+  const actions = [];
+
+  if (!hasFirestore && mongoUser) {
+    const profile = {
+      uid: mongoUser.firebaseUid,
+      email: mongoUser.email || "",
+      fullName: mongoUser.name || mongoUser.fullName || "",
+      role: mongoUser.role || "student",
+      createdAt: mongoUser.createdAt || new Date().toISOString(),
+      lastLogin: mongoUser.lastLogin || null,
+    };
+    await db.collection("users").doc(uid).set(profile, { merge: true });
+    actions.push("firestore_profile_created");
+  }
+
+  if (!hasMongo && firestoreData) {
+    const now = new Date().toISOString();
+    await mongoDB.collection("users").updateOne(
+      { firebaseUid: uid },
+      {
+        $set: {
+          firebaseUid: uid,
+          email: firestoreData.email || "",
+          name: firestoreData.fullName || "",
+          fullName: firestoreData.fullName || "",
+          role: firestoreData.role || "student",
+          lastLogin: now,
+        },
+        $setOnInsert: {
+          totalXp: 0,
+          currentLevel: 1,
+          xpToNextLevel: 100,
+          currentStreak: 0,
+          unlockedBadges: [],
+          attendanceHistory: [],
+          createdAt: now,
+        },
+      },
+      { upsert: true }
+    );
+    actions.push("mongo_document_created");
+  }
+
+  if (actions.length === 0) {
+    return jsonError("User not found in either database", 404);
+  }
+
+  return jsonSuccess({
+    message: "User reconciled successfully",
+    actions,
+    firestore: true,
+    mongo: true,
+  });
+});

--- a/app/api/auth/set-role/route.js
+++ b/app/api/auth/set-role/route.js
@@ -86,37 +86,55 @@ export const POST = withValidation(
 
     // Sync user to MongoDB so gamification (awardXp) and biometric labels
     // endpoints can locate the student by their Firebase UID.
-    try {
-      const mongoDB = await connectDb();
-      const now = new Date().toISOString();
+    const MAX_MONGO_RETRIES = 3;
+    const RETRY_BASE_DELAY_MS = 500;
 
-      await mongoDB.collection("users").updateOne(
-        { firebaseUid: decodedToken.uid },
-        {
-          $set: {
-            firebaseUid: decodedToken.uid,
-            email: decodedToken.email,
-            name: fullName,
-            fullName,
-            role,
-            lastLogin: now,
+    for (let attempt = 1; attempt <= MAX_MONGO_RETRIES; attempt++) {
+      try {
+        const mongoDB = await connectDb();
+        const now = new Date().toISOString();
+
+        await mongoDB.collection("users").updateOne(
+          { firebaseUid: decodedToken.uid },
+          {
+            $set: {
+              firebaseUid: decodedToken.uid,
+              email: decodedToken.email,
+              name: fullName,
+              fullName,
+              role,
+              lastLogin: now,
+            },
+            $setOnInsert: {
+              totalXp: 0,
+              currentLevel: 1,
+              xpToNextLevel: 100,
+              currentStreak: 0,
+              unlockedBadges: [],
+              attendanceHistory: [],
+              createdAt: now,
+            },
           },
-          $setOnInsert: {
-            totalXp: 0,
-            currentLevel: 1,
-            xpToNextLevel: 100,
-            currentStreak: 0,
-            unlockedBadges: [],
-            attendanceHistory: [],
-            createdAt: now,
-          },
-        },
-        { upsert: true }
-      );
-    } catch (mongoErr) {
-      // MongoDB sync is non-blocking — Firestore is the primary store.
-      // Log the error but do not fail the registration flow.
-      console.error("[set-role] MongoDB user sync failed:", mongoErr.message);
+          { upsert: true }
+        );
+        break;
+      } catch (mongoErr) {
+        if (attempt === MAX_MONGO_RETRIES) {
+          console.error("[set-role] MongoDB sync failed after", MAX_MONGO_RETRIES, "attempts:", mongoErr.message);
+          // Roll back Firestore profile and auth claims so the user is not left
+          // in a partial state (Firestore exists, MongoDB missing).
+          try {
+            await db.collection("users").doc(decodedToken.uid).delete();
+            await admin.auth().setCustomUserClaims(decodedToken.uid, {});
+          } catch (rollbackErr) {
+            console.error("[set-role] Rollback failed:", rollbackErr.message);
+          }
+          return jsonError("Account setup failed due to a server error. Please try again.", 500);
+        }
+        const delay = RETRY_BASE_DELAY_MS * Math.pow(2, attempt - 1);
+        console.warn("[set-role] MongoDB sync attempt", attempt, "failed, retrying in", delay, "ms:", mongoErr.message);
+        await new Promise((resolve) => setTimeout(resolve, delay));
+      }
     }
 
     return jsonSuccess({ userProfile }, 201);

--- a/lib/gamification-service.js
+++ b/lib/gamification-service.js
@@ -105,9 +105,23 @@ export async function awardXp(firebaseUid, actionType, metadata = {}) {
   while (attempt < MAX_RETRIES) {
     attempt++;
 
-    const student = await db.collection("users").findOne({ firebaseUid });
+    let student = await db.collection("users").findOne({ firebaseUid });
     if (!student) {
-      throw new Error("Student not found");
+      const now = new Date().toISOString();
+      await db.collection("users").insertOne({
+        firebaseUid,
+        totalXp: 0,
+        currentLevel: 1,
+        xpToNextLevel: 100,
+        currentStreak: 0,
+        unlockedBadges: [],
+        attendanceHistory: [],
+        createdAt: now,
+      });
+      student = await db.collection("users").findOne({ firebaseUid });
+      if (!student) {
+        throw new Error("Failed to create user document for gamification");
+      }
     }
 
     // Fetch true attendance history from Firestore for accurate early bird & gamification analysis


### PR DESCRIPTION
Closes #1884

## What this fixes

Users can be left in unrecoverable broken states when MongoDB sync fails during role assignment in `app/api/auth/set-role/route.js`. The error was silently logged and the response returned HTTP 201, leaving a user with Firestore and Auth records but no MongoDB document. Any subsequent call to award XP, look up biometric labels, or query gamification data would fail silently or throw.

## Root cause

Two defects:

1. `set-role/route.js:87-120` wrapped the MongoDB `updateOne` (upsert) in a try-catch that logged the error and continued, returning success. A transient MongoDB failure or network issue permanently orphaned the user.

2. `lib/gamification-service.js:108` threw "Student not found" when the MongoDB document was missing, with no fallback. The `attendance/record` and `attendance/sync` routes both call `awardXp` as a side effect, so the missing document caused attendance operations to fail.

## What changed

- `app/api/auth/set-role/route.js`: Replaced the silent try-catch with a retry loop (3 attempts with exponential backoff: 500ms, 1000ms, 2000ms). If all retries fail, the Firestore profile and auth claims are rolled back and HTTP 500 is returned, preventing orphaned users.

- `lib/gamification-service.js`: When `awardXp` finds no MongoDB document for the user, it now creates one with default gamification values (totalXp: 0, currentLevel: 1, etc.) instead of throwing. This is defense-in-depth for any code path that reaches `awardXp` without going through `set-role`.

- `app/api/admin/reconcile/route.js` (new): `POST /api/admin/reconcile` endpoint that checks both databases for a given Firebase UID and creates whichever record is missing. Requires admin role.

## How to verify

1. **MongoDB failure during set-role**: Call `POST /api/auth/set-role` with valid credentials while MongoDB is unreachable. The API should return HTTP 500 after 3 retry attempts. The user should not exist in Firestore and should not have custom claims set.

2. **Missing MongoDB doc**: Delete a user MongoDB document manually. Call `POST /api/attendance/record` for that user. The attendance should be recorded in Firestore, and `awardXp` should create a new MongoDB document instead of failing.

3. **Admin reconciliation**: As an admin, call `POST /api/admin/reconcile` with `{ "uid": "..." }` for a user that exists in only one database. The endpoint should create the missing record and report which action was taken.

## Edge cases considered

- Rollback failure: If the Firestore delete or claims removal fails during rollback, the error is logged but HTTP 500 is still returned.
- Transient MongoDB failure: Up to 3 retries with exponential backoff will succeed before any rollback is triggered.
- Concurrent awardXp calls: Version-based OCC in updateOne is preserved. When a new document is created, it has no version field, so the `$or` condition matches correctly.
- Reconcile with already-consistent user: Returns immediately with no actions taken.