### PR TITLE
fix: resolve AI Chatbot payload schema mismatch on the /api/groq endpoint

### DIFF
--- a/lib/ai/groq.js
+++ b/lib/ai/groq.js
@@ -9,8 +9,15 @@ const GROQ_MODEL = "llama-3.1-8b-instant";
 const groqBodySchema = z.object({
   message: z.string().optional(),
   userMessage: z.string().optional(),
+  messages: z.array(z.object({
+    role: z.string(),
+    content: z.string(),
+  })).optional(),
 }).transform((data) => {
-  const rawMessage = data.message ?? data.userMessage ?? "";
+  let rawMessage = data.message ?? data.userMessage ?? "";
+  if (!rawMessage && data.messages && data.messages.length > 0) {
+    rawMessage = data.messages[data.messages.length - 1].content;
+  }
   return { trimmedMessage: rawMessage.trim() };
 }).superRefine((data, ctx) => {
   if (!data.trimmedMessage) {


### PR DESCRIPTION
This pull request updates the message parsing logic in `lib/ai/groq.js` to better handle cases where the message may be provided in a new `messages` array format. This improves compatibility with different input structures.

**Improvements to message parsing:**

* The `groqBodySchema` now optionally accepts a `messages` array, each containing a `role` and `content`. If neither `message` nor `userMessage` is present, it falls back to using the content of the last message in the `messages` array as the input.


Closes #1877 