### PR TITLE
fix :dark mode drop down list fields in complaints page

### DIFF
--- a/components/ComplaintsTable.jsx
+++ b/components/ComplaintsTable.jsx
@@ -85,12 +85,35 @@ export default function ComplaintsTable({
           <select
             value={statusFilter}
             onChange={(e) => setStatusFilter(e.target.value)}
-            className="bg-transparent outline-none w-full"
+            className="bg-transparent dark:bg-[#0b1120] text-black dark:text-white outline-none w-full"
           >
-            <option value="All">All</option>
-            <option value="Pending">Pending</option>
-            <option value="Resolved">Resolved</option>
-            <option value="Not Resolved">Not Resolved</option>
+            <option
+              value="All"
+              className="bg-white text-black dark:bg-[#0b1120] dark:text-white"
+            >
+              All
+            </option>
+
+            <option
+              value="Pending"
+              className="bg-white text-black dark:bg-[#0b1120] dark:text-white"
+            >
+              Pending
+            </option>
+
+            <option
+              value="Resolved"
+              className="bg-white text-black dark:bg-[#0b1120] dark:text-white"
+            >
+              Resolved
+            </option>
+
+            <option
+              value="Not Resolved"
+              className="bg-white text-black dark:bg-[#0b1120] dark:text-white"
+            >
+              Not Resolved
+            </option>
           </select>
         </div>
 
@@ -156,13 +179,12 @@ export default function ComplaintsTable({
 
                       <span
                         className={`px-3 py-1 rounded-full text-xs font-semibold
-                        ${
-                          c.priority === "High"
+                        ${c.priority === "High"
                             ? "bg-red-500/10 text-red-500"
                             : c.priority === "Medium"
-                            ? "bg-yellow-500/10 text-yellow-500"
-                            : "bg-green-500/10 text-green-500"
-                        }`}
+                              ? "bg-yellow-500/10 text-yellow-500"
+                              : "bg-green-500/10 text-green-500"
+                          }`}
                       >
                         {c.priority}
                       </span>
@@ -173,13 +195,12 @@ export default function ComplaintsTable({
 
                       <span
                         className={`inline-flex items-center gap-2 px-3 py-1 rounded-full text-xs font-semibold
-                        ${
-                          c.status === "Resolved"
+                        ${c.status === "Resolved"
                             ? "bg-green-500/10 text-green-500"
                             : c.status === "Pending"
-                            ? "bg-yellow-500/10 text-yellow-500"
-                            : "bg-red-500/10 text-red-500"
-                        }`}
+                              ? "bg-yellow-500/10 text-yellow-500"
+                              : "bg-red-500/10 text-red-500"
+                          }`}
                       >
 
                         {c.status === "Resolved" ? (


### PR DESCRIPTION
## Description
Fixed dropdown/select field visibility issues in dark mode by improving option background and text color styling for better readability and theme consistency

Fixes #1779 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] My changes generate no new warnings
- [x] I have performed a self-review of my own code



