### PR TITLE
chore: set private true in package.json to prevent accidental publish

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "learnova",
   "version": "1.0.0",
   "description": "AI-Powered Smart Student Engagement & Attendance Platform",
-  "private": false,
+  "private": true,
   "repository": {
     "type": "git",
     "url": "https://github.com/Premshaw23/Learnova.git"


### PR DESCRIPTION
## Description

This PR updates the `private` field in `package.json` from `false` to `true` to prevent accidental publishing of the project to npm.

### Changes Made

* Changed:

```json
"private": false
```

to:

```json
"private": true
```

### Why

Setting `"private": true` ensures the package cannot be unintentionally published to the npm registry, improving repository safety and preventing accidental releases.

Fixes #1942
