### PR TITLE
Fix IDOR allowing unauthorized access to biometric face images

### DIFF
--- a/app/api/images/route.js
+++ b/app/api/images/route.js
@@ -3,7 +3,9 @@ import { requireAuth } from "@/lib/rbac";
 import { withErrorHandler } from "@/lib/error-handler";
 import { checkRateLimit } from "@/lib/rateLimit";
 import { del } from "@vercel/blob";
-import { AppError } from "@/lib/errors";
+import { connectDb } from "@/lib/mongodb";
+import { getUserProfile } from "@/lib/firebase-admin";
+import { AppError, ForbiddenError, NotFoundError } from "@/lib/errors";
 import {
   extractImageFileFromFormData,
   fetchAndValidateImage,
@@ -20,7 +22,25 @@ export const GET = withErrorHandler(async (request) => {
   const { searchParams } = new URL(request.url);
   const id = searchParams.get("id");
 
-  await requireAuth(request);
+  const decodedToken = await requireAuth(request);
+
+  const db = await connectDb();
+  const users = db.collection("users");
+  const requestingUser = await users.findOne(
+    { firebaseUid: decodedToken.uid },
+    { projection: { _id: 1 } }
+  );
+
+  if (!requestingUser) {
+    throw new NotFoundError("User not found");
+  }
+
+  if (requestingUser._id.toString() !== id) {
+    const profile = await getUserProfile(decodedToken.uid);
+    if (!profile || !["admin", "teacher"].includes(profile.role)) {
+      throw new ForbiddenError("You can only view your own profile image");
+    }
+  }
 
   const imageUrl = await getUserImageFromDb({ id });
   const { imageBuffer, contentType } = await fetchAndValidateImage(imageUrl);

--- a/app/api/labels/route.js
+++ b/app/api/labels/route.js
@@ -21,7 +21,7 @@ export const GET = withErrorHandler(async (request) => {
   }
 
   // Authentication and Role Verification
-  await requireRole(request, ["admin", "teacher", "student"]);
+  const { profile } = await requireRole(request, ["admin", "teacher", "student"]);
 
   // Search query — escape metacharacters to prevent ReDoS
   const { searchParams } = new URL(request.url);
@@ -55,9 +55,10 @@ export const GET = withErrorHandler(async (request) => {
     .limit(50)
     .toArray();
 
+  const showImageFlag = profile.role !== "student";
   const sanitizedUsers = allUsers.map(({ image, ...rest }) => ({
     ...rest,
-    hasImage: !!image,
+    ...(showImageFlag ? { hasImage: !!image } : {}),
   }));
 
   return jsonSuccess(sanitizedUsers, 200);

--- a/components/__tests__/imagesRoute.test.js
+++ b/components/__tests__/imagesRoute.test.js
@@ -1,3 +1,4 @@
+import { ObjectId } from "mongodb";
 import { GET, POST } from "@/app/api/images/route";
 import { requireAuth } from "@/lib/rbac";
 import {
@@ -35,6 +36,14 @@ jest.mock("@/lib/rbac", () => ({
   requireAuth: jest.fn(),
 }));
 
+jest.mock("@/lib/mongodb", () => ({
+  connectDb: jest.fn(),
+}));
+
+jest.mock("@/lib/firebase-admin", () => ({
+  getUserProfile: jest.fn(),
+}));
+
 jest.mock("@/lib/images/imagesService", () => ({
   extractImageFileFromFormData: jest.fn(),
   fetchAndValidateImage: jest.fn(),
@@ -50,12 +59,23 @@ jest.mock("@/lib/images/imagesService", () => ({
 }));
 
 describe("/api/images route orchestration", () => {
+  let connectDb;
+
   beforeEach(() => {
     jest.clearAllMocks();
+    connectDb = require("@/lib/mongodb").connectDb;
   });
 
-  test("GET orchestrates auth, DB image lookup, and remote fetch", async () => {
-    requireAuth.mockResolvedValue({ uid: "u1" });
+  test("GET returns own image when requested id matches authenticated user", async () => {
+    const uid = "firebase-uid-1";
+    const userId = new ObjectId();
+
+    requireAuth.mockResolvedValue({ uid });
+    connectDb.mockResolvedValue({
+      collection: jest.fn().mockReturnValue({
+        findOne: jest.fn().mockResolvedValue({ _id: userId }),
+      }),
+    });
     getUserImageFromDb.mockResolvedValue("https://public.blob.vercel-storage.com/a.jpg");
     fetchAndValidateImage.mockResolvedValue({
       imageBuffer: new ArrayBuffer(3),
@@ -63,7 +83,7 @@ describe("/api/images route orchestration", () => {
     });
 
     const req = {
-      url: "https://learnova.test/api/images?id=507f1f77bcf86cd799439011",
+      url: `https://learnova.test/api/images?id=${userId.toString()}`,
       headers: { get: jest.fn() },
     };
 
@@ -72,11 +92,120 @@ describe("/api/images route orchestration", () => {
     expect(response.status).toBe(200);
     expect(requireAuth).toHaveBeenCalledWith(req);
     expect(getUserImageFromDb).toHaveBeenCalledWith({
-      id: "507f1f77bcf86cd799439011",
+      id: userId.toString(),
     });
     expect(fetchAndValidateImage).toHaveBeenCalledWith(
       "https://public.blob.vercel-storage.com/a.jpg"
     );
+  });
+
+  test("GET rejects when user requests another user's image and is not admin or teacher", async () => {
+    const uid = "firebase-uid-1";
+    const ownId = new ObjectId();
+    const otherId = new ObjectId();
+
+    requireAuth.mockResolvedValue({ uid });
+    connectDb.mockResolvedValue({
+      collection: jest.fn().mockReturnValue({
+        findOne: jest.fn().mockResolvedValue({ _id: ownId }),
+      }),
+    });
+    const { getUserProfile } = require("@/lib/firebase-admin");
+    getUserProfile.mockResolvedValue({ role: "student" });
+
+    const req = {
+      url: `https://learnova.test/api/images?id=${otherId.toString()}`,
+      headers: { get: jest.fn() },
+    };
+
+    const response = await GET(req);
+    const body = await response.json();
+
+    expect(response.status).toBe(403);
+    expect(body.error.message).toBe("You can only view your own profile image");
+  });
+
+  test("GET allows admin to view any user's image", async () => {
+    const uid = "admin-uid-1";
+    const ownId = new ObjectId();
+    const otherId = new ObjectId();
+
+    requireAuth.mockResolvedValue({ uid });
+    connectDb.mockResolvedValue({
+      collection: jest.fn().mockReturnValue({
+        findOne: jest.fn().mockResolvedValue({ _id: ownId }),
+      }),
+    });
+    const { getUserProfile } = require("@/lib/firebase-admin");
+    getUserProfile.mockResolvedValue({ role: "admin" });
+    getUserImageFromDb.mockResolvedValue("https://public.blob.vercel-storage.com/admin-view.jpg");
+    fetchAndValidateImage.mockResolvedValue({
+      imageBuffer: new ArrayBuffer(3),
+      contentType: "image/jpeg",
+    });
+
+    const req = {
+      url: `https://learnova.test/api/images?id=${otherId.toString()}`,
+      headers: { get: jest.fn() },
+    };
+
+    const response = await GET(req);
+
+    expect(response.status).toBe(200);
+    expect(getUserImageFromDb).toHaveBeenCalledWith({
+      id: otherId.toString(),
+    });
+  });
+
+  test("GET allows teacher to view any user's image", async () => {
+    const uid = "teacher-uid-1";
+    const ownId = new ObjectId();
+    const otherId = new ObjectId();
+
+    requireAuth.mockResolvedValue({ uid });
+    connectDb.mockResolvedValue({
+      collection: jest.fn().mockReturnValue({
+        findOne: jest.fn().mockResolvedValue({ _id: ownId }),
+      }),
+    });
+    const { getUserProfile } = require("@/lib/firebase-admin");
+    getUserProfile.mockResolvedValue({ role: "teacher" });
+    getUserImageFromDb.mockResolvedValue("https://public.blob.vercel-storage.com/teacher-view.jpg");
+    fetchAndValidateImage.mockResolvedValue({
+      imageBuffer: new ArrayBuffer(3),
+      contentType: "image/jpeg",
+    });
+
+    const req = {
+      url: `https://learnova.test/api/images?id=${otherId.toString()}`,
+      headers: { get: jest.fn() },
+    };
+
+    const response = await GET(req);
+
+    expect(response.status).toBe(200);
+  });
+
+  test("GET returns 404 if authenticated user has no MongoDB record", async () => {
+    const uid = "orphan-uid";
+
+    requireAuth.mockResolvedValue({ uid });
+    connectDb.mockResolvedValue({
+      collection: jest.fn().mockReturnValue({
+        findOne: jest.fn().mockResolvedValue(null),
+      }),
+    });
+
+    const req = {
+      url: "https://learnova.test/api/images?id=507f1f77bcf86cd799439011",
+      headers: { get: jest.fn() },
+    };
+
+    const response = await GET(req);
+    const body = await response.json();
+
+    expect(response.status).toBe(404);
+    expect(body.error.message).toBe("User not found");
   });
 
   test("POST orchestrates auth, file extraction, upload and DB update", async () => {

--- a/components/__tests__/labelsRoute.test.js
+++ b/components/__tests__/labelsRoute.test.js
@@ -85,7 +85,7 @@ describe("GET /api/labels - Security & Authentication Tests", () => {
     const body = await response.json();
 
     expect(response.status).toBe(401);
-    expect(body.error).toBe("Unauthorized");
+    expect(body.error.message).toBe("Unauthorized");
     expect(connectDb).not.toHaveBeenCalled();
   });
 
@@ -96,7 +96,7 @@ describe("GET /api/labels - Security & Authentication Tests", () => {
     const body = await response.json();
 
     expect(response.status).toBe(401);
-    expect(body.error).toBe("Unauthorized");
+    expect(body.error.message).toBe("Unauthorized");
     expect(connectDb).not.toHaveBeenCalled();
   });
 
@@ -189,6 +189,29 @@ describe("GET /api/labels - Security & Authentication Tests", () => {
     const body11 = await response11.json();
 
     expect(response11.status).toBe(429);
-    expect(body11.error).toContain("Too many attempts");
+    expect(body11.error.message).toContain("Too many attempts");
+  });
+
+  test("does not expose hasImage flag for student role to prevent enumeration", async () => {
+    const mockUsers = [
+      { name: "Alice", email: "alice@domain.com", image: "https://example.com/alice.jpg" },
+      { name: "Bob", email: "bob@domain.com", image: "https://example.com/bob.jpg" },
+    ];
+    mockToArray.mockResolvedValue(mockUsers);
+
+    getUserProfile.mockResolvedValue({ role: "student" });
+
+    const req = createMockRequest("valid-token");
+    const response = await GET(req);
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.success).toBe(true);
+    expect(body.data).toEqual([
+      { name: "Alice", email: "alice@domain.com" },
+      { name: "Bob", email: "bob@domain.com" },
+    ]);
+    expect(body.data[0]).not.toHaveProperty("hasImage");
+    expect(body.data[1]).not.toHaveProperty("hasImage");
   });
 });


### PR DESCRIPTION
## What this fixes

The `GET /api/images` endpoint returned any user's facial photograph given only their MongoDB ObjectId, with no ownership or role check. Combined with the `hasImage` flag on `GET /api/labels` (visible to all authenticated roles), any student could enumerate users and download facial images across the entire system. Facial images are biometric data subject to GDPR Art. 9 and similar privacy regulations.

## Root cause

Two independent vulnerabilities:

1. **GET /api/images (`app/api/images/route.js:19-32`)** — The handler called `requireAuth` to verify a valid Firebase token existed, but never checked whether the requesting user owned the image they were fetching. The `getUserImageFromDb` service function accepted only an `{ id }` parameter with no caller context.

2. **GET /api/labels (`app/api/labels/route.js:58-61`)** — The response unconditionally included a `hasImage` boolean derived from the stored image URL. Since any student could search all users, this flag acted as an enumeration oracle — telling the attacker which users had photos and giving them the MongoDB `_id` needed for the images endpoint.

## What changed

- **`app/api/images/route.js`** — After authentication, the handler now looks up the requesting user's MongoDB record by `firebaseUid` and compares the requested `id` against their own `_id`. If they do not match, it checks the caller's role via `getUserProfile`. Only admin and teacher roles are exempted (needed for face-recognition workflows). Ownership match proceeds immediately without an extra profile lookup.
- **`app/api/labels/route.js`** — The `hasImage` field is now conditionally included based on role. Students no longer receive the flag, closing the enumeration vector. Teachers and admins continue to see it.
- **`components/__tests__/imagesRoute.test.js`** — Added tests for: own-image access, another-user rejection with ForbiddenError, admin override, teacher override, and missing MongoDB user record (404).
- **`components/__tests__/labelsRoute.test.js`** — Added test verifying `hasImage` is absent from the response for student role.

## How to verify

1. Authenticate as a student, obtain a valid Firebase token.
2. Call `GET /api/labels` with the token — confirm `hasImage` is not present in the response array.
3. Find any user's MongoDB `_id` and call `GET /api/images?id=<that-id>` — confirm 403 Forbidden.
4. Call `GET /api/images?id=<own-id>` — confirm 200 and the image is returned.
5. Repeat steps 2-4 as an admin user — confirm `hasImage` is present and any user's image is accessible.

## Edge cases considered

- **Authenticated user without a MongoDB record** (e.g. Firebase user who never completed registration) — returns 404.
- **Admin/teacher viewing a non-existent user id** — falls through to `getUserImageFromDb` which validates and returns 404 via `NotFoundError`.
- **Self-view optimized** — when the requested id matches the caller's own `_id`, no Firestore profile lookup is performed, keeping the fast path fast.
- **Student enumeration via labels** — the `hasImage` flag is entirely removed from student responses; the raw `image` URL was already excluded from the projection (only `_id, name, email` are returned).
- **Batch/rate-limit bypass** — out of scope for this fix; the existing rate limiter on the labels endpoint still applies.
- **`hasImage` is still useful for UI** — teachers need it for face-recognition workflows during attendance, so it remains for admin and teacher roles.

Closes #1883
