### PR TITLE
fix: replace invalid Tailwind `transition ...` with proper utility classes in Navbar.js

### DIFF
--- a/components/Navbar.js
+++ b/components/Navbar.js
@@ -645,7 +645,7 @@ export function Navbar() {
                       key={item.key}
                       href={item.href}
                       onClick={() => setIsMenuOpen(false)}
-                      className={`flex items-center gap-3 px-4 py-3.5 rounded-xl text-sm font-medium transition ...`}
+                      className={`flex items-center gap-3 px-4 py-3.5 rounded-xl text-sm font-medium transition-colors duration-200 text-zinc-700 dark:text-zinc-300 hover:bg-zinc-100 dark:hover:bg-zinc-800`}
 
                     >
                       <item.icon className="h-4 w-4 text-zinc-400" />


### PR DESCRIPTION
Fixes #1837

## Description
Replaced invalid Tailwind placeholder `transition ...` with proper 
utility classes in mobile drawer account links in Navbar.js. 
This restores missing hover and transition styles.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] My changes generate no new warnings
- [x] I have performed a self-review of my own code