### PR TITLE
fix(auth): restore buildable auth and groq helpers

### DIFF
--- a/components/AuthForm.js
+++ b/components/AuthForm.js
@@ -242,13 +242,18 @@ export default function AuthForm({
                   errors.password ? "border-red-500/50" : "border-border"
                 }`}
               />
-            );
-          })}
-        </div>
-      </div>
-    )}
-  </div>
-  {!isLogin && (
+              <button
+                type="button"
+                onClick={() => setShowPassword(!showPassword)}
+                className="absolute right-3 top-1/2 transform -translate-y-1/2 text-gray-400 hover:text-muted-foreground"
+              >
+                {showPassword ? <EyeOff className="w-5 h-5" /> : <Eye className="w-5 h-5" />}
+              </button>
+            </div>
+            {errors.password && <p className="text-red-400 text-sm mt-1">{errors.password}</p>}
+          </div>
+
+          {!isLogin && (
             <div>
               <label className="block text-sm font-medium text-foreground mb-2">
                 Confirm Password
@@ -261,11 +266,10 @@ export default function AuthForm({
                   placeholder="Confirm your password"
                   value={confirmPassword}
                   onChange={(e) => {
-                  const value = e.target.value;
-                  setConfirmPassword(value);
-                  // Run validation on every stroke so error clearing/setting is truly instant
-                  validateField("confirmPassword", value);
-                }}
+                    const value = e.target.value;
+                    setConfirmPassword(value);
+                    validateField("confirmPassword", value);
+                  }}
                   onBlur={(e) => validateField("confirmPassword", e.target.value)}
                   className={`w-full pl-10 pr-12 py-3 border rounded-xl focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500 transition-all duration-200 bg-background text-foreground placeholder-muted-foreground ${
                     errors.confirmPassword ? "border-red-500/50" : "border-border"
@@ -288,17 +292,18 @@ export default function AuthForm({
               )}
             </div>
           )}
-  {isLogin && (
-    <div className="text-right">
-      <button
-        type="button"
-        onClick={onForgotPassword}
-        className="text-sm text-indigo-400 hover:text-indigo-300 font-medium"
-      >
-        Forgot password?
-      </button>
-    </div>
-  )}
+
+          {isLogin && (
+            <div className="text-right">
+              <button
+                type="button"
+                onClick={onForgotPassword}
+                className="text-sm text-indigo-400 hover:text-indigo-300 font-medium"
+              >
+                Forgot password?
+              </button>
+            </div>
+          )}
 
           <button
             type="submit"

--- a/lib/ai/__tests__/groq.test.js
+++ b/lib/ai/__tests__/groq.test.js
@@ -8,13 +8,13 @@ describe("lib/ai/groq helpers", () => {
   test("validateGroqBody returns trimmed message from message field", () => {
     const result = validateGroqBody({ message: "  hello nova  " });
 
-    expect(result).toEqual({ trimmedMessage: "hello nova" });
+    expect(result).toEqual({ trimmedMessage: "hello nova", messages: [] });
   });
 
   test("validateGroqBody supports userMessage fallback", () => {
     const result = validateGroqBody({ userMessage: "  from fallback field " });
 
-    expect(result).toEqual({ trimmedMessage: "from fallback field" });
+    expect(result).toEqual({ trimmedMessage: "from fallback field", messages: [] });
   });
 
   test("validateGroqBody throws for empty message", () => {

--- a/lib/ai/groq.js
+++ b/lib/ai/groq.js
@@ -37,11 +37,6 @@ const groqBodySchema = z.object({
     trimmedMessage: rawMessage.trim(),
     messages: historyMessages,
   };
-  let rawMessage = data.message ?? data.userMessage ?? "";
-  if (!rawMessage && data.messages && data.messages.length > 0) {
-    rawMessage = data.messages[data.messages.length - 1].content;
-  }
-  return { trimmedMessage: rawMessage.trim() };
 }).superRefine((data, ctx) => {
   if (!data.trimmedMessage) {
     ctx.addIssue({


### PR DESCRIPTION
## What
Fixes the current production build failure reported in #1974 by repairing malformed auth-form JSX and removing a duplicate Groq parser declaration that made `rawMessage` redeclare in the same scope.

## How
Restored the password visibility control and confirm-password field to valid JSX, kept the existing confirm-password validation behavior, and removed the unreachable duplicate Groq transform block while preserving conversation-history parsing. Updated the Groq helper unit test to match the current return shape.

## Testing
- `npm run build`
- `npm test -- lib/ai/__tests__/groq.test.js`
- `git diff --check`

## Risks / Notes
The full Vitest suite still has unrelated upstream failures in route tests and test mocks; this PR keeps the scope to the build-blocking syntax errors. Local build completes successfully, with the existing missing-env warnings printed during prerendering.

Fixes #1974