### PR TITLE
fix(ui): replace invalid Tailwind color shades

### DIFF
--- a/app/not-found.jsx
+++ b/app/not-found.jsx
@@ -99,7 +99,7 @@ export default function NotFound() {
           {/* Go to Dashboard */}
           <Link
             href="/student/dashboard"
-            className="w-full sm:w-auto inline-flex items-center justify-center gap-2 rounded-2xl border border-slate-200 dark:border-slate-800 hover:border-slate-350 dark:hover:border-slate-700 bg-white dark:bg-slate-900 hover:bg-slate-50 dark:hover:bg-slate-850 active:scale-95 text-slate-700 dark:text-slate-200 font-bold py-3.5 px-8 shadow-md transition-all duration-300 select-none group"
+            className="w-full sm:w-auto inline-flex items-center justify-center gap-2 rounded-2xl border border-slate-200 dark:border-slate-800 hover:border-slate-300 dark:hover:border-slate-700 bg-white dark:bg-slate-900 hover:bg-slate-50 dark:hover:bg-slate-800 active:scale-95 text-slate-700 dark:text-slate-200 font-bold py-3.5 px-8 shadow-md transition-all duration-300 select-none group"
           >
             <BookOpen className="w-4 h-4 transition-transform duration-300 group-hover:scale-110" />
             Go to Dashboard

--- a/components/courses/CourseFilters.jsx
+++ b/components/courses/CourseFilters.jsx
@@ -117,7 +117,7 @@ export default function CourseFilters() {
                 className={`inline-flex items-center gap-2 px-4.5 py-2.5 rounded-full text-sm font-semibold tracking-wide border cursor-pointer select-none transition-all duration-300 active:scale-95 ${
                   isSelected
                     ? "bg-gradient-to-r from-indigo-500 via-indigo-600 to-indigo-700 text-white border-transparent shadow-lg shadow-indigo-600/20"
-                    : "bg-slate-900/60 border-slate-850 hover:border-slate-700 hover:bg-slate-800/50 text-slate-300 hover:text-white"
+                    : "bg-slate-900/60 border-slate-800 hover:border-slate-700 hover:bg-slate-800/50 text-slate-300 hover:text-white"
                 }`}
               >
                 <Icon className={`w-4 h-4 transition-transform duration-300 ${isSelected ? "scale-110" : ""}`} />

--- a/components/courses/CourseLibrary.jsx
+++ b/components/courses/CourseLibrary.jsx
@@ -142,7 +142,7 @@ export default function CourseLibrary({
 
                       <Link
                         href={`/courses/${course.id}`}
-                        className="inline-flex items-center gap-1.5 px-4 py-2 rounded-xl bg-slate-900 border border-slate-850 hover:bg-slate-800 hover:border-slate-700 hover:text-white text-xs font-bold text-slate-300 transition-all duration-300 select-none group/btn shadow-md"
+                        className="inline-flex items-center gap-1.5 px-4 py-2 rounded-xl bg-slate-900 border border-slate-800 hover:bg-slate-800 hover:border-slate-700 hover:text-white text-xs font-bold text-slate-300 transition-all duration-300 select-none group/btn shadow-md"
                       >
                         Explore
                         <ArrowRight className="w-3.5 h-3.5 text-slate-500 group-hover/btn:translate-x-1 group-hover/btn:text-white transition-all duration-200" />

--- a/components/dashboard/CurriculumBuilder.jsx
+++ b/components/dashboard/CurriculumBuilder.jsx
@@ -647,7 +647,7 @@ export default function CurriculumBuilder() {
                               <select
                                 value={lesson.type}
                                 onChange={(e) => handleChangeLessonType(mod.id, lesson.id, e.target.value)}
-                                className="bg-zinc-900 border border-zinc-850 hover:border-zinc-800 rounded-md px-2 py-0.5 text-xs text-zinc-400 font-medium focus:outline-none cursor-pointer transition-all"
+                                className="bg-zinc-900 border border-zinc-800 hover:border-zinc-700 rounded-md px-2 py-0.5 text-xs text-zinc-400 font-medium focus:outline-none cursor-pointer transition-all"
                               >
                                 <option value="video">🎥 Video</option>
                                 <option value="article">📄 Text Article</option>

--- a/components/ui/BackToTop.jsx
+++ b/components/ui/BackToTop.jsx
@@ -40,7 +40,7 @@ export default function BackToTop() {
       onClick={scrollToTop}
       type="button"
       aria-label="Back to top"
-      className={`fixed bottom-24 right-7 z-[9999] p-3.5 rounded-2xl bg-slate-900/90 border border-slate-800 text-slate-100 hover:text-white shadow-2xl hover:shadow-indigo-500/20 active:scale-95 transition-all duration-500 ease-out backdrop-blur-md cursor-pointer hover:border-indigo-500/50 hover:bg-slate-850 ${isVisible
+      className={`fixed bottom-24 right-7 z-[9999] p-3.5 rounded-2xl bg-slate-900/90 border border-slate-800 text-slate-100 hover:text-white shadow-2xl hover:shadow-indigo-500/20 active:scale-95 transition-all duration-500 ease-out backdrop-blur-md cursor-pointer hover:border-indigo-500/50 hover:bg-slate-800 ${isVisible
         ? "opacity-100 scale-100 pointer-events-auto translate-y-0"
         : "opacity-0 scale-75 pointer-events-none translate-y-4"
         }`}

--- a/components/ui/BackToTop.jsx
+++ b/components/ui/BackToTop.jsx
@@ -40,7 +40,7 @@ export default function BackToTop() {
       onClick={scrollToTop}
       type="button"
       aria-label="Back to top"
-      className={`fixed bottom-24 right-7 z-[9999] p-3.5 rounded-2xl bg-slate-900/90 border border-slate-800 text-slate-100 hover:text-white shadow-2xl hover:shadow-indigo-500/20 active:scale-95 transition-all duration-500 ease-out backdrop-blur-md cursor-pointer hover:border-indigo-500/50 hover:bg-slate-800 ${isVisible
+      className={`fixed bottom-24 right-7 z-[9999] p-3.5 rounded-2xl bg-slate-900/90 border border-slate-800 text-slate-100 hover:text-white shadow-2xl hover:shadow-indigo-500/20 active:scale-95 transition-all duration-500 ease-out backdrop-blur-md cursor-pointer hover:border-indigo-500/50 hover:bg-slate-800/90 ${isVisible
         ? "opacity-100 scale-100 pointer-events-auto translate-y-0"
         : "opacity-0 scale-75 pointer-events-none translate-y-4"
         }`}

--- a/lib/courses.js
+++ b/lib/courses.js
@@ -82,7 +82,7 @@ export const COURSES = [
     rating: "4.9",
     category: "data-science",
     categoryLabel: "Data Science",
-    color: "from-red-650 to-orange-650",
+    color: "from-red-600 to-orange-600",
   },
   {
     id: "figma-prototyping-advanced",


### PR DESCRIPTION
## What
Replaces invalid Tailwind color shade utilities in the course and shared UI so the intended gradients, borders, and hover states are generated correctly. Closes #1997.

## How
Swapped nonstandard shades (`red-650`, `orange-650`, `slate-850`, `zinc-850`, and `slate-350`) for valid nearby Tailwind palette values while preserving the existing visual direction and component structure.

## Testing
- `rg -n "(slate|gray|zinc|neutral|stone|red|orange|amber|yellow|lime|green|emerald|teal|cyan|sky|blue|indigo|violet|purple|fuchsia|pink|rose)-[0-9]{2,3}" app components lib --glob "!node_modules" | grep -Ev -- "-(50|100|200|300|400|500|600|700|800|900|950)([^0-9]|$)" || true`
- `rg -n "red-650|orange-650|slate-850|zinc-850|slate-350" lib components app --glob "!node_modules"`
- `git diff --check`
- GitHub PR Checks: passed
- GitGuardian Security Checks: passed
- Contributor Guidelines Reminder: passed

`npm ci` could not be completed locally because the upstream `package-lock.json` is currently out of sync with `package.json` before tests/build can run. The exact blocker starts with: `npm ci can only install packages when your package.json and package-lock.json or npm-shrinkwrap.json are in sync`, including mismatches such as `Invalid: lock file's ajv@6.15.0 does not satisfy ajv@8.20.0` and missing `webpack@5.107.2`.

## Risks / Notes
No behavior or layout structure changes. The change is limited to replacing invalid Tailwind utility names with valid equivalent shades.

Vercel currently reports `Authorization required to deploy` before running an app deployment. That is an external deployment authorization/configuration failure, not a code failure from this PR.