### PR TITLE
fix: secure attendance passcodes by increasing PBKDF2 iterations

### DIFF
--- a/utils/passcodeUtils.js
+++ b/utils/passcodeUtils.js
@@ -1,5 +1,7 @@
 import crypto from "crypto";
 
+const PBKDF2_ITERATIONS = 210000;
+
 /**
  * Generates a secure, salted PBKDF2 hash of a passcode.
  * @param {string} passcode - The plain text passcode.
@@ -8,7 +10,7 @@ import crypto from "crypto";
 export function hashPasscode(passcode) {
   if (!passcode) return "";
   const salt = crypto.randomBytes(16).toString("hex");
-  const hash = crypto.pbkdf2Sync(passcode, salt, 1000, 64, "sha512").toString("hex");
+  const hash = crypto.pbkdf2Sync(passcode, salt, PBKDF2_ITERATIONS, 64, "sha512").toString("hex");
   return `${salt}:${hash}`;
 }
 
@@ -23,6 +25,6 @@ export function verifyPasscode(passcode, storedHash) {
     return false;
   }
   const [salt, originalHash] = storedHash.split(":");
-  const hash = crypto.pbkdf2Sync(passcode, salt, 1000, 64, "sha512").toString("hex");
+  const hash = crypto.pbkdf2Sync(passcode, salt, PBKDF2_ITERATIONS, 64, "sha512").toString("hex");
   return hash === originalHash;
 }


### PR DESCRIPTION
## 📌 Summary
This PR addresses a critical security vulnerability (CWE-916) by increasing the PBKDF2 iteration count for attendance passcodes from 1,000 to 210,000. This brings the application into compliance with NIST SP 800-132 standards and properly secures the 4-8 digit passcodes against offline brute-force attacks in the event of a database exposure.

## 🔗 Related Issue
Closes #2002

## 🛠️ Changes Made
- Modified `utils/passcodeUtils.js`.
- Extracted the iteration count into a maintainable constant `PBKDF2_ITERATIONS`.
- Increased the PBKDF2 iteration count from `1000` to `210000` for both `hashPasscode` and `verifyPasscode`.

## 🧪 How to Test
1. Check out this branch locally.
2. In your local Firebase/MongoDB environment, clear any existing attendance settings (passcodes hashed with 1,000 iterations will permanently fail verification after this fix).
3. Log in as a Teacher and generate a new attendance passcode.
4. Verify that the new passcode saves successfully to the database.
5. Log in as a Student and mark attendance using the newly generated passcode.
6. Confirm that verification succeeds and attendance is successfully marked.

## ✅ Checklist
- [x] Code follows the project's code style
- [x] Self-review done
- [x] No console errors or warnings
- [x] Tested locally
- [x] Related issue linked

## 📝 Additional Notes
**Migration Warning:** Existing passcodes generated prior to this PR will fail verification. It is recommended to invalidate active sessions upon deployment so teachers are prompted to generate fresh, secure passcodes.
