### PR TITLE
Fix auth logout cache clearing to preserve PWA static caches

### DIFF
--- a/hooks/__tests__/useAuth.test.js
+++ b/hooks/__tests__/useAuth.test.js
@@ -1,0 +1,42 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { clearAuthSensitiveCaches } from "../useAuth";
+
+describe("clearAuthSensitiveCaches", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("deletes only auth-sensitive cache keys and preserves other caches", async () => {
+    const deletedKeys = [];
+
+    globalThis.caches = {
+      keys: vi.fn().mockResolvedValue([
+        "static-assets-v1",
+        "image-cache",
+        "google-fonts-cache",
+        "auth-session-cache",
+        "user-profile-cache",
+        "api-token-cache",
+      ]),
+      delete: vi.fn().mockImplementation(async (key) => {
+        deletedKeys.push(key);
+        return true;
+      }),
+    };
+
+    await clearAuthSensitiveCaches();
+
+    expect(globalThis.caches.keys).toHaveBeenCalled();
+    expect(deletedKeys).toEqual(["auth-session-cache", "user-profile-cache", "api-token-cache"]);
+    expect(globalThis.caches.delete).toHaveBeenCalledTimes(3);
+  });
+
+  it("does nothing when caches is unavailable", async () => {
+    const originalCaches = globalThis.caches;
+    delete globalThis.caches;
+
+    await expect(clearAuthSensitiveCaches()).resolves.toBeUndefined();
+
+    globalThis.caches = originalCaches;
+  });
+});

--- a/hooks/useAuth.js
+++ b/hooks/useAuth.js
@@ -24,6 +24,30 @@ const deleteCookie = (name) => {
   }
 };
 
+const AUTH_SENSITIVE_CACHE_PATTERNS = [
+  /auth/i,
+  /user/i,
+  /session/i,
+  /token/i,
+  /profile/i,
+  /secure/i,
+];
+
+export const clearAuthSensitiveCaches = async () => {
+  if (typeof window === "undefined" || !("caches" in window)) return;
+
+  try {
+    const cacheKeys = await caches.keys();
+    const authCacheKeys = cacheKeys.filter((key) =>
+      AUTH_SENSITIVE_CACHE_PATTERNS.some((pattern) => pattern.test(key))
+    );
+
+    await Promise.all(authCacheKeys.map((key) => caches.delete(key)));
+  } catch (cacheErr) {
+    console.warn("Failed to clear auth-sensitive caches:", cacheErr);
+  }
+};
+
 /**
  * Provides authentication state and user profile information.
  * Tracks Firebase authentication changes and exposes auth-related utilities.
@@ -117,17 +141,8 @@ export const useAuth = () => {
           deleteCookie("authToken");
           deleteCookie("userRole");
 
-          // Clear PWA caches on logout to prevent data leakage on shared devices
-          if (typeof window !== "undefined" && "caches" in window) {
-            try {
-              const cacheKeys = await caches.keys();
-              await Promise.all(
-                cacheKeys.map((key) => caches.delete(key))
-              );
-            } catch (cacheErr) {
-              console.warn("Failed to clear PWA caches on auth state change:", cacheErr);
-            }
-          }
+          // Clear only auth-sensitive caches and preserve static/app shell caches
+          await clearAuthSensitiveCaches();
           setLoading(false);
         }
 
@@ -167,17 +182,8 @@ export const useAuth = () => {
       deleteCookie("authToken");
       deleteCookie("userRole");
 
-      // Clear all PWA caches to prevent cached API responses from persisting after logout
-      if (typeof window !== "undefined" && "caches" in window) {
-        try {
-          const cacheKeys = await caches.keys();
-          await Promise.all(
-            cacheKeys.map((key) => caches.delete(key))
-          );
-        } catch (cacheErr) {
-          console.warn("Failed to clear PWA caches on sign out:", cacheErr);
-        }
-      }
+      // Clear only auth-sensitive caches and preserve static/app shell caches
+      await clearAuthSensitiveCaches();
     } catch (err) {
       setError(err.message);
     }


### PR DESCRIPTION
## Description

Updated [useAuth.js] so logout and auth state cleanup only remove auth-sensitive caches instead of deleting all service worker caches. This preserves static assets, offline page cache, font cache, and other PWA resources while still clearing cookies and sensitive auth/session caches on sign-out.

Fixes #1764 

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [ ] My code follows the style guidelines of this project
- [ ] My changes generate no new warnings
- [ ] I have performed a self-review of my own code
