### PR TITLE
security: tighten token verification — 60s clock tolerance and revoca…

### DIFF
--- a/lib/firebase-admin.js
+++ b/lib/firebase-admin.js
@@ -55,7 +55,9 @@ export const verifyFirebaseToken = async (token) => {
   try {
     initializeFirebase();
 
-    const decodedToken = await admin.auth().verifyIdToken(token);
+    // Enable revocation check so tokens revoked in Firebase are rejected
+    // immediately rather than being accepted due to clock skew.
+    const decodedToken = await admin.auth().verifyIdToken(token, true);
 
     return {
       valid: true,
@@ -72,6 +74,10 @@ export const verifyFirebaseToken = async (token) => {
     switch (error.code) {
       case "auth/id-token-expired":
         reason = "expired";
+        break;
+
+      case "auth/id-token-revoked":
+        reason = "revoked";
         break;
 
       case "auth/invalid-id-token":

--- a/middleware.js
+++ b/middleware.js
@@ -6,6 +6,10 @@ const FIREBASE_API_KEY = process.env.NEXT_PUBLIC_FIREBASE_API_KEY;
 
 // ─── Rate Limiting ────────────────────────────────────────────────────────────
 
+// Allowed clock skew when validating JWT `exp` (seconds). Keep small to limit
+// acceptance window for expired or revoked tokens.
+const CLOCK_TOLERANCE_SECONDS = 60;
+
 const rateLimitMap = new Map();
 const RATE_LIMIT_WINDOW_MS = 15 * 60 * 1000; // 15 minutes
 const RATE_LIMIT_MAX = 5;
@@ -76,6 +80,37 @@ function buildPageCsp() {
 
 async function verifyIdToken(token) {
   try {
+    // Quick expiry check based on the token's `exp` claim to limit clock tolerance.
+    const getJwtExp = (t) => {
+      try {
+        const parts = t.split(".");
+        if (parts.length < 2) return null;
+        let payload = parts[1].replace(/-/g, "+").replace(/_/g, "/");
+        while (payload.length % 4) payload += "=";
+        let jsonStr;
+        if (typeof atob === "function") {
+          jsonStr = atob(payload);
+        } else if (typeof Buffer !== "undefined") {
+          jsonStr = Buffer.from(payload, "base64").toString("utf8");
+        } else {
+          return null;
+        }
+        const parsed = JSON.parse(jsonStr);
+        return typeof parsed.exp === "number" ? parsed.exp : null;
+      } catch {
+        return null;
+      }
+    };
+
+    const exp = getJwtExp(token);
+    if (exp) {
+      const now = Math.floor(Date.now() / 1000);
+      if (now > exp + CLOCK_TOLERANCE_SECONDS) {
+        // Token expired beyond acceptable clock skew/tolerance
+        return null;
+      }
+    }
+
     if (!FIREBASE_PROJECT_ID || !FIREBASE_API_KEY) return null;
 
     const response = await fetch(


### PR DESCRIPTION

## Description

Reduce JWT clock tolerance to 60 seconds (was accepting longer skew), add an explicit [exp] check in middleware to reject tokens expired beyond the tolerance, and enable Firebase Admin revocation checking so revoked tokens are rejected immediately. This closes the 5-minute window where stale/revoked tokens could access protected routes.

Fixes #1759 

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [ ] My code follows the style guidelines of this project
- [ ] My changes generate no new warnings
- [ ] I have performed a self-review of my own code
