### PR TITLE
fix(auth): refresh Firebase token after server-side role claim assign…

### DIFF
--- a/utils/authUtils.js
+++ b/utils/authUtils.js
@@ -110,12 +110,27 @@ export const createUserProfile = async (user, role, additionalData = {}) => {
     );
   }
 
+  try {
+    // Force refresh the token immediately after server-side custom claim assignment.
+    // This ensures the middleware receives an auth token with the role claim
+    // before the first redirect, avoiding expensive edge-runtime fallback lookups.
+    await user.getIdToken(true);
+  } catch (tokenError) {
+    console.error(
+      "[createUserProfile] Failed to refresh auth token after role assignment:",
+      tokenError?.message || tokenError,
+    );
+    throw new Error(
+      "Failed to update authentication token after signup. Please try again."
+    );
+  }
+
   // Initialize their empty dashboard stats
   try {
-  await initializeUserStats(user.uid);
-} catch (error) {
-  console.log("Stats init failed", error);
-}
+    await initializeUserStats(user.uid);
+  } catch (error) {
+    console.log("Stats init failed", error);
+  }
 
   return data.data.userProfile;
 };


### PR DESCRIPTION


## Description

Ensure [createUserProfile] refreshes the Firebase ID token immediately after [/api/auth/set-role] succeeds. This makes custom claims available before the first redirect, preventing middleware from relying on extra token verification lookups on initial page loads.

Fixes #1752 

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [ ] My code follows the style guidelines of this project
- [ ] My changes generate no new warnings
- [ ] I have performed a self-review of my own code
