### PR TITLE
fix(permissions): allow camera on /attendance via route-specific Perm…

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -23,7 +23,13 @@ const nextConfig = {
   async headers() {
     return [
       {
-        source: '/(.*)',
+        source: '/attendance/:path*',
+        headers: [
+          { key: 'Permissions-Policy', value: "camera=(self), microphone=(), geolocation=()" },
+        ],
+      },
+      {
+        source: '/((?!attendance).*)',
         headers: [
           { key: 'X-Frame-Options', value: 'DENY' },
           { key: 'Content-Security-Policy', value: "frame-ancestors 'none';" },


### PR DESCRIPTION


## Description

1. Add a dedicated header entry for /attendance/:path* that sets Permissions-Policy: camera=(self), microphone=(), geolocation=().
2. Change the global catch-all header source to exclude /attendance so the global camera=() rule doesn't block the attendance page.

Fixes #1751 

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [ ] My code follows the style guidelines of this project
- [ ] My changes generate no new warnings
- [ ] I have performed a self-review of my own code
