### PR TITLE
[REFACTOR] components/AuthForm.js

### DIFF
--- a/components/AuthForm.js
+++ b/components/AuthForm.js
@@ -1,15 +1,19 @@
 "use client";
 
 import { useMemo, useState } from "react";
-import { Eye, EyeOff, Mail, Lock, Sparkles } from "lucide-react";
+import { Mail, Lock, Sparkles } from "lucide-react";
 import { ROLE_CONFIG, USER_ROLES } from "@/constants/userRoles";
 import { getPasswordStrength } from "@/utils/passwordStrength";
 import {
-  validateRequired,
-  validateEmail,
-  validatePassword,
-  validateName,
-} from "@/utils/formValidation";
+  getPasswordRequirementFlags,
+  validateAuthField,
+} from "@/utils/authFormValidation";
+import {
+  OptionalInstituteField,
+  PasswordInputField,
+  SelectedRoleBadge,
+  TextInputField,
+} from "@/components/auth/AuthFormFields";
 
 export default function AuthForm({
   isLogin,
@@ -36,9 +40,13 @@ export default function AuthForm({
   const [showPassword, setShowPassword] = useState(false);
   const [confirmPassword, setConfirmPassword] = useState("");
   const [showConfirmPassword, setShowConfirmPassword] = useState(false);
-  
+
   const passwordStrength = useMemo(
     () => getPasswordStrength(password || ""),
+    [password]
+  );
+  const passwordRequirements = useMemo(
+    () => getPasswordRequirementFlags(password || ""),
     [password]
   );
 
@@ -49,30 +57,11 @@ export default function AuthForm({
   };
 
   const validateField = (field, value) => {
-    let result = true;
-    if (field === "fullName") {
-      result = validateName(value, "Full Name");
-    } else if (field === "instituteName") {
-      result = validateRequired(value, "Institute Name");
-    } else if (field === "inviteCode") {
-      result = validateRequired(value, "Invite Code");
-    } else if (field === "email") {
-      result = validateEmail(value);
-    } else if (field === "password") {
-      result = isLogin ? validateRequired(value, "Password") : validatePassword(value);
-      // Real-time synchronization check:
-      if (!isLogin && confirmPassword) {
-        if (value === confirmPassword) clearError("confirmPassword");
-        else setErrors((prev) => ({ ...prev, confirmPassword: "Passwords do not match" }));
-      }
-    } else if (field === "confirmPassword") {
-      // Direct verification block:
-      if (!value) {
-        result = "Please confirm your password";
-      } else if (value !== password) {
-        result = "Passwords do not match";
-      }
-    }
+    const result = validateAuthField(field, value, {
+      isLogin,
+      password,
+      confirmPassword,
+    });
 
     if (result !== true) {
       setErrors((prev) => ({ ...prev, [field]: result }));
@@ -81,34 +70,52 @@ export default function AuthForm({
     }
   };
 
+  const handleFieldChange = (field, setter) => (value) => {
+    setter(value);
+
+    if (errors[field]) {
+      validateField(field, value);
+    }
+
+    if (field === "password" && !isLogin && confirmPassword) {
+      const confirmResult = validateAuthField("confirmPassword", confirmPassword, {
+        password: value,
+      });
+
+      if (confirmResult === true) {
+        clearError("confirmPassword");
+      } else {
+        setErrors((prev) => ({ ...prev, confirmPassword: confirmResult }));
+      }
+    }
+  };
+
+  const handleFieldBlur = (field) => (value) => {
+    validateField(field, value);
+  };
+
+  const handleSubmit = (event) => {
+    event.preventDefault();
+
+    if (!isLogin && password !== confirmPassword) {
+      setErrors((prev) => ({
+        ...prev,
+        confirmPassword: "Passwords do not match",
+      }));
+      return;
+    }
+
+    onSubmit(event);
+  };
+
+  const selectedRoleConfig = selectedRole ? ROLE_CONFIG[selectedRole] : null;
+
   return (
     <div>
       {/* Selected Role Display */}
-      {selectedRole && ROLE_CONFIG[selectedRole] && (
-        <div className="mb-6">
-          <button
-            onClick={onRoleChange}
-            className="inline-flex items-center gap-3 p-4 bg-card backdrop-blur-sm rounded-xl border border-border hover:border-indigo-500/50 transition-all duration-200"
-          >
-            {(() => {
-              const config = ROLE_CONFIG[selectedRole];
-              if (!config) return null;
-              const IconComponent = config.icon;
-              return (
-                <>
-                  <div className={`w-10 h-10 rounded-full bg-gradient-to-r ${config.color} p-2`}>
-                    <IconComponent className="w-6 h-6 text-white" />
-                  </div>
-                  <div className="text-left">
-                    <h4 className="font-semibold text-card-foreground">{config.title}</h4>
-                    <p className="text-muted-foreground text-sm">Click to change role</p>
-                  </div>
-                </>
-              );
-            })()}
-          </button>
-        </div>
-      )}
+      {selectedRoleConfig ? (
+        <SelectedRoleBadge config={selectedRoleConfig} onClick={onRoleChange} />
+      ) : null}
 
       <div className="bg-card backdrop-blur-xl rounded-2xl shadow-2xl border border-border p-8 min-h-[620px] flex flex-col justify-between transition-all duration-300">
         <div className="text-center mb-8">
@@ -128,170 +135,78 @@ export default function AuthForm({
           </div>
         )}
 
-        <form 
-          onSubmit={(e) => {
-            e.preventDefault();
-            if (!isLogin && password !== confirmPassword) {
-              setErrors((prev) => ({ ...prev, confirmPassword: "Passwords do not match" }));
-              return;
-            }
-            onSubmit(e);
-          }} 
-          className="space-y-6"
-        >
-  {!isLogin && (
-    <>
-      <div>
-        <label className="block text-sm font-medium text-foreground mb-2">
-          Full Name
-        </label>
-        <input
-          type="text"
-          name="fullName"
-          placeholder="Enter your full name"
-          value={fullName}
-          onChange={(e) => {
-            const value = e.target.value;
-            setFullName(value);
+        <form onSubmit={handleSubmit} className="space-y-6">
+          {!isLogin ? (
+            <>
+              <TextInputField
+                label="Full Name"
+                name="fullName"
+                value={fullName}
+                onChange={handleFieldChange("fullName", setFullName)}
+                onBlur={handleFieldBlur("fullName")}
+                error={errors.fullName}
+                placeholder="Enter your full name"
+              />
 
-                    if (errors.fullName) {
-                      validateField("fullName", value);
-                    }
-                  }}
-                  onBlur={(e) => validateField("fullName", e.target.value)}
-                  className={`w-full px-4 py-3 border rounded-xl focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500 transition-all duration-200 bg-background text-foreground placeholder-muted-foreground ${
-                    errors.fullName ? "border-red-500/50" : "border-border"
-                  }`}
+              {selectedRole === USER_ROLES.INSTITUTE ? (
+                <OptionalInstituteField
+                  label="Institute Name"
+                  name="instituteName"
+                  value={instituteName}
+                  onChange={handleFieldChange("instituteName", setInstituteName)}
+                  onBlur={handleFieldBlur("instituteName")}
+                  error={errors.instituteName}
+                  placeholder="Enter your institute name"
                 />
-                {errors.fullName && <p className="text-red-400 text-sm mt-1">{errors.fullName}</p>}
-              </div>
-
-              {selectedRole === USER_ROLES.INSTITUTE && (
-                <div>
-                  <label className="block text-sm font-medium text-foreground mb-2">Institute Name</label>
-                  <input
-                    type="text"
-                    name="instituteName"
-                    placeholder="Enter your institute name"
-                    value={instituteName}
-                    onChange={(e) => {
-                      const value = e.target.value;
-                      setInstituteName(value);
-                      if (errors.instituteName) {
-                        validateField("instituteName", value);
-                      }
-                    }}
-                    onBlur={(e) => validateField("instituteName", e.target.value)}
-                    className={`w-full px-4 py-3 border rounded-xl focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500 transition-all duration-200 bg-background text-foreground placeholder-muted-foreground ${
-                      errors.instituteName ? "border-red-500/50" : "border-border"
-                    }`}
-                  />
-                  {errors.instituteName && <p className="text-red-400 text-sm mt-1">{errors.instituteName}</p>}
-                </div>
-              )}
+              ) : null}
             </>
-          )}
+          ) : null}
 
-          <div>
-            <label className="block text-sm font-medium text-foreground mb-2">Email Address</label>
-            <div className="relative">
-              <Mail className="absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-400 w-5 h-5" />
-              <input
-                type="email"
-                name="email"
-                autoComplete="email"
-                maxLength={254}
-                placeholder="Enter your email"
-                value={email}
-                onChange={(e) => {
-                  const value = e.target.value;
-                  setEmail(value);
-                  if (errors.email) {
-                    validateField("email", value);
-                  }
-                }}
-                onBlur={(e) => validateField("email", e.target.value)}
-                className={`w-full pl-10 pr-4 py-3 border rounded-xl focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500 transition-all duration-200 bg-background text-foreground placeholder-muted-foreground ${
-                  errors.email ? "border-red-500/50" : "border-border"
-                }`}
-              />
-            </div>
-            {errors.email && <p className="text-red-400 text-sm mt-1">{errors.email}</p>}
-          </div>
+          <TextInputField
+            label="Email Address"
+            name="email"
+            autoComplete="email"
+            maxLength={254}
+            value={email}
+            onChange={handleFieldChange("email", setEmail)}
+            onBlur={handleFieldBlur("email")}
+            error={errors.email}
+            placeholder="Enter your email"
+            icon={Mail}
+          />
 
-          <div>
-            <label className="block text-sm font-medium text-foreground mb-2">Password</label>
-            <div className="relative">
-              <Lock className="absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-400 w-5 h-5" />
-              <input
-                type={showPassword ? "text" : "password"}
-                name="password"
-                autoComplete={isLogin ? "current-password" : "new-password"}
-                maxLength={254}
-                placeholder="Enter your password"
-                value={password}
-                onChange={(e) => {
-                  const value = e.target.value;
-                  setPassword(value);
-                  if (errors.password) {
-                    validateField("password", value);
-                  }
-                }}
-                onBlur={(e) => validateField("password", e.target.value)}
-                className={`w-full pl-10 pr-12 py-3 border rounded-xl focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500 transition-all duration-200 bg-background text-foreground placeholder-muted-foreground ${
-                  errors.password ? "border-red-500/50" : "border-border"
-                }`}
-              />
-              <button
-                type="button"
-                onClick={() => setShowPassword(!showPassword)}
-                className="absolute right-3 top-1/2 transform -translate-y-1/2 text-gray-400 hover:text-muted-foreground"
-              >
-                {showPassword ? <EyeOff className="w-5 h-5" /> : <Eye className="w-5 h-5" />}
-              </button>
-            </div>
-            {errors.password && <p className="text-red-400 text-sm mt-1">{errors.password}</p>}
-          </div>
+          <PasswordInputField
+            label="Password"
+            name="password"
+            autoComplete={isLogin ? "current-password" : "new-password"}
+            maxLength={254}
+            value={password}
+            onChange={handleFieldChange("password", setPassword)}
+            onBlur={handleFieldBlur("password")}
+            error={errors.password}
+            placeholder="Enter your password"
+            icon={Lock}
+            isVisible={showPassword}
+            onToggleVisibility={() => setShowPassword((prev) => !prev)}
+            showRequirements={!isLogin}
+            requirements={passwordRequirements}
+            strength={passwordStrength}
+          />
 
-          {!isLogin && (
-            <div>
-              <label className="block text-sm font-medium text-foreground mb-2">
-                Confirm Password
-              </label>
-              <div className="relative">
-                <Lock className="absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-400 w-5 h-5" />
-                <input
-                  type={showConfirmPassword ? "text" : "password"}
-                  name="confirmPassword"
-                  placeholder="Confirm your password"
-                  value={confirmPassword}
-                  onChange={(e) => {
-                    const value = e.target.value;
-                    setConfirmPassword(value);
-                    validateField("confirmPassword", value);
-                  }}
-                  onBlur={(e) => validateField("confirmPassword", e.target.value)}
-                  className={`w-full pl-10 pr-12 py-3 border rounded-xl focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500 transition-all duration-200 bg-background text-foreground placeholder-muted-foreground ${
-                    errors.confirmPassword ? "border-red-500/50" : "border-border"
-                  }`}
-                />
-                <button
-                  type="button"
-                  onClick={() => setShowConfirmPassword(!showConfirmPassword)}
-                  className="absolute right-3 top-1/2 transform -translate-y-1/2 text-gray-400 hover:text-muted-foreground"
-                >
-                  {showConfirmPassword ? (
-                    <EyeOff className="w-5 h-5" />
-                  ) : (
-                    <Eye className="w-5 h-5" />
-                  )}
-                </button>
-              </div>
-              {errors.confirmPassword && (
-                <p className="text-red-400 text-sm mt-1">{errors.confirmPassword}</p>
-              )}
-            </div>
-          )}
+          {!isLogin ? (
+            <PasswordInputField
+              label="Confirm Password"
+              name="confirmPassword"
+              value={confirmPassword}
+              onChange={handleFieldChange("confirmPassword", setConfirmPassword)}
+              onBlur={handleFieldBlur("confirmPassword")}
+              error={errors.confirmPassword}
+              placeholder="Confirm your password"
+              icon={Lock}
+              isVisible={showConfirmPassword}
+              onToggleVisibility={() => setShowConfirmPassword((prev) => !prev)}
+            />
+          ) : null}
 
           {isLogin && (
             <div className="text-right">

--- a/components/StudentDashboard.js
+++ b/components/StudentDashboard.js
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useState, useEffect, useMemo } from "react";
+import React, { useState, useEffect, useMemo, useRef } from "react";
 import Image from "next/image";
 import dynamic from "next/dynamic";
 
@@ -55,6 +55,156 @@ const AttendanceCalendar = dynamic(
   }
 );
 
+const DAY_NAMES = [
+  "Sunday",
+  "Monday",
+  "Tuesday",
+  "Wednesday",
+  "Thursday",
+  "Friday",
+  "Saturday",
+];
+
+const ATTENDANCE_WINDOW_START_HOUR = 9;
+const ATTENDANCE_WINDOW_END_MINUTE = 10;
+
+const getUserInitials = (user) => {
+  if (!user?.displayName && !user?.email) {
+    return "U";
+  }
+
+  return (
+    user?.displayName
+      ?.split(" ")
+      .map((name) => name[0])
+      .join("")
+      .toUpperCase() || user?.email?.[0]?.toUpperCase() || "U"
+  );
+};
+
+const getDayName = (dayIndex) => DAY_NAMES[dayIndex] || DAY_NAMES[0];
+
+const isWeekday = (dayIndex) => dayIndex >= 1 && dayIndex <= 5;
+
+const parseClassStartTime = (time = "") => {
+  const [startTime = "00:00"] = String(time).split("-");
+  const [hour = "0", minute = "0"] = startTime.split(":");
+
+  return {
+    hour: Number(hour),
+    minute: Number(minute),
+  };
+};
+
+const getUpcomingClass = (classes, now) => {
+  const currentMinutes = now.getHours() * 60 + now.getMinutes();
+
+  return (
+    classes.find((cls) => {
+      const startTime = parseClassStartTime(cls?.time);
+      const classStartMinutes = startTime.hour * 60 + startTime.minute;
+
+      return classStartMinutes > currentMinutes;
+    }) || null
+  );
+};
+
+const getTodaySchedule = (now, schedule = weeklySchedule) => {
+  const dayIndex = now.getDay();
+  const dayName = getDayName(dayIndex);
+  const classes = schedule[dayName] || [];
+
+  return {
+    dayName,
+    classes,
+    upcomingClass: getUpcomingClass(classes, now),
+    isAttendanceWindow:
+      isWeekday(dayIndex) &&
+      now.getHours() === ATTENDANCE_WINDOW_START_HOUR &&
+      now.getMinutes() <= ATTENDANCE_WINDOW_END_MINUTE,
+  };
+};
+
+const getScheduleTickKey = (now) =>
+  `${now.getFullYear()}-${now.getMonth()}-${now.getDate()}-${now.getHours()}-${now.getMinutes()}`;
+
+const DashboardError = ({ error, onRetry }) => (
+  <div className="min-h-screen bg-background flex items-center justify-center p-4">
+    <div className="text-center max-w-sm">
+      <div className="w-16 h-16 bg-red-500/20 rounded-full flex items-center justify-center mx-auto mb-4">
+        <AlertTriangle className="w-8 h-8 text-red-400" />
+      </div>
+
+      <h2 className="text-xl font-bold mb-2">Error Loading Dashboard</h2>
+
+      <p className="text-muted-foreground text-sm mb-6">{error}</p>
+
+      <button
+        onClick={onRetry}
+        className="w-full bg-gradient-to-r from-green-500 to-blue-500 py-3 rounded-xl font-bold text-white"
+      >
+        <RefreshCw className="w-4 h-4 mr-2 inline" />
+        Retry
+      </button>
+    </div>
+  </div>
+);
+
+const DashboardHeader = ({ user, currentTime, getInitials }) => (
+  <div className="bg-card/40 backdrop-blur-xl rounded-2xl border border-border p-4 sm:p-6 shadow-xl">
+    <div className="flex flex-col md:flex-row md:items-center justify-between gap-6">
+      <div className="flex items-center gap-4">
+        <div className="relative flex-shrink-0">
+          {user?.photoURL ? (
+            <Image
+              src={user.photoURL}
+              alt="Profile"
+              width={48}
+              height={48}
+              className="w-12 h-12 rounded-xl object-cover border border-accent/30"
+            />
+          ) : (
+            <div className="w-12 h-12 rounded-xl bg-gradient-to-br from-accent to-blue-500 flex items-center justify-center">
+              <span className="text-sm font-bold text-white">{getInitials(user)}</span>
+            </div>
+          )}
+
+          <div className="absolute -bottom-1 -right-1 w-4 h-4 bg-green-400 rounded-full border-2 border-background" />
+        </div>
+
+        <div>
+          <div className="flex items-center gap-2 flex-wrap">
+            <h1 className="text-lg sm:text-2xl font-bold">
+              {user?.displayName || user?.email?.split("@")[0] || "Student"}
+            </h1>
+
+            <StreakTracker />
+          </div>
+
+          <div className="text-sm text-muted-foreground">{user?.email || "No email"}</div>
+        </div>
+      </div>
+
+      <div className="text-left md:text-right">
+        <div className="text-lg sm:text-xl font-mono">
+          {currentTime?.toLocaleTimeString([], {
+            hour: "2-digit",
+            minute: "2-digit",
+          })}
+        </div>
+
+        <div className="text-xs text-muted-foreground">
+          {currentTime?.toLocaleDateString([], {
+            weekday: "short",
+            month: "short",
+            day: "numeric",
+          })}
+        </div>
+      </div>
+    </div>
+  </div>
+);
+
 const StudentDashboard = () => {
   const { user } = useAuth();
 
@@ -63,15 +213,12 @@ const StudentDashboard = () => {
 
   const [loading, setLoading] = useState(true);
   const [currentTime, setCurrentTime] = useState(new Date());
+  const [scheduleTime, setScheduleTime] = useState(new Date());
   const [error, setError] = useState(null);
-
-  const [todayClasses, setTodayClasses] = useState([]);
-
-  const [upcomingClass, setUpcomingClass] = useState(null);
-  const [isAttendanceWindow, setIsAttendanceWindow] = useState(false);
 
   const [viewMode, setViewMode] = useState("heatmap");
   const [showComplaint, setShowComplaint] = useState(false);
+  const lastScheduleTickRef = useRef(getScheduleTickKey(new Date()));
 
   const attendanceStats = useMemo(() => {
     const counts = recentActivity.reduce(
@@ -121,80 +268,32 @@ const StudentDashboard = () => {
     };
   }, [attendanceStats, gamificationData]);
 
+  const scheduleState = useMemo(
+    () => getTodaySchedule(scheduleTime, weeklySchedule),
+    [scheduleTime]
+  );
+
+  const todayClasses = scheduleState.classes;
+  const upcomingClass = scheduleState.upcomingClass;
+  const isAttendanceWindow = scheduleState.isAttendanceWindow;
+
   useEffect(() => {
     const loadingTimer = setTimeout(() => {
       setLoading(false);
     }, 1500);
 
-    const updateDashboard = async () => {
-      try {
-        const now = new Date();
+    const updateDashboard = () => {
+      const now = new Date();
 
-        setCurrentTime(now);
+      setCurrentTime(now);
 
-        const hour = now.getHours();
-        const minute = now.getMinutes();
-        const day = now.getDay();
-
-        const isWeekday =
-          day >= 1 && day <= 5;
-
-        const isAttendanceTime =
-          hour === 9 && minute <= 10;
-
-        const newAttendanceState =
-          isWeekday && isAttendanceTime;
-
-        setIsAttendanceWindow(
-          (prev) =>
-            prev !== newAttendanceState
-              ? newAttendanceState
-              : prev
-        );
-
-        const dayNames = [
-          "Sunday",
-          "Monday",
-          "Tuesday",
-          "Wednesday",
-          "Thursday",
-          "Friday",
-          "Saturday",
-        ];
-
-        const today = dayNames[day];
-
-        const classes =
-          weeklySchedule[today] || [];
-
-        setTodayClasses(classes);
-
-        const upcoming = classes.find(
-          (cls) => {
-            const [startTime] =
-              cls.time.split("-");
-
-            const [classHour, classMinute] =
-              startTime
-                .split(":")
-                .map(Number);
-
-            return (
-              hour < classHour ||
-              (hour === classHour &&
-                minute < classMinute)
-            );
-          }
-        );
-
-        setUpcomingClass(upcoming || null);
-
-        setError(null);
-      } catch (err) {
-        setError(
-          "Failed to load dashboard data. Please try again."
-        );
+      const scheduleTickKey = getScheduleTickKey(now);
+      if (lastScheduleTickRef.current !== scheduleTickKey) {
+        lastScheduleTickRef.current = scheduleTickKey;
+        setScheduleTime(now);
       }
+
+      setError(null);
     };
 
     updateDashboard();
@@ -210,54 +309,12 @@ const StudentDashboard = () => {
     };
   }, []);
 
-  const getUserInitials = () => {
-    if (!user?.displayName && !user?.email) {
-      return "U";
-    }
-
-    return (
-      user?.displayName
-        ?.split(" ")
-        .map((n) => n[0])
-        .join("")
-        .toUpperCase() ||
-      user?.email?.[0]?.toUpperCase() ||
-      "U"
-    );
-  };
-
   if (loading) {
     return <DashboardSkeleton />;
   }
 
   if (error) {
-    return (
-      <div className="min-h-screen bg-background flex items-center justify-center p-4">
-        <div className="text-center max-w-sm">
-          <div className="w-16 h-16 bg-red-500/20 rounded-full flex items-center justify-center mx-auto mb-4">
-            <AlertTriangle className="w-8 h-8 text-red-400" />
-          </div>
-
-          <h2 className="text-xl font-bold mb-2">
-            Error Loading Dashboard
-          </h2>
-
-          <p className="text-muted-foreground text-sm mb-6">
-            {error}
-          </p>
-
-          <button
-            onClick={() =>
-              window.location.reload()
-            }
-            className="w-full bg-gradient-to-r from-green-500 to-blue-500 py-3 rounded-xl font-bold text-white"
-          >
-            <RefreshCw className="w-4 h-4 mr-2 inline" />
-            Retry
-          </button>
-        </div>
-      </div>
-    );
+    return <DashboardError error={error} onRetry={() => window.location.reload()} />;
   }
 
   return (
@@ -265,70 +322,11 @@ const StudentDashboard = () => {
       <Navbar />
 
       <div className="relative z-10 max-w-7xl mx-auto pt-20 pb-12 px-4 sm:px-6 space-y-6">
-
-        {/* Header */}
-        <div className="bg-card/40 backdrop-blur-xl rounded-2xl border border-border p-4 sm:p-6 shadow-xl">
-          <div className="flex flex-col md:flex-row md:items-center justify-between gap-6">
-
-            <div className="flex items-center gap-4">
-
-              <div className="relative flex-shrink-0">
-
-                {user?.photoURL ? (
-                  <Image
-                    src={user.photoURL}
-                    alt="Profile"
-                    width={48}
-                    height={48}
-                    className="w-12 h-12 rounded-xl object-cover border border-accent/30"
-                  />
-                ) : (
-                  <div className="w-12 h-12 rounded-xl bg-gradient-to-br from-accent to-blue-500 flex items-center justify-center">
-                    <span className="text-sm font-bold text-white">
-                      {getUserInitials()}
-                    </span>
-                  </div>
-                )}
-
-                <div className="absolute -bottom-1 -right-1 w-4 h-4 bg-green-400 rounded-full border-2 border-background" />
-              </div>
-
-              <div>
-                <div className="flex items-center gap-2 flex-wrap">
-                  <h1 className="text-lg sm:text-2xl font-bold">
-                    {user?.displayName ||
-                      user?.email?.split("@")[0] ||
-                      "Student"}
-                  </h1>
-
-                  <StreakTracker />
-                </div>
-
-                <div className="text-sm text-muted-foreground">
-                  {user?.email || "No email"}
-                </div>
-              </div>
-            </div>
-
-            <div className="text-left md:text-right">
-              <div className="text-lg sm:text-xl font-mono">
-                {currentTime?.toLocaleTimeString([], {
-                  hour: "2-digit",
-                  minute: "2-digit",
-                })}
-              </div>
-
-              <div className="text-xs text-muted-foreground">
-                {currentTime?.toLocaleDateString([], {
-                  weekday: "short",
-                  month: "short",
-                  day: "numeric",
-                })}
-              </div>
-            </div>
-
-          </div>
-        </div>
+        <DashboardHeader
+          user={user}
+          currentTime={currentTime}
+          getInitials={getUserInitials}
+        />
 
         {/* Remaining UI same structure */}
 
@@ -337,11 +335,7 @@ const StudentDashboard = () => {
   );
 };
 
-const StatCard = ({
-  color,
-  label,
-  value,
-}) => {
+const StatCard = ({ color, label, value }) => {
   const styles = {
     green:
       "from-green-500/20 to-green-600/20 border-green-500/30 text-green-400",

--- a/components/auth/AuthFormFields.jsx
+++ b/components/auth/AuthFormFields.jsx
@@ -1,0 +1,170 @@
+"use client";
+
+import React from "react";
+import { Eye, EyeOff } from "lucide-react";
+
+const fieldBaseClasses =
+  "w-full py-3 border rounded-xl focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500 transition-all duration-200 bg-background text-foreground placeholder-muted-foreground";
+
+const FieldShell = ({
+  label,
+  error,
+  children,
+}) => (
+  <div>
+    <label className="block text-sm font-medium text-foreground mb-2">
+      {label}
+    </label>
+    {children}
+    {error && <p className="text-red-400 text-sm mt-1">{error}</p>}
+  </div>
+);
+
+export const TextInputField = ({
+  label,
+  name,
+  value,
+  onChange,
+  onBlur,
+  error,
+  placeholder,
+  icon: Icon,
+  type = "text",
+  autoComplete,
+  maxLength,
+}) => (
+  <FieldShell label={label} error={error}>
+    <div className="relative">
+      {Icon ? (
+        <Icon className="absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-400 w-5 h-5" />
+      ) : null}
+      <input
+        type={type}
+        name={name}
+        autoComplete={autoComplete}
+        maxLength={maxLength}
+        placeholder={placeholder}
+        value={value}
+        onChange={(event) => onChange(event.target.value)}
+        onBlur={(event) => onBlur?.(event.target.value)}
+        className={`${fieldBaseClasses} ${Icon ? "pl-10 pr-4" : "px-4"} ${error ? "border-red-500/50" : "border-border"}`}
+      />
+    </div>
+  </FieldShell>
+);
+
+export const PasswordInputField = ({
+  label,
+  name,
+  value,
+  onChange,
+  onBlur,
+  error,
+  placeholder,
+  icon: Icon,
+  autoComplete,
+  maxLength,
+  isVisible,
+  onToggleVisibility,
+  showRequirements = false,
+  requirements,
+  strength,
+}) => (
+  <FieldShell label={label} error={error}>
+    <div className="relative">
+      {Icon ? (
+        <Icon className="absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-400 w-5 h-5" />
+      ) : null}
+      <input
+        type={isVisible ? "text" : "password"}
+        name={name}
+        autoComplete={autoComplete}
+        maxLength={maxLength}
+        placeholder={placeholder}
+        value={value}
+        onChange={(event) => onChange(event.target.value)}
+        onBlur={(event) => onBlur?.(event.target.value)}
+        className={`${fieldBaseClasses} ${Icon ? "pl-10 pr-12" : "pl-4 pr-12"} ${error ? "border-red-500/50" : "border-border"}`}
+      />
+      <button
+        type="button"
+        onClick={onToggleVisibility}
+        className="absolute right-3 top-1/2 transform -translate-y-1/2 text-gray-400 hover:text-muted-foreground"
+        aria-label={isVisible ? "Hide password" : "Show password"}
+      >
+        {isVisible ? <EyeOff className="w-5 h-5" /> : <Eye className="w-5 h-5" />}
+      </button>
+    </div>
+
+    {showRequirements && requirements ? (
+      <div className="mt-3 rounded-xl border border-border/70 bg-muted/30 p-3">
+        <div className="flex items-center justify-between gap-3 mb-3">
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-[0.2em] text-muted-foreground">
+              Password strength
+            </p>
+            <p className={`text-sm font-medium ${strength?.textClass || "text-muted-foreground"}`}>
+              {strength?.label || "Weak"}
+            </p>
+          </div>
+
+          <div className="h-2 w-24 rounded-full bg-border overflow-hidden">
+            <div className={`h-full ${strength?.barClass || "bg-red-500"} ${strength?.widthClass || "w-0"}`} />
+          </div>
+        </div>
+
+        <ul className="grid gap-2 text-xs text-muted-foreground sm:grid-cols-2">
+          <li className={requirements.lengthOk ? "text-emerald-400" : ""}>
+            {requirements.lengthOk ? "✓" : "•"} At least 8 characters
+          </li>
+          <li className={requirements.hasUpper ? "text-emerald-400" : ""}>
+            {requirements.hasUpper ? "✓" : "•"} One uppercase letter
+          </li>
+          <li className={requirements.hasLower ? "text-emerald-400" : ""}>
+            {requirements.hasLower ? "✓" : "•"} One lowercase letter
+          </li>
+          <li className={requirements.hasNumber ? "text-emerald-400" : ""}>
+            {requirements.hasNumber ? "✓" : "•"} One number
+          </li>
+          <li className={requirements.hasSpecial ? "text-emerald-400 sm:col-span-2" : "sm:col-span-2"}>
+            {requirements.hasSpecial ? "✓" : "•"} One special character
+          </li>
+        </ul>
+      </div>
+    ) : null}
+  </FieldShell>
+);
+
+export const OptionalInstituteField = (props) => {
+  if (!props) {
+    return null;
+  }
+
+  return <TextInputField {...props} />;
+};
+
+export const SelectedRoleBadge = ({ config, onClick }) => {
+  if (!config) {
+    return null;
+  }
+
+  const IconComponent = config.icon;
+
+  return (
+    <div className="mb-6">
+      <button
+        onClick={onClick}
+        className="inline-flex items-center gap-3 p-4 bg-card backdrop-blur-sm rounded-xl border border-border hover:border-indigo-500/50 transition-all duration-200"
+      >
+        <div className={`w-10 h-10 rounded-full bg-gradient-to-r ${config.color} p-2`}>
+          <IconComponent className="w-6 h-6 text-white" />
+        </div>
+
+        <div className="text-left">
+          <h4 className="font-semibold text-card-foreground">{config.title}</h4>
+          <p className="text-muted-foreground text-sm">Click to change role</p>
+        </div>
+      </button>
+    </div>
+  );
+};

--- a/utils/authFormValidation.js
+++ b/utils/authFormValidation.js
@@ -1,0 +1,47 @@
+import {
+  validateEmail,
+  validateName,
+  validatePassword,
+  validateRequired,
+} from "@/utils/formValidation";
+
+export const getPasswordRequirementFlags = (password = "") => {
+  const value = String(password || "");
+
+  return {
+    hasUpper: /[A-Z]/.test(value),
+    hasLower: /[a-z]/.test(value),
+    hasNumber: /\d/.test(value),
+    hasSpecial: /[^A-Za-z0-9]/.test(value),
+    lengthOk: value.length >= 8,
+  };
+};
+
+export const validateAuthField = (field, value, context = {}) => {
+  switch (field) {
+    case "fullName":
+      return validateName(value, "Full Name");
+    case "instituteName":
+      return validateRequired(value, "Institute Name");
+    case "inviteCode":
+      return validateRequired(value, "Invite Code");
+    case "email":
+      return validateEmail(value);
+    case "password":
+      return context.isLogin
+        ? validateRequired(value, "Password")
+        : validatePassword(value);
+    case "confirmPassword":
+      if (!value) {
+        return "Please confirm your password";
+      }
+
+      if (value !== context.password) {
+        return "Passwords do not match";
+      }
+
+      return true;
+    default:
+      return true;
+  }
+};


### PR DESCRIPTION
AuthForm is now split into reusable field components and a small validation helper, with the parent focused on wiring state and submit flow instead of inlining every field’s behavior. The validator mapping lives in authFormValidation.js, the reusable inputs and selected-role badge live in AuthFormFields.jsx, and the parent now memoizes password requirements at AuthForm.js.

I also removed the repeated inline change/blur blocks by using handler factories, and the password UI now computes its requirement flags once and reuses them in the checklist. Syntax checks passed on the edited files, but `pnpm test` and ESLint could not run here because this workspace does not have `node_modules` installed, so `vitest` and the lint binary are unavailable.


closes #1985