### PR TITLE
fix(chatbot): make chatbot stateful and preserve history (#2055)

### DIFF
--- a/components/ChatBot.js
+++ b/components/ChatBot.js
@@ -315,11 +315,15 @@ async function generateBotResponse(userMessage, currentCategory, idToken, update
 // ---------------------------------------------------------------------------
 // Save conversation helper
 // ---------------------------------------------------------------------------
-async function saveConversation(userText, botText) {
+async function saveConversation(userText, botText, idToken) {
+  if (!idToken) return;
   try {
     await fetch("/api/conversations", {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: {
+        "Content-Type": "application/json",
+        "Authorization": `Bearer ${idToken}`,
+      },
       body: JSON.stringify({ userMessage: userText, botMessage: botText }),
     });
   } catch {
@@ -397,6 +401,7 @@ export default function LearnovaChatbot() {
   const [messages, setMessages] = useState([INITIAL_MESSAGE]);
   const [inputMessage, setInputMessage] = useState("");
   const [isLoading, setIsLoading] = useState(false);
+  const [isHistoryLoading, setIsHistoryLoading] = useState(false);
   const [currentCategory, setCurrentCategory] = useState("general");
   const [isScrolling, setIsScrolling] = useState(false);
 
@@ -420,15 +425,99 @@ export default function LearnovaChatbot() {
   const userHasScrolledUp = useRef(false);
 
   useEffect(() => {
-    setMessages([
-      {
-        id: Date.now(),
-        text: getContextWelcomeMessage(),
-        isBot: true,
-        timestamp: new Date(),
+    let isMounted = true;
+
+    const fetchHistory = async () => {
+      if (!user || !isOpen) {
+        if (!user) {
+          setMessages([
+            {
+              id: "welcome",
+              text: getContextWelcomeMessage(),
+              isBot: true,
+              timestamp: new Date(),
+            }
+          ]);
+        }
+        return;
       }
-    ]);
-  }, [getContextWelcomeMessage]);
+
+      setIsHistoryLoading(true);
+      try {
+        const idToken = await user.getIdToken();
+        const response = await fetch("/api/conversations", {
+          headers: {
+            Authorization: `Bearer ${idToken}`,
+          },
+        });
+
+        if (!isMounted) return;
+
+        if (response.ok) {
+          const payload = await response.json();
+          const history = payload?.data || [];
+          if (history.length > 0) {
+            const historyMessages = [];
+            history.forEach((conv, index) => {
+              historyMessages.push({
+                id: conv._id ? `${conv._id}-user` : `hist-${index}-user`,
+                text: conv.userMessage,
+                isBot: false,
+                timestamp: new Date(conv.timestamp),
+              });
+              historyMessages.push({
+                id: conv._id ? `${conv._id}-bot` : `hist-${index}-bot`,
+                text: conv.botMessage,
+                isBot: true,
+                timestamp: new Date(conv.timestamp),
+              });
+            });
+            setMessages(historyMessages);
+          } else {
+            setMessages([
+              {
+                id: "welcome",
+                text: getContextWelcomeMessage(),
+                isBot: true,
+                timestamp: new Date(),
+              }
+            ]);
+          }
+        } else {
+          setMessages([
+            {
+              id: "welcome",
+              text: getContextWelcomeMessage(),
+              isBot: true,
+              timestamp: new Date(),
+            }
+          ]);
+        }
+      } catch (error) {
+        console.error("Error loading chat history:", error);
+        if (isMounted) {
+          setMessages([
+            {
+              id: "welcome",
+              text: getContextWelcomeMessage(),
+              isBot: true,
+              timestamp: new Date(),
+            }
+          ]);
+        }
+      } finally {
+        if (isMounted) {
+          setIsHistoryLoading(false);
+        }
+      }
+    };
+
+    fetchHistory();
+
+    return () => {
+      isMounted = false;
+    };
+  }, [user, isOpen, getContextWelcomeMessage]);
 
   useEffect(() => {
     if (!inputMessage && textareaRef.current) {
@@ -499,11 +588,12 @@ export default function LearnovaChatbot() {
       await new Promise((r) => setTimeout(r, 600));
 
       let botText = "";
+      let idToken = null;
       try {
         if (!user) {
           botText = "[**Please sign in**](/auth) to use the AI chatbot.";
         } else {
-          const idToken = await user.getIdToken();
+          idToken = await user.getIdToken();
           botText = await generateBotResponse(text, currentCategory, idToken, [...messages, userMsg]);
         }
       } catch {
@@ -521,7 +611,9 @@ export default function LearnovaChatbot() {
       setMessages((prev) => [...prev, botMsg]);
       setIsLoading(false);
 
-      await saveConversation(text, botText);
+      if (idToken) {
+        await saveConversation(text, botText, idToken);
+      }
     },
     [inputMessage, isLoading, currentCategory, user, messages]
   );
@@ -654,52 +746,61 @@ export default function LearnovaChatbot() {
             onScroll={handleScroll}
             className="flex-1 overflow-y-auto p-4 space-y-4 min-h-0 select-text"
           >
-            {messages.map((msg) => (
-              <div key={msg.id} className={`flex items-start space-x-2.5 ${msg.isBot ? "" : "flex-row-reverse space-x-reverse"}`}>
-                <div className={`p-2 rounded-xl shrink-0 ${msg.isBot ? themeTokens.botAvatar : themeTokens.userAvatar}`}>
-                  {msg.isBot ? <Bot size={16} /> : <User size={16} />}
-                </div>
-                <div className={`max-w-[80%] rounded-2xl px-3.5 py-2 text-sm shadow-sm transition-all duration-200 ${msg.isBot ? themeTokens.botMsg : themeTokens.userMsg}`}>
-                  {msg.isBot ? (
-                    <ReactMarkdown components={markdownComponents}>{msg.text}</ReactMarkdown>
-                  ) : (
-                    <p className="whitespace-pre-wrap break-words leading-relaxed">{msg.text}</p>
-                  )}
-                </div>
+            {isHistoryLoading ? (
+              <div className="flex flex-col items-center justify-center h-full space-y-2 text-gray-500">
+                <RefreshCw size={24} className="animate-spin text-purple-500" />
+                <span className="text-xs">Loading conversation history...</span>
               </div>
-            ))}
-
-            {isLoading && (
-              <div className="flex items-start space-x-2.5">
-                <div className={`p-2 rounded-xl shrink-0 ${themeTokens.botAvatar}`}>
-                  <Bot size={16} />
-                </div>
-                <div className={`rounded-2xl px-4 py-2.5 text-sm shadow-sm ${themeTokens.loading}`}>
-                  <div className="flex space-x-1 items-center h-4 select-none">
-                    <div className={`w-1.5 h-1.5 rounded-full animate-bounce delay-100 ${themeTokens.dot}`} style={{ backgroundColor: 'currentColor' }} />
-                    <div className={`w-1.5 h-1.5 rounded-full animate-bounce delay-200 ${themeTokens.dot}`} style={{ backgroundColor: 'currentColor' }} />
-                    <div className={`w-1.5 h-1.5 rounded-full animate-bounce delay-300 ${themeTokens.dot}`} style={{ backgroundColor: 'currentColor' }} />
+            ) : (
+              <>
+                {messages.map((msg) => (
+                  <div key={msg.id} className={`flex items-start space-x-2.5 ${msg.isBot ? "" : "flex-row-reverse space-x-reverse"}`}>
+                    <div className={`p-2 rounded-xl shrink-0 ${msg.isBot ? themeTokens.botAvatar : themeTokens.userAvatar}`}>
+                      {msg.isBot ? <Bot size={16} /> : <User size={16} />}
+                    </div>
+                    <div className={`max-w-[80%] rounded-2xl px-3.5 py-2 text-sm shadow-sm transition-all duration-200 ${msg.isBot ? themeTokens.botMsg : themeTokens.userMsg}`}>
+                      {msg.isBot ? (
+                        <ReactMarkdown components={markdownComponents}>{msg.text}</ReactMarkdown>
+                      ) : (
+                        <p className="whitespace-pre-wrap break-words leading-relaxed">{msg.text}</p>
+                      )}
+                    </div>
                   </div>
-                </div>
-              </div>
-            )}
+                ))}
 
-            {/* Suggested Questions Pillar Context Chips */}
-            {suggestedQuestions[currentCategory] && messages.length <= 1 && (
-              <div className="pt-2 space-y-2">
-                <p className="text-[11px] font-semibold tracking-wider uppercase opacity-60 px-1">Suggested Questions</p>
-                <div className="flex flex-col gap-2">
-                  {suggestedQuestions[currentCategory].map((q, idx) => (
-                    <button
-                      key={idx}
-                      onClick={() => handleSendMessage(q)}
-                      className={`text-left px-3 py-2 rounded-xl text-xs transition-all duration-200 cursor-pointer ${themeTokens.suggestion}`}
-                    >
-                      {q}
-                    </button>
-                  ))}
-                </div>
-              </div>
+                {isLoading && (
+                  <div className="flex items-start space-x-2.5">
+                    <div className={`p-2 rounded-xl shrink-0 ${themeTokens.botAvatar}`}>
+                      <Bot size={16} />
+                    </div>
+                    <div className={`rounded-2xl px-4 py-2.5 text-sm shadow-sm ${themeTokens.loading}`}>
+                      <div className="flex space-x-1 items-center h-4 select-none">
+                        <div className={`w-1.5 h-1.5 rounded-full animate-bounce delay-100 ${themeTokens.dot}`} style={{ backgroundColor: 'currentColor' }} />
+                        <div className={`w-1.5 h-1.5 rounded-full animate-bounce delay-200 ${themeTokens.dot}`} style={{ backgroundColor: 'currentColor' }} />
+                        <div className={`w-1.5 h-1.5 rounded-full animate-bounce delay-300 ${themeTokens.dot}`} style={{ backgroundColor: 'currentColor' }} />
+                      </div>
+                    </div>
+                  </div>
+                )}
+
+                {/* Suggested Questions Pillar Context Chips */}
+                {suggestedQuestions[currentCategory] && messages.length <= 1 && (
+                  <div className="pt-2 space-y-2">
+                    <p className="text-[11px] font-semibold tracking-wider uppercase opacity-60 px-1">Suggested Questions</p>
+                    <div className="flex flex-col gap-2">
+                      {suggestedQuestions[currentCategory].map((q, idx) => (
+                        <button
+                          key={idx}
+                          onClick={() => handleSendMessage(q)}
+                          className={`text-left px-3 py-2 rounded-xl text-xs transition-all duration-200 cursor-pointer ${themeTokens.suggestion}`}
+                        >
+                          {q}
+                        </button>
+                      ))}
+                    </div>
+                  </div>
+                )}
+              </>
             )}
           </div>
 
@@ -712,12 +813,13 @@ export default function LearnovaChatbot() {
                 value={inputMessage}
                 onChange={handleInputChange}
                 onKeyDown={handleKeyDown}
-                placeholder="Ask Nova a question..."
+                placeholder={isHistoryLoading ? "Loading chat history..." : "Ask Nova a question..."}
+                disabled={isHistoryLoading || isLoading}
                 className={`flex-1 resize-none overflow-y-auto py-2.5 pl-4 pr-10 rounded-xl text-sm focus:outline-none transition-all duration-150 border max-h-32 ${themeTokens.input}`}
               />
               <button
                 onClick={() => handleSendMessage()}
-                disabled={!inputMessage.trim() || isLoading}
+                disabled={!inputMessage.trim() || isLoading || isHistoryLoading}
                 className="absolute right-2 bottom-2 p-1.5 rounded-lg bg-purple-600 hover:bg-purple-700 text-white disabled:opacity-40 disabled:hover:bg-purple-600 transition-colors cursor-pointer"
                 aria-label="Send message"
               >

--- a/components/__tests__/conversationsRoute.test.js
+++ b/components/__tests__/conversationsRoute.test.js
@@ -60,7 +60,7 @@ describe("POST /api/conversations - Authentication and Validation Security Tests
     const body = await response.json();
 
     expect(response.status).toBe(401);
-    expect(body.error).toBe("Unauthorized");
+    expect(body.error.message).toBe("Unauthorized");
     expect(mockInsertOne).not.toHaveBeenCalled();
     expect(connectDb).not.toHaveBeenCalled();
   });
@@ -80,7 +80,7 @@ describe("POST /api/conversations - Authentication and Validation Security Tests
     const body = await response.json();
 
     expect(response.status).toBe(401);
-    expect(body.error).toBe("Unauthorized");
+    expect(body.error.message).toBe("Unauthorized");
     expect(mockInsertOne).not.toHaveBeenCalled();
     expect(connectDb).not.toHaveBeenCalled();
   });
@@ -128,7 +128,7 @@ describe("POST /api/conversations - Authentication and Validation Security Tests
     const body = await response.json();
 
     expect(response.status).toBe(413);
-    expect(body.error).toBe("Payload too large");
+    expect(body.error.message).toBe("Payload too large");
     expect(mockInsertOne).not.toHaveBeenCalled();
   });
 
@@ -146,7 +146,7 @@ describe("POST /api/conversations - Authentication and Validation Security Tests
     const body = await response.json();
 
     expect(response.status).toBe(400);
-    expect(body.error).toBe("Invalid JSON payload");
+    expect(body.error.message).toBe("Invalid JSON payload");
     expect(mockInsertOne).not.toHaveBeenCalled();
   });
 
@@ -166,7 +166,7 @@ describe("POST /api/conversations - Authentication and Validation Security Tests
     const body = await response.json();
 
     expect(response.status).toBe(400);
-    expect(body.error).toContain("userMessage must be a string");
+    expect(body.error.message).toContain("userMessage must be a string");
     expect(mockInsertOne).not.toHaveBeenCalled();
   });
 
@@ -186,7 +186,7 @@ describe("POST /api/conversations - Authentication and Validation Security Tests
     const body = await response.json();
 
     expect(response.status).toBe(400);
-    expect(body.error).toContain("botMessage is required");
+    expect(body.error.message).toContain("botMessage is required");
     expect(mockInsertOne).not.toHaveBeenCalled();
   });
 
@@ -280,7 +280,7 @@ describe("GET /api/conversations - History Retrieval Security and Performance Te
     const body = await response.json();
 
     expect(response.status).toBe(401);
-    expect(body.error).toBe("Unauthorized");
+    expect(body.error.message).toBe("Unauthorized");
     expect(connectDb).not.toHaveBeenCalled();
   });
 
@@ -293,7 +293,7 @@ describe("GET /api/conversations - History Retrieval Security and Performance Te
     const body = await response.json();
 
     expect(response.status).toBe(401);
-    expect(body.error).toBe("Unauthorized");
+    expect(body.error.message).toBe("Unauthorized");
     expect(connectDb).not.toHaveBeenCalled();
   });
 
@@ -370,6 +370,6 @@ describe("GET /api/conversations - History Retrieval Security and Performance Te
     const body = await response.json();
 
     expect(response.status).toBe(500);
-    expect(body.error).toBe("Internal server error");
+    expect(body.error.message).toBe("Internal server error");
   });
 });


### PR DESCRIPTION
## Description
This pull request fixes the statelessness of the Nova AI Chatbot by loading the user's conversation history when the chat is opened and authenticated. It also resolves authorization failures when saving new messages by passing the Firebase auth ID token in the bearer token header.

### Key Changes:
- **History loading**: Updated [ChatBot.js](file:///d:/Projects/GSSoC%202026/Learnova/components/ChatBot.js) to load up to 50 conversation pairs (100 messages) chronologically from `/api/conversations` when opened.
- **Save authorization**: Injected the ID token into the `Authorization` headers for POST requests to `/api/conversations`.
- **UX/UI polishing**: Added a spinner during history retrieval and disabled the chat input until the loaded messages are set.
- **API Tests**: Corrected test assertions in [conversationsRoute.test.js](file:///d:/Projects/GSSoC%202026/Learnova/components/__tests__/conversationsRoute.test.js) to check the nested `body.error.message` structure returned by the backend error handler. All 14 tests pass successfully.

Closes #2055

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] My changes generate no new warnings
- [x] I have performed a self-review of my own code
