### PR TITLE
fix(comments): persist homepage discussion thread

### DIFF
--- a/components/CommentSection.jsx
+++ b/components/CommentSection.jsx
@@ -3,8 +3,27 @@
 import { useState, useEffect } from "react";
 import { MessageSquare, Send } from "lucide-react";
 import { motion, AnimatePresence } from "framer-motion";
+import {
+  getCommentStorageKey,
+  normalizeStoredComments,
+} from "@/lib/commentStorage";
+import { safeLocalStorageGet, safeLocalStorageSet } from "@/lib/storage";
 
 // REMOVE db AND useAuth IMPORTS FOR NOW TO PREVENT CRASHES
+const defaultComments = [
+  {
+    id: "seed_1",
+    userName: "Ananya Rao",
+    userRole: "Teacher",
+    text: "Please make sure to review this notice before Monday's class.",
+  },
+  {
+    id: "seed_2",
+    userName: "Rahul Sharma",
+    userRole: "Student",
+    text: "Got it! Thanks for the update.",
+  },
+];
 
 const CommentSection = ({ noticeId }) => {
   // 1. FAKE USER BYPASS: This pretends you are logged in as a Teacher or Student
@@ -16,35 +35,22 @@ const CommentSection = ({ noticeId }) => {
 
   const [comments, setComments] = useState([]);
   const [newComment, setNewComment] = useState("");
+  const storageKey = getCommentStorageKey(noticeId);
 
   // 2. Load existing fake comments or persistent local storage comments
   useEffect(() => {
-    if (!noticeId) return;
-    
-    // Check if we have comments stored in the browser for this notice
-    const savedComments = localStorage.getItem(`comments_${noticeId}`);
-    if (savedComments) {
-      setComments(JSON.parse(savedComments));
-    } else {
-      // Seed data so the screen isn't empty when you first look at it
-      const defaultComments = [
-        {
-          id: "seed_1",
-          userName: "Ananya Rao",
-          userRole: "Teacher",
-          text: "Please make sure to review this notice before Monday's class.",
-        },
-        {
-          id: "seed_2",
-          userName: "Rahul Sharma",
-          userRole: "Student",
-          text: "Got it! Thanks for the update.",
-        }
-      ];
-      setComments(defaultComments);
-      localStorage.setItem(`comments_${noticeId}`, JSON.stringify(defaultComments));
+    const savedComments = normalizeStoredComments(
+      safeLocalStorageGet(storageKey, []),
+    );
+
+    if (savedComments.length > 0) {
+      setComments(savedComments);
+      return;
     }
-  }, [noticeId]);
+
+    setComments(defaultComments);
+    safeLocalStorageSet(storageKey, defaultComments);
+  }, [storageKey]);
 
   // 3. Handle comment submission without needing a live backend database connection
   const handleSubmitComment = (e) => {
@@ -60,9 +66,9 @@ const CommentSection = ({ noticeId }) => {
 
     const updatedComments = [...comments, freshComment];
     setComments(updatedComments);
-    
+
     // Save to browser memory so it stays there when you refresh the page
-    localStorage.setItem(`comments_${noticeId}`, JSON.stringify(updatedComments));
+    safeLocalStorageSet(storageKey, updatedComments);
     setNewComment("");
   };
 

--- a/components/__tests__/CommentSection.test.jsx
+++ b/components/__tests__/CommentSection.test.jsx
@@ -1,0 +1,63 @@
+import React from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import CommentSection from "../CommentSection";
+
+const createLocalStorageMock = () => {
+  let store = {};
+
+  return {
+    clear: vi.fn(() => {
+      store = {};
+    }),
+    getItem: vi.fn((key) => store[key] ?? null),
+    removeItem: vi.fn((key) => {
+      delete store[key];
+    }),
+    setItem: vi.fn((key, value) => {
+      store[key] = String(value);
+    }),
+  };
+};
+
+describe("CommentSection", () => {
+  beforeEach(() => {
+    Object.defineProperty(window, "localStorage", {
+      configurable: true,
+      value: createLocalStorageMock(),
+    });
+
+    window.localStorage.clear();
+  });
+
+  it("persists homepage comments under a stable fallback thread key", async () => {
+    const user = userEvent.setup();
+
+    const { unmount } = render(React.createElement(CommentSection));
+
+    await waitFor(() =>
+      expect(window.localStorage.getItem("comments_homepage")).toBeTruthy(),
+    );
+
+    await user.type(
+      screen.getByPlaceholderText(/write a comment or share feedback/i),
+      "This should persist{enter}",
+    );
+
+    await waitFor(() => {
+      expect(
+        JSON.parse(window.localStorage.getItem("comments_homepage")),
+      ).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ text: "This should persist" }),
+        ]),
+      );
+    });
+    expect(window.localStorage.getItem("comments_undefined")).toBeNull();
+
+    unmount();
+    render(React.createElement(CommentSection));
+
+    expect(await screen.findByText("This should persist")).toBeInTheDocument();
+  });
+});

--- a/lib/__tests__/commentStorage.test.js
+++ b/lib/__tests__/commentStorage.test.js
@@ -1,0 +1,74 @@
+import {
+  DEFAULT_COMMENT_THREAD_ID,
+  getCommentStorageKey,
+  normalizeStoredComments,
+} from "@/lib/commentStorage";
+
+describe("commentStorage", () => {
+  describe("getCommentStorageKey", () => {
+    it("uses the homepage thread when notice id is missing", () => {
+      expect(getCommentStorageKey()).toBe(
+        `comments_${DEFAULT_COMMENT_THREAD_ID}`,
+      );
+      expect(getCommentStorageKey("")).toBe(
+        `comments_${DEFAULT_COMMENT_THREAD_ID}`,
+      );
+      expect(getCommentStorageKey("   ")).toBe(
+        `comments_${DEFAULT_COMMENT_THREAD_ID}`,
+      );
+    });
+
+    it("uses a stable notice-specific key when notice id is provided", () => {
+      expect(getCommentStorageKey("notice-42")).toBe("comments_notice-42");
+      expect(getCommentStorageKey(42)).toBe("comments_42");
+    });
+  });
+
+  describe("normalizeStoredComments", () => {
+    it("returns an empty list for wrong-shaped stored comments", () => {
+      expect(normalizeStoredComments({ bad: true })).toEqual([]);
+      expect(normalizeStoredComments("not-an-array")).toEqual([]);
+      expect(normalizeStoredComments(null)).toEqual([]);
+    });
+
+    it("keeps valid comments and removes blank entries", () => {
+      expect(
+        normalizeStoredComments([
+          {
+            id: " comment-1 ",
+            userName: " Ananya Rao ",
+            userRole: " Teacher ",
+            text: " Review the notice ",
+          },
+          { id: "comment-2", text: "Fallback author" },
+          { id: "comment-3", text: "" },
+          "bad",
+        ]),
+      ).toEqual([
+        {
+          id: "comment-1",
+          userName: "Ananya Rao",
+          userRole: "Teacher",
+          text: "Review the notice",
+        },
+        {
+          id: "comment-2",
+          userName: "Anonymous",
+          userRole: "Contributor",
+          text: "Fallback author",
+        },
+      ]);
+    });
+
+    it("creates deterministic ids for stored comments missing an id", () => {
+      expect(normalizeStoredComments([{ text: "Saved comment" }])).toEqual([
+        {
+          id: "stored_0",
+          userName: "Anonymous",
+          userRole: "Contributor",
+          text: "Saved comment",
+        },
+      ]);
+    });
+  });
+});

--- a/lib/commentStorage.js
+++ b/lib/commentStorage.js
@@ -1,0 +1,42 @@
+export const DEFAULT_COMMENT_THREAD_ID = "homepage";
+
+export const getCommentStorageKey = (noticeId) => {
+  const normalizedThreadId = String(noticeId ?? "").trim();
+
+  return `comments_${normalizedThreadId || DEFAULT_COMMENT_THREAD_ID}`;
+};
+
+const isRecord = (value) =>
+  value !== null && typeof value === "object" && !Array.isArray(value);
+
+export const normalizeStoredComments = (comments) => {
+  if (!Array.isArray(comments)) {
+    return [];
+  }
+
+  return comments
+    .map((comment, index) => {
+      if (!isRecord(comment)) {
+        return null;
+      }
+
+      const text = typeof comment.text === "string" ? comment.text.trim() : "";
+      if (!text) {
+        return null;
+      }
+
+      const id = typeof comment.id === "string" ? comment.id.trim() : "";
+      const userName =
+        typeof comment.userName === "string" ? comment.userName.trim() : "";
+      const userRole =
+        typeof comment.userRole === "string" ? comment.userRole.trim() : "";
+
+      return {
+        id: id || `stored_${index}`,
+        userName: userName || "Anonymous",
+        userRole: userRole || "Contributor",
+        text,
+      };
+    })
+    .filter(Boolean);
+};

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -9,7 +9,7 @@ export default defineConfig({
   plugins: [react()],
   esbuild: {
     loader: 'jsx',
-    include: /.*\.js$/,
+    include: /.*\.[jt]sx?$/,
     exclude: [],
   },
   test: {


### PR DESCRIPTION
## What
Fixes #2080. The homepage discussion section now uses a stable fallback comment thread instead of writing submissions under `comments_undefined` when `CommentSection` is rendered without a `noticeId`.

## How
Added a small comment storage helper for stable key generation and stored comment normalization, then updated `CommentSection` to use the existing safe localStorage utilities. Added unit coverage for the storage helper and a component regression test for the homepage no-`noticeId` flow. The Vitest JSX include pattern now covers `.jsx` files so component tests can import JSX components correctly.

## Testing
- `git diff --check`
- `npm test -- lib/__tests__/commentStorage.test.js components/__tests__/CommentSection.test.jsx`
- `npm test -- components/__tests__/NoticeCard.test.jsx`
- `npm run build` currently fails before this change path because the local install is missing `react-circular-progressbar`/`recharts`, and upstream `app/layout.js` exports `metadata` twice via both `export { metadata } from "@/lib/seo/siteMetadata"` and `export const metadata = { ... }`.

## Risks / Notes
Existing comments previously stored under the bad `comments_undefined` key are not migrated; the fix prevents new homepage comments from using that unstable key and persists them under `comments_homepage`.
