### PR TITLE
Fix cascading reconnect loop in notice stream change handler

### DIFF
--- a/app/api/notices/stream/route.js
+++ b/app/api/notices/stream/route.js
@@ -66,9 +66,11 @@ let sharedStream = null;
 let sharedDb = null;
 let streamReconnectTimer = null;
 let streamReconnectRetryCount = 0;
+let streamGeneration = 0;
 
 async function startChangeStream() {
   stopChangeStream();
+  const gen = ++streamGeneration;
   try {
     sharedDb = await connectDbForSSE();
     const coll = sharedDb.collection("notices");
@@ -77,15 +79,24 @@ async function startChangeStream() {
       const doc = change.fullDocument;
       if (doc) broadcastNotice(doc);
     });
-    sharedStream.on("error", () => scheduleChangeStreamReconnect());
-    sharedStream.on("close", () => scheduleChangeStreamReconnect());
+    sharedStream.on("error", () => {
+      if (streamGeneration !== gen) return;
+      scheduleChangeStreamReconnect();
+    });
+    sharedStream.on("close", () => {
+      if (streamGeneration !== gen) return;
+      scheduleChangeStreamReconnect();
+    });
     streamReconnectRetryCount = 0;
   } catch {
-    scheduleChangeStreamReconnect();
+    if (streamGeneration === gen) {
+      scheduleChangeStreamReconnect();
+    }
   }
 }
 
 function stopChangeStream() {
+  streamGeneration++;
   if (streamReconnectTimer) {
     clearTimeout(streamReconnectTimer);
     streamReconnectTimer = null;


### PR DESCRIPTION
## What this fixes

The MongoDB change stream in `app/api/notices/stream/route.js` spawns duplicate cursors and polling intervals every time `stopChangeStream()` is called while a close event is pending. Each cycle doubles the number of active cursors, leaking connections from the SSE pool managed by `connectDbForSSE` in `lib/mongodb.js` and causing memory growth, duplicate event delivery, and eventually connection pool exhaustion.

## Root cause

`startChangeStream()` binds `close` and `error` handlers that unconditionally call `scheduleChangeStreamReconnect()`. When `stopChangeStream()` calls `sharedStream.close()`, the MongoDB driver fires the `close` event **asynchronously** -- after `stopChangeStream()` has already returned and cleared the timer. The stale handler then creates a new reconnect timer, which spawns a new cursor on top of whatever the current state is.

The critical paths:

1. `cleanup()` (line 194) calls `stopChangeStream()` when the last SSE client disconnects. The async close event fires afterward, scheduling a ghost reconnect that creates a cursor with no clients listening.
2. `startChangeStream()` calls `stopChangeStream()` at line 71 before creating a new stream. The old stream's close handler fires asynchronously and schedules a duplicate reconnect alongside the new stream.

Both paths result in unbounded cursor/timer accumulation.

## What changed

- `app/api/notices/stream/route.js`:
  - Added `streamGeneration` counter -- incremented on every `startChangeStream` and `stopChangeStream` call
  - `startChangeStream()` captures `const gen = ++streamGeneration` and binds `close`/`error` handlers that only reconnect if `streamGeneration === gen`
  - `stopChangeStream()` increments `streamGeneration` at entry, invalidating any handlers bound to the previous stream
  - The `catch` block in `startChangeStream()` also checks generation before scheduling a reconnect

## How to verify

1. Start the notice SSE stream: `curl -H "Authorization: Bearer <token>" http://localhost:3000/api/notices/stream`
2. Confirm notices stream normally
3. Stop the stream (abort curl) -- the last client disconnects, `stopChangeStream()` runs
4. Wait 30+ seconds and confirm no new MongoDB cursors are created (check with `db.currentOp()` in mongosh)
5. Before the fix, each stop would spawn a new cursor after 1-30s; after the fix, zero new cursors appear

## Edge cases considered

- **Reconnect during reconnection**: If the reconnect timer fires while `startChangeStream()` is still connecting, the generation check in the `catch` block prevents a duplicate reconnect.
- **Multiple clients disconnecting simultaneously**: Only the last client to reach `noticeListeners.size === 0` triggers `stopChangeStream()`. Subsequent close events from that single stop are invalidated by the generation increment.
- **MongoDB restart mid-reconnect**: The exponential backoff timer is unaffected; each new `startChangeStream()` call captures a fresh generation, so only that generation's handlers can trigger reconnects.
- **Rapid stop/start cycles**: Each `stopChangeStream()` increments the generation, making all prior handlers no-ops. Each `startChangeStream()` increments again and captures the new generation.

Closes #1970
