### PR TITLE
Fix avatar upload: store in Vercel Blob instead of MongoDB base64

### DIFF
--- a/app/api/upload/avatar/route.js
+++ b/app/api/upload/avatar/route.js
@@ -2,7 +2,8 @@ import { NextResponse } from "next/server";
 import { requireAuth } from "@/lib/rbac";
 import { checkRateLimit } from "@/lib/rateLimit";
 import { connectDb } from "@/lib/mongodb";
-import { extractImageFileFromFormData } from "@/lib/images/imagesService";
+import { extractImageFileFromFormData, uploadAvatarToBlob } from "@/lib/images/imagesService";
+import { del } from "@vercel/blob";
 
 export const dynamic = "force-dynamic";
 
@@ -56,30 +57,45 @@ export const POST = async (request) => {
       );
     }
 
-    // Convert file to base64
-    console.log("Converting file to base64...");
-    const arrayBuffer = await file.arrayBuffer();
-    const buffer = Buffer.from(arrayBuffer);
-    const base64Data = buffer.toString("base64");
-    const dataUrl = `data:${file.type};base64,${base64Data}`;
+    // Upload to Vercel Blob instead of storing base64 in MongoDB
+    console.log("Uploading to blob storage...");
+    const { blobUrl } = await uploadAvatarToBlob({
+      file,
+      uid: decodedToken.uid,
+    });
 
-    console.log("Data URL created, saving to database...");
+    try {
+      const db = await connectDb();
+      const usersCollection = db.collection("users");
 
-    // Save to MongoDB users collection
-    const db = await connectDb();
-    const usersCollection = db.collection("users");
-    
-    await usersCollection.updateOne(
-      { firebaseUid: decodedToken.uid },
-      { $set: { avatar: dataUrl } }
-    );
+      // Fetch existing avatar URL to clean up old blob if present
+      const existingUser = await usersCollection.findOne(
+        { firebaseUid: decodedToken.uid },
+        { projection: { avatar: 1 } }
+      );
 
-    console.log("Avatar saved successfully to database");
+      await usersCollection.updateOne(
+        { firebaseUid: decodedToken.uid },
+        { $set: { avatar: blobUrl } }
+      );
+
+      // Delete old blob after successful DB write
+      const oldAvatar = existingUser?.avatar;
+      if (oldAvatar && oldAvatar.startsWith("https://")) {
+        await del(oldAvatar).catch(() => {});
+      }
+    } catch (error) {
+      // Roll back blob upload on DB failure
+      await del(blobUrl).catch(() => {});
+      throw error;
+    }
+
+    console.log("Avatar saved successfully to blob storage");
     
     return NextResponse.json(
       { 
         success: true, 
-        url: dataUrl,
+        url: blobUrl,
         message: "Avatar uploaded successfully" 
       },
       { status: 200 }


### PR DESCRIPTION
## What this fixes

The avatar upload endpoint at `app/api/upload/avatar/route.js` converted uploaded images to base64 data URLs and stored them directly in the `avatar` field of the user's MongoDB document. A 5 MB JPEG becomes ~6.7 MB of base64 in the document. Every query against the `users` collection — gamification reads, role checks, dashboard data fetches — loaded this blob into memory, even when the avatar was irrelevant. At scale, user documents exceed MongoDB's 16 MB BSON limit after accumulating face descriptors, attendance history, and a large avatar.

## Root cause

The route handler at lines 59-75 read the uploaded file into a Buffer, encoded it as base64, constructed a `data:${file.type};base64,...` URL, and wrote it to MongoDB with `$set: { avatar: dataUrl }`. No other code in the codebase projects out the `avatar` field on reads, so every `db.collection("users").findOne(...)` fetched the full blob. The `lib/images/imagesService.js` file already had a working `uploadAvatarToBlob` function that uploads to Vercel Blob and returns a lightweight URL — it was used by `app/api/images/route.js` but not by the avatar upload endpoint.

## What changed

- `app/api/upload/avatar/route.js`:
  - Replaced base64 conversion and inline MongoDB storage with `uploadAvatarToBlob` from `lib/images/imagesService.js`
  - Stores the blob URL (a few hundred bytes) in the `avatar` field instead of the full image payload
  - Fetches the existing avatar URL before writing, and deletes the old blob after a successful DB write
  - Rolls back the new blob upload if the DB write fails
  - Added `del` import from `@vercel/blob` for cleanup

## How to verify

1. POST to `/api/upload/avatar` with a 3 MB JPEG and a valid auth token
2. Confirm the response contains a `url` field pointing to `public.blob.vercel-storage.com`
3. Query the `users` collection in MongoDB and confirm the `avatar` field contains a short URL, not a base64 string
4. Upload a second avatar and confirm the old blob is deleted from Vercel Blob Storage
5. Simulate a MongoDB write failure (e.g., invalid user ID) and confirm the newly uploaded blob is cleaned up

## Edge cases considered

- **First-time upload**: `existingUser` is null, no old blob to clean up — skips the `del` call safely
- **Existing base64 avatar from old code**: The `oldAvatar.startsWith("https://")` check skips base64 data URLs, so old documents with inline avatars are not incorrectly passed to `del`
- **DB write failure**: The catch block calls `del(blobUrl)` to clean up the newly uploaded blob, preventing orphaned blobs in Vercel storage
- **Concurrent uploads**: Each upload creates a new blob with a UUID-based filename, so concurrent requests don't collide

Closes #1969
