### PR TITLE
security: prevent user enumeration in password reset endpoint (CWE-204)

### DIFF
--- a/app/api/auth/reset-password/route.js
+++ b/app/api/auth/reset-password/route.js
@@ -50,11 +50,12 @@ export async function POST(request) {
     const firebaseData = await firebaseRes.json();
 
     if (!firebaseRes.ok) {
-      // Firebase throws "EMAIL_NOT_FOUND" when the user isn't registered
-      const errorMessage = firebaseData.error?.message === "EMAIL_NOT_FOUND" 
-        ? "No user found with this email address."
-        : firebaseData.error?.message || "Failed to send reset email.";
-        
+      // Prevent user enumeration: return success even if email not found
+      if (firebaseData.error?.message === "EMAIL_NOT_FOUND") {
+        return NextResponse.json({ success: true });
+      }
+      
+      const errorMessage = firebaseData.error?.message || "Failed to send reset email.";
       return NextResponse.json(
         { success: false, error: errorMessage },
         { status: firebaseRes.status }

--- a/app/api/auth/reset-password/route.test.js
+++ b/app/api/auth/reset-password/route.test.js
@@ -1,0 +1,126 @@
+import { POST } from "./route";
+import { checkRateLimit } from "@/lib/rateLimit";
+
+vi.mock("next/server", () => ({
+  NextResponse: {
+    json: vi.fn().mockImplementation((body, init) => {
+      return {
+        status: init?.status || 200,
+        json: async () => body,
+      };
+    }),
+  },
+}));
+
+vi.mock("@/lib/rateLimit", () => ({
+  checkRateLimit: vi.fn(),
+}));
+
+global.fetch = vi.fn();
+
+describe("POST /api/auth/reset-password", () => {
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env = { ...originalEnv };
+    process.env.NEXT_PUBLIC_FIREBASE_API_KEY = "mock-firebase-api-key";
+    checkRateLimit.mockResolvedValue({ allowed: true, remaining: 9 });
+  });
+
+  const createMockRequest = (bodyData, headers = {}) => {
+    return {
+      headers: {
+        get: (name) => headers[name.toLowerCase()] || null,
+      },
+      json: vi.fn().mockResolvedValue(bodyData),
+    };
+  };
+
+  test("returns 400 Bad Request if email is missing", async () => {
+    const req = createMockRequest({});
+    const response = await POST(req);
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.success).toBe(false);
+    expect(body.error).toBe("Email is required");
+  });
+
+  test("returns 429 if request is rate limited", async () => {
+    checkRateLimit.mockResolvedValue({ allowed: false });
+
+    const req = createMockRequest({ email: "test@example.com" });
+    const response = await POST(req);
+    const body = await response.json();
+
+    expect(response.status).toBe(429);
+    expect(body.success).toBe(false);
+    expect(body.error).toBe("Too many password reset requests. Please try again later.");
+  });
+
+  test("returns success true if Firebase API responds successfully", async () => {
+    global.fetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({ email: "test@example.com", requestType: "PASSWORD_RESET" }),
+    });
+
+    const req = createMockRequest({ email: "test@example.com" });
+    const response = await POST(req);
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.success).toBe(true);
+    expect(global.fetch).toHaveBeenCalledWith(
+      expect.stringContaining("accounts:sendOobCode"),
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({
+          requestType: "PASSWORD_RESET",
+          email: "test@example.com",
+        }),
+      })
+    );
+  });
+
+  test("returns success true (preventing user enumeration) if Firebase returns EMAIL_NOT_FOUND", async () => {
+    global.fetch.mockResolvedValue({
+      ok: false,
+      status: 400,
+      json: async () => ({
+        error: {
+          code: 400,
+          message: "EMAIL_NOT_FOUND",
+        },
+      }),
+    });
+
+    const req = createMockRequest({ email: "notfound@example.com" });
+    const response = await POST(req);
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.success).toBe(true);
+  });
+
+  test("returns non-EMAIL_NOT_FOUND Firebase errors transparently", async () => {
+    global.fetch.mockResolvedValue({
+      ok: false,
+      status: 400,
+      json: async () => ({
+        error: {
+          code: 400,
+          message: "INVALID_EMAIL",
+        },
+      }),
+    });
+
+    const req = createMockRequest({ email: "invalid-email" });
+    const response = await POST(req);
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.success).toBe(false);
+    expect(body.error).toBe("INVALID_EMAIL");
+  });
+});


### PR DESCRIPTION
### What this PR does
This PR hardens the password reset API endpoint `/api/auth/reset-password` against user enumeration attacks (CWE-204). 

Previously, when a client requested a password reset with an unregistered email, the API returned a detailed error or `404` code from Firebase Auth (`EMAIL_NOT_FOUND`), confirming that the account did not exist. This would allow a malicious actor to scan and harvest registered emails on the platform.

### Changes made
- **Hardening**: Masked `EMAIL_NOT_FOUND` from the Firebase API, mapping it to a standard `200 OK` success response (returning `{ success: true }`), effectively returning the exact same response as a registered email and completely preventing account enumeration.
- **Testing**: Created a comprehensive test suite `app/api/auth/reset-password/route.test.js` verifying proper validation, rate limiting, transparent handling of other genuine Firebase errors (like `INVALID_EMAIL`), and successful masking of `EMAIL_NOT_FOUND` to protect against enumeration.

Contributing on behalf of GSSoc'26!
Fixes #2099
