### PR TITLE
Fix imagesRoute test module resolution for vitest

### DIFF
--- a/components/__tests__/imagesRoute.test.js
+++ b/components/__tests__/imagesRoute.test.js
@@ -1,6 +1,8 @@
 import { ObjectId } from "mongodb";
 import { GET, POST } from "@/app/api/images/route";
 import { requireAuth } from "@/lib/rbac";
+import { connectDb } from "@/lib/mongodb";
+import { getUserProfile } from "@/lib/firebase-admin";
 import {
   extractImageFileFromFormData,
   fetchAndValidateImage,
@@ -59,11 +61,8 @@ vi.mock("@/lib/images/imagesService", () => ({
 }));
 
 describe("/api/images route orchestration", () => {
-  let connectDb;
-
   beforeEach(() => {
     vi.clearAllMocks();
-    connectDb = require("@/lib/mongodb").connectDb;
   });
 
   test("GET returns own image when requested id matches authenticated user", async () => {
@@ -110,7 +109,6 @@ describe("/api/images route orchestration", () => {
         findOne: vi.fn().mockResolvedValue({ _id: ownId }),
       }),
     });
-    const { getUserProfile } = require("@/lib/firebase-admin");
     getUserProfile.mockResolvedValue({ role: "student" });
 
     const req = {
@@ -136,7 +134,6 @@ describe("/api/images route orchestration", () => {
         findOne: vi.fn().mockResolvedValue({ _id: ownId }),
       }),
     });
-    const { getUserProfile } = require("@/lib/firebase-admin");
     getUserProfile.mockResolvedValue({ role: "admin" });
     getUserImageFromDb.mockResolvedValue("https://public.blob.vercel-storage.com/admin-view.jpg");
     fetchAndValidateImage.mockResolvedValue({
@@ -168,7 +165,6 @@ describe("/api/images route orchestration", () => {
         findOne: vi.fn().mockResolvedValue({ _id: ownId }),
       }),
     });
-    const { getUserProfile } = require("@/lib/firebase-admin");
     getUserProfile.mockResolvedValue({ role: "teacher" });
     getUserImageFromDb.mockResolvedValue("https://public.blob.vercel-storage.com/teacher-view.jpg");
     fetchAndValidateImage.mockResolvedValue({


### PR DESCRIPTION
## What this fixes

The `imagesRoute.test.js` test file failed to run under vitest because it used `require()` inside `beforeEach` to resolve mocked modules (`@/lib/mongodb`, `@/lib/firebase-admin`). Vitest's `vi.mock()` is hoisted to the top of the file, but `require()` calls inside test functions execute after the mock setup and fail with "Cannot find module" errors because the path alias isn't resolved at that point.

## Root cause

The test file was migrated from `jest.mock()` to `vi.mock()` (commit `3bc5322`), but the `require()` calls inside `beforeEach` and individual tests were not updated to use the top-level imports that vitest expects. `vi.mock()` hoists mock definitions, but `require()` with path aliases (`@/lib/mongodb`) fails when called outside the module scope.

## What changed

- `components/__tests__/imagesRoute.test.js`:
  - Added top-level imports for `connectDb` from `@/lib/mongodb` and `getUserProfile` from `@/lib/firebase-admin`
  - Removed `let connectDb` declaration and `require()` call from `beforeEach`
  - Removed inline `require()` calls from three test cases that fetched `getUserProfile`

## How to verify

1. Run `npx vitest run components/__tests__/imagesRoute.test.js` — all 6 tests should pass
2. Run `npx vitest run components/__tests__/labelsRoute.test.js` — all 7 tests should pass (unchanged)
3. Run `npx vitest run` — full test suite should pass

## Edge cases considered

- **Mock hoisting**: Top-level `vi.mock()` is hoisted before imports, so the mocked `connectDb` and `getUserProfile` are available in tests
- **Clearing mocks**: `vi.clearAllMocks()` in `beforeEach` still works correctly with the top-level imports since mocks are reset each test
- **No behavioral change**: The test logic and assertions are identical — only the module resolution mechanism changed

Closes #1952
