### PR TITLE
fix: validate reset password email input

### DIFF
--- a/app/api/auth/reset-password/route.js
+++ b/app/api/auth/reset-password/route.js
@@ -3,12 +3,13 @@ import { checkRateLimit } from "@/lib/rateLimit";
 import { parseJSON } from "@/lib/error-handler";
 
 const MAX_RESET_PASSWORD_PAYLOAD_BYTES = 1024;
+const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
 export async function POST(request) {
   try {
     const { email } = await parseJSON(request, MAX_RESET_PASSWORD_PAYLOAD_BYTES);
 
-    if (!email) {
+    if (typeof email !== "string" || !email.trim()) {
       return NextResponse.json(
         { success: false, error: "Email is required" },
         { status: 400 }
@@ -16,6 +17,13 @@ export async function POST(request) {
     }
 
     const sanitizedEmail = email.trim().toLowerCase();
+
+    if (!EMAIL_PATTERN.test(sanitizedEmail)) {
+      return NextResponse.json(
+        { success: false, error: "Please enter a valid email address." },
+        { status: 400 }
+      );
+    }
     
     // Rate limit both by IP and by email to prevent spamming
     const ip = request.headers.get("x-forwarded-for") || "unknown";


### PR DESCRIPTION
## Description
Fixes weak password reset input validation. The API now rejects missing, blank, non-string, or malformed email values before rate limiting or calling Firebase.

Fixes #2127 

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [ ] My code follows the style guidelines of this project
- [ ] My changes generate no new warnings
- [ ] I have performed a self-review of my own code
