### PR TITLE
fix: clear auth caches across runtimes

### DIFF
--- a/hooks/useAuth.js
+++ b/hooks/useAuth.js
@@ -3,7 +3,7 @@
 import { useState, useEffect } from "react";
 import { auth, db } from "@/lib/firebaseConfig";
 import { onAuthStateChanged, signOut as firebaseSignOut } from "firebase/auth";
-import { doc, getDoc, onSnapshot } from "firebase/firestore";
+import { doc, onSnapshot } from "firebase/firestore";
 
 /**
  * Cookie utility helpers for writing/deleting client cookies
@@ -40,15 +40,16 @@ const AUTH_SENSITIVE_CACHE_PATTERNS = [
 ];
 
 export const clearAuthSensitiveCaches = async () => {
-  if (typeof window === "undefined" || !("caches" in window)) return;
+  const cacheStorage = globalThis?.caches;
+  if (!cacheStorage) return;
 
   try {
-    const cacheKeys = await caches.keys();
+    const cacheKeys = await cacheStorage.keys();
     const authCacheKeys = cacheKeys.filter((key) =>
       AUTH_SENSITIVE_CACHE_PATTERNS.some((pattern) => pattern.test(key))
     );
 
-    await Promise.all(authCacheKeys.map((key) => caches.delete(key)));
+    await Promise.all(authCacheKeys.map((key) => cacheStorage.delete(key)));
   } catch (cacheErr) {
     console.warn("Failed to clear auth-sensitive caches:", cacheErr);
   }


### PR DESCRIPTION
## Description

Fixes auth-sensitive cache clearing across runtimes. clearAuthSensitiveCaches now uses globalThis.caches, so it works reliably in browser-like test environments as well as normal browser runtime. Also removes an unused Firestore import.

Fixes #2128 

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [ ] My code follows the style guidelines of this project
- [ ] My changes generate no new warnings
- [ ] I have performed a self-review of my own code
