### PR TITLE
fix: restart timeout on reset

### DIFF
--- a/hooks/useTimer.js
+++ b/hooks/useTimer.js
@@ -27,21 +27,35 @@ export function useTimeout(callback, delay, immediate = false) {
     }
   };
 
+  const start = () => {
+    if (delay !== null && delay !== undefined) {
+      timeoutRef.current = setTimeout(() => {
+        callbackRef.current();
+        timeoutRef.current = null;
+      }, delay);
+    }
+  };
+
   useEffect(() => {
     if (immediate) {
       callbackRef.current();
     }
 
-    if (delay !== null && delay !== undefined) {
-      timeoutRef.current = setTimeout(() => {
-        callbackRef.current();
-      }, delay);
-    }
+    start();
 
     return clear;
   }, [delay, immediate]);
 
-  return { clear, reset: () => clear() };
+  return {
+    clear,
+    reset: () => {
+      clear();
+      if (immediate) {
+        callbackRef.current();
+      }
+      start();
+    },
+  };
 }
 
 /**


### PR DESCRIPTION
## Description

Fixes useTimeout.reset(). Before, reset() only cleared the timeout. Now it clears the old timer and starts a fresh one, matching expected reset behavior.

Fixes #2129 

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [ ] My code follows the style guidelines of this project
- [ ] My changes generate no new warnings
- [ ] I have performed a self-review of my own code
