### PR TITLE
fix: prevent duplicate attendance background sync execution

### DIFF
--- a/worker/index.js
+++ b/worker/index.js
@@ -139,7 +139,11 @@ async function replayQueuedMutations() {
 
 self.addEventListener("sync", (event) => {
   if (event.tag === "sync-attendance") {
-    event.waitUntil(syncAttendanceSW());
+    event.waitUntil(
+      syncAttendanceSW().catch((error) => {
+        console.error("[Service Worker] Background sync failed:", error);
+      })
+    );
   } else if (event.tag === "sync-offline-mutations") {
     event.waitUntil(replayQueuedMutations());
   }
@@ -222,16 +226,4 @@ self.addEventListener("fetch", (event) => {
       })
     );
   }
-});
-
-self.addEventListener("sync", (event) => {
-  if (event.tag !== "sync-attendance") {
-    return;
-  }
-
-  event.waitUntil(
-    syncAttendanceSW().catch((error) => {
-      console.error("[Service Worker] Background sync failed:", error);
-    })
-  );
 });


### PR DESCRIPTION
## Description
**Purpose:** Fixes duplicate execution of attendance background sync in the service worker.

**Description of Changes:**
- Removed the duplicate sync event listener in `worker/index.js`
- Consolidated `sync-attendance` handling into a single source of truth
- Preserved support for `sync-offline-mutations`
- Preserved background sync error logging
- Prevented duplicate execution of `syncAttendanceSW()`

**Verification / Testing Done:**
- [x] Verified only one sync listener handles `sync-attendance`
- [x] Confirmed `syncAttendanceSW()` executes once per sync event
- [x] Checked that offline mutation sync behavior remains unchanged
- [x] Verified service worker builds without errors

**Screenshots / GIFs:**
N/A — no UI changes introduced.

Fixes #1980

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings or console errors
- [x] I have deleted any temporary or debugging console logs