### PR TITLE
fix: improve stress meter text visibility in light theme

### DIFF
--- a/components/StressMeter.js
+++ b/components/StressMeter.js
@@ -45,14 +45,14 @@ export default function StressMeter() {
 
       <div className="mt-8 grid gap-6 lg:grid-cols-[280px_1fr] items-center">
         <div className="rounded-3xl border border-slate-200/80 dark:border-slate-800/80 bg-slate-50/90 dark:bg-slate-900/80 p-6 shadow-sm">
-          <div className="w-48 mx-auto">
+          <div className="w-48 mx-auto text-slate-950 dark:text-slate-50">
             <CircularProgressbar
               value={stress}
               text={`${stress}%`}
               strokeWidth={10}
               styles={buildStyles({
                 pathColor: accent,
-                textColor: "#ffffff",
+                textColor: "currentColor",
                 textSize: "22px",
                 trailColor: "rgba(148,163,184,0.2)",
                 backgroundColor: "#0f172a",


### PR DESCRIPTION
## Summary

This PR fixes the low-contrast percentage text issue inside the Stress Meter circular progress component in light mode.

## Changes Made

* Improved percentage text contrast for light theme
* Added theme-aware text styling
* Preserved existing circular progress layout and animations
* Maintained dark mode appearance consistency
## Fixes #2165
## Result

* Better readability in light mode
* Improved accessibility
* Consistent appearance across themes
* No layout regressions
* Before
<img width="838" height="677" alt="image" src="https://github.com/user-attachments/assets/92f7e77b-43a6-4a7e-82ae-7fb288fd9397" />
* After
<img width="853" height="722" alt="image" src="https://github.com/user-attachments/assets/b48e04d1-4169-4de0-b0fa-298ebcac6ada" />

## Testing

* Verified readability in light mode
* Confirmed dark mode remains unchanged
* Tested responsive behavior
