### PR TITLE
fix: add ARIA attributes for screen reader accessibility #1490

### DIFF
--- a/components/AuthForm.js
+++ b/components/AuthForm.js
@@ -145,6 +145,8 @@ export default function AuthForm({
                 onChange={handleFieldChange("fullName", setFullName)}
                 onBlur={handleFieldBlur("fullName")}
                 error={errors.fullName}
+                aria-invalid={errors.fullName ? "true" : "false"}
+                aria-describedby={errors.fullName ? "name-error" : undefined}
                 placeholder="Enter your full name"
               />
 
@@ -156,6 +158,8 @@ export default function AuthForm({
                   onChange={handleFieldChange("instituteName", setInstituteName)}
                   onBlur={handleFieldBlur("instituteName")}
                   error={errors.instituteName}
+                  aria-invalid={errors.instituteName ? "true" : "false"}
+                  aria-describedby={errors.instituteName ? "institute-error" : undefined}
                   placeholder="Enter your institute name"
                 />
               ) : null}
@@ -171,6 +175,8 @@ export default function AuthForm({
             onChange={handleFieldChange("email", setEmail)}
             onBlur={handleFieldBlur("email")}
             error={errors.email}
+            aria-invalid={errors.email ? "true" : "false"}
+            aria-describedby={errors.email ? "email-error" : undefined}
             placeholder="Enter your email"
             icon={Mail}
           />


### PR DESCRIPTION
## Description
Added standard ARIA accessibility attributes (`aria-invalid` and `aria-describedby`) to the input fields within the `AuthForm` component. This links the programmatic input state directly to the active error text elements, allowing screen readers (like VoiceOver, NVDA, and Narrator) to announce field invalidation and read out descriptive validation errors immediately when a field gains focus.

Fixes #1490 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] My changes generate no new warnings
- [x] I have performed a self-review of my own code