### PR TITLE
fix: resolve stale async validation messaging in AuthForm

### DIFF
--- a/components/AuthForm.js
+++ b/components/AuthForm.js
@@ -51,11 +51,14 @@ export default function AuthForm({
   );
 
   const clearError = (field) => {
-    if (errors[field]) {
-      setErrors((prev) => ({ ...prev, [field]: "" }));
-    }
-  };
-
+  if (errors[field]) {
+    setErrors((prev) => {
+      const updatedErrors = { ...prev };
+      delete updatedErrors[field];
+      return updatedErrors;
+    });
+  }
+};
   const validateField = (field, value) => {
     const result = validateAuthField(field, value, {
       isLogin,
@@ -207,6 +210,8 @@ export default function AuthForm({
               onChange={handleFieldChange("confirmPassword", setConfirmPassword)}
               onBlur={handleFieldBlur("confirmPassword")}
               error={errors.confirmPassword}
+              aria-invalid={errors.confirmPassword ? "true" : "false"}
+              aria-describedby={errors.confirmPassword ? "confirm-password-error" : undefined}
               placeholder="Confirm your password"
               icon={Lock}
               isVisible={showConfirmPassword}


### PR DESCRIPTION
## Description
This PR resolves an issue with the dynamic inline form validation inside `AuthForm.js`. Previously, when a validation error was triggered (e.g., via `onBlur`), the inline error string was reset to an empty string `""` once the input became valid. On subsequent keystrokes, JavaScript evaluated `""` as falsy, skipping the `handleFieldChange` re-evaluation block entirely and trapping stale error messages on the screen until a manual blur event was fired again. 

The fix modifies `clearError` to completely remove/delete the field's tracking key from the `errors` state object instead of setting it to an empty string. This ensures that real-time, character-by-character feedback clears error indicators instantly the exact moment the field satisfies the underlying validation rules.

Fixes #1489 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] My changes generate no new warnings
- [x] I have performed a self-review of my own code