### PR TITLE
Add security tests for auth cleanup endpoint

### DIFF
--- a/app/api/auth/cleanup/__tests__/route.test.js
+++ b/app/api/auth/cleanup/__tests__/route.test.js
@@ -1,0 +1,206 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { POST } from "@/app/api/auth/cleanup/route";
+
+const mockDeleteUser = vi.fn();
+
+vi.mock("firebase-admin", () => ({
+  default: {
+    auth: () => ({
+      deleteUser: mockDeleteUser,
+    }),
+  },
+}));
+
+vi.mock("@/lib/firebase-admin", () => ({
+  initializeFirebase: vi.fn(),
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+vi.mock("@/lib/error-handler", async () => {
+  const actual = await vi.importActual("@/lib/error-handler");
+  return {
+    ...actual,
+    withErrorHandler: (handler) => {
+      return async (request, ...args) => {
+        try {
+          return await handler(request, ...args);
+        } catch (error) {
+          const status = error.statusCode || 500;
+          const message = error.originalMessage !== undefined
+            ? (typeof error.originalMessage === "object"
+              ? error.originalMessage.message || JSON.stringify(error.originalMessage)
+              : error.originalMessage)
+            : error.message;
+          return {
+            status,
+            json: async () => ({
+              success: false,
+              error: {
+                code: `HTTP_${status}`,
+                message,
+                details: null,
+              },
+            }),
+          };
+        }
+      };
+    },
+    authenticateRequest: vi.fn(),
+    parseJSON: vi.fn(),
+  };
+});
+
+describe("POST /api/auth/cleanup", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("rejects unauthenticated requests with 401", async () => {
+    const { authenticateRequest } = await import("@/lib/error-handler");
+    const { UnauthorizedError } = await import("@/lib/errors");
+
+    authenticateRequest.mockRejectedValue(new UnauthorizedError("Unauthorized"));
+
+    const request = {
+      headers: {
+        get: vi.fn().mockReturnValue(null),
+      },
+    };
+
+    const response = await POST(request);
+    const body = await response.json();
+
+    expect(body.success).toBe(false);
+    expect(response.status).toBe(401);
+  });
+
+  it("rejects requests where authenticated user tries to delete another user's account", async () => {
+    const { authenticateRequest, parseJSON } = await import("@/lib/error-handler");
+
+    authenticateRequest.mockResolvedValue({ uid: "user-123", email: "a@test.com" });
+    parseJSON.mockResolvedValue({ uid: "user-456" });
+
+    const request = {
+      headers: {
+        get: vi.fn().mockReturnValue("Bearer valid-token"),
+      },
+    };
+
+    const response = await POST(request);
+    const body = await response.json();
+
+    expect(body.success).toBe(false);
+    expect(response.status).toBe(403);
+  });
+
+  it("allows authenticated user to delete their own orphaned account", async () => {
+    const { authenticateRequest, parseJSON } = await import("@/lib/error-handler");
+    const { initializeFirebase } = await import("@/lib/firebase-admin");
+
+    authenticateRequest.mockResolvedValue({ uid: "user-123", email: "a@test.com" });
+    parseJSON.mockResolvedValue({ uid: "user-123" });
+    mockDeleteUser.mockResolvedValue();
+
+    const request = {
+      headers: {
+        get: vi.fn().mockReturnValue("Bearer valid-token"),
+      },
+    };
+
+    const response = await POST(request);
+    const body = await response.json();
+
+    expect(body.success).toBe(true);
+    expect(response.status).toBe(200);
+    expect(initializeFirebase).toHaveBeenCalled();
+    expect(mockDeleteUser).toHaveBeenCalledWith("user-123");
+  });
+
+  it("returns 400 for missing UID", async () => {
+    const { authenticateRequest, parseJSON } = await import("@/lib/error-handler");
+
+    authenticateRequest.mockResolvedValue({ uid: "user-123", email: "a@test.com" });
+    parseJSON.mockResolvedValue({});
+
+    const request = {
+      headers: {
+        get: vi.fn().mockReturnValue("Bearer valid-token"),
+      },
+    };
+
+    const response = await POST(request);
+    const body = await response.json();
+
+    expect(body.success).toBe(false);
+    expect(response.status).toBe(400);
+  });
+
+  it("returns 400 for non-string UID", async () => {
+    const { authenticateRequest, parseJSON } = await import("@/lib/error-handler");
+
+    authenticateRequest.mockResolvedValue({ uid: "user-123", email: "a@test.com" });
+    parseJSON.mockResolvedValue({ uid: 12345 });
+
+    const request = {
+      headers: {
+        get: vi.fn().mockReturnValue("Bearer valid-token"),
+      },
+    };
+
+    const response = await POST(request);
+    const body = await response.json();
+
+    expect(body.success).toBe(false);
+    expect(response.status).toBe(400);
+  });
+
+  it("returns success when user was already deleted", async () => {
+    const { authenticateRequest, parseJSON } = await import("@/lib/error-handler");
+
+    authenticateRequest.mockResolvedValue({ uid: "user-123", email: "a@test.com" });
+    parseJSON.mockResolvedValue({ uid: "user-123" });
+
+    const notFoundError = new Error("User not found");
+    notFoundError.code = "auth/user-not-found";
+    mockDeleteUser.mockRejectedValue(notFoundError);
+
+    const request = {
+      headers: {
+        get: vi.fn().mockReturnValue("Bearer valid-token"),
+      },
+    };
+
+    const response = await POST(request);
+    const body = await response.json();
+
+    expect(body.success).toBe(true);
+    expect(response.status).toBe(200);
+  });
+
+  it("returns 500 on unexpected Firebase errors", async () => {
+    const { authenticateRequest, parseJSON } = await import("@/lib/error-handler");
+
+    authenticateRequest.mockResolvedValue({ uid: "user-123", email: "a@test.com" });
+    parseJSON.mockResolvedValue({ uid: "user-123" });
+    mockDeleteUser.mockRejectedValue(new Error("internal firebase error"));
+
+    const request = {
+      headers: {
+        get: vi.fn().mockReturnValue("Bearer valid-token"),
+      },
+    };
+
+    const response = await POST(request);
+    const body = await response.json();
+
+    expect(body.success).toBe(false);
+    expect(response.status).toBe(500);
+  });
+});


### PR DESCRIPTION
## What this fixes

The `POST /api/auth/cleanup` endpoint accepts a `{ uid }` from the request body and deletes the corresponding Firebase Auth account via the Admin SDK. The authentication and authorization checks were added in prior commits (ef0aafe, 5ee8833), but no tests existed to verify that these security guarantees actually work. Without test coverage, regressions could silently remove the auth check and reintroduce the critical vulnerability reported in #1768.

## Root cause

The endpoint was added as a server-side fix for orphaned Firebase Auth accounts (PR #1744) without any authentication check. Subsequent PRs (#1817, #1848) added `authenticateRequest` and a UID ownership check, but no tests were included to guard against regressions. Every other authenticated API route in the codebase has test coverage for its auth behavior — this was the sole exception.

## What changed

- Added `app/api/auth/cleanup/__tests__/route.test.js` with 7 test cases covering:
  - Unauthenticated requests are rejected with 401
  - Authenticated users cannot delete other users' accounts (403)
  - Authenticated users can delete their own orphaned accounts (200)
  - Missing UID returns 400
  - Non-string UID returns 400
  - Already-deleted user returns success (idempotent)
  - Unexpected Firebase errors return 500

## How to verify

1. Run the test suite: `npx vitest run app/api/auth/cleanup/__tests__/route.test.js`
2. Confirm all 7 tests pass
3. Verify the unauthenticated test (test 1) fails if you remove the `authenticateRequest` call from the route handler

## Edge cases considered

- Firebase `auth/user-not-found` error returns success (idempotent cleanup)
- Non-string UIDs (numbers, objects, arrays) are rejected
- Ownership check uses strict equality on `uid` to prevent cross-account deletion
- Error messages do not leak internal Firebase details to the client

Closes #1768