### PR TITLE
fix: prevent showing "You (Current)" to unauthenticated users

### DIFF
--- a/app/leaderboards/page.js
+++ b/app/leaderboards/page.js
@@ -137,13 +137,23 @@ export default function LeaderboardsPage() {
 
   const isDark = mounted ? theme === "dark" : true;
 
-  const displayData = leaderboardData.length > 0 ? leaderboardData : LEADERBOARD_DATA;
-  const topThree = displayData.length >= 3 ? [displayData[1], displayData[0], displayData[2]] : [];
-  const restOfList = displayData.slice(3);
-  
-  // Find current user or default to the last one
-  const currentUser = displayData.find(u => u.isCurrentUser) || displayData[displayData.length - 1] || LEADERBOARD_DATA[9];
+ const baseData =
+  leaderboardData.length > 0 ? leaderboardData : LEADERBOARD_DATA;
 
+const displayData = user
+  ? baseData
+  : baseData.filter(entry => entry.name !== "You (Current)");
+
+const topThree =
+  displayData.length >= 3
+    ? [displayData[1], displayData[0], displayData[2]]
+    : [];
+
+const restOfList = displayData.slice(3);
+
+const currentUser = user
+  ? displayData.find(u => u.isCurrentUser)
+  : null;
   const getRankStyle = (rank) => {
     switch (rank) {
       case 1:
@@ -343,7 +353,7 @@ export default function LeaderboardsPage() {
         </main>
         
         {/* Sticky Current User Status Bar */}
-        {!loading && currentUser && (
+        {!loading && user && currentUser && (
           <motion.div 
             initial={{ y: 100 }}
             animate={{ y: 0 }}


### PR DESCRIPTION
## Description

Fixes #2122

This PR fixes an issue where unauthenticated users could see a hardcoded **"You (Current)"** leaderboard entry and a current-user leaderboard section even when no user was logged in.

### Changes Made

* Filtered out the fallback **"You (Current)"** entry when no authenticated user is present.
* Prevented rendering of the current-user leaderboard section for unauthenticated users.

## Type of change

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] This change requires a documentation update

## Checklist:

* [x] My code follows the style guidelines of this project
* [x] My changes generate no new warnings
* [x] I have performed a self-review of my own code

