### PR TITLE
fix: replace hardcoded attendance stats with real dashboardData in InstituteDashboard.js

### DIFF
--- a/components/InstituteDashboard.js
+++ b/components/InstituteDashboard.js
@@ -733,28 +733,28 @@ const InstituteDashboard = () => {
       <div className="grid grid-cols-1 md:grid-cols-4 gap-6">
         <StatCard
           title="Present Today"
-          value="1,112"
-          subtitle="89.2% of total"
+          value={dashboardData.todayAttendance?.toLocaleString() ?? "N/A"}
+          subtitle={`${dashboardData.todayAttendance ? ((dashboardData.todayAttendance/dashboardData.totalStudents)*100).toFixed(1) : 0}% of total`}
           icon={CheckCircle}
           color="green"
         />
         <StatCard
           title="Absent Today"
-          value="135"
-          subtitle="10.8% of total"
+          value={dashboardData.totalStudents - dashboardData.todayAttendance || 0}
+          subtitle={`${dashboardData.totalStudents ? (((dashboardData.totalStudents - dashboardData.todayAttendance)/dashboardData.totalStudents)*100).toFixed(1) : 0}% of total`}
           icon={XCircle}
           color="red"
         />
         <StatCard
           title="Late Arrivals"
-          value="23"
-          subtitle="1.8% of total"
+          value={dashboardData.lateArrivals ?? "N/A"}
+          subtitle={dashboardData.lateArrivals ? `${((dashboardData.lateArrivals/dashboardData.totalStudents)*100).toFixed(1)}% of total` : "Data unavailable"}
           icon={Clock}
           color="yellow"
         />
         <StatCard
           title="Pending Requests"
-          value="8"
+          value={dashboardData.pendingRequests ?? 0}
           subtitle="Awaiting approval"
           icon={AlertTriangle}
           color="purple"


### PR DESCRIPTION
Fixes #1971

## Description
Replaced 4 permanently hardcoded attendance stat values in the 
Attendance Overview tab with real data from `dashboardData` which 
was already being fetched from the API but ignored in this section.

## Changes
- "Present Today": `"1,112"` → `dashboardData.todayAttendance`
- "Absent Today": `"135"` → `dashboardData.totalStudents - dashboardData.todayAttendance`
- "Late Arrivals": `"23"` → `dashboardData.lateArrivals ?? "N/A"`
- "Pending Requests": `"8"` → `dashboardData.pendingRequests`
- Subtitles now calculate real percentages dynamically

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] My changes generate no new warnings
- [x] I have performed a self-review of my own code