### PR TITLE
fix: add toast notifications for admin stats fetch failures in AdminDashboard.js

### DIFF
--- a/components/AdminDashboard.js
+++ b/components/AdminDashboard.js
@@ -1,4 +1,5 @@
 "use client";
+import toast from "react-hot-toast";
 import { useEffect } from "react";
 import { useState } from "react";
 import {
@@ -192,10 +193,12 @@ const SuperAdminDashboard = () => {
           if (data.featureUsage) setFeatureUsage(data.featureUsage);
         } else {
           console.error("Failed to fetch admin stats:", res.status);
+          toast.error("Failed to load platform stats. Please refresh.");
         }
       } catch (err) {
         if (err.name === "AbortError") return;
         console.error("Error fetching admin stats:", err);
+        toast.error("Network error loading admin stats.");
       } finally {
         if (isActive) {
           setLoading(false);


### PR DESCRIPTION
Fixes #1966

## Description
Added `toast` import and user-facing error notifications in 
`components/AdminDashboard.js` for both failure cases when 
fetching admin stats — non-OK API response and network errors.
Admins now see a clear toast instead of a silent blank dashboard.

## Changes
- Added `import toast from "react-hot-toast"`
- Added `toast.error()` for non-OK API response (line 194)
- Added `toast.error()` for network/fetch errors (line 199)

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] My changes generate no new warnings
- [x] I have performed a self-review of my own code