### PR TITLE
fix: add id and maxLength to ComplaintForm inputs for accessibility and payload safety

### DIFF
--- a/components/ComplaintForm.jsx
+++ b/components/ComplaintForm.jsx
@@ -66,6 +66,8 @@ export default function ComplaintForm({
 
           <input
             required
+            id="student-name"
+            maxLength={100}
             placeholder="Student Name"
             value={form.student}
             onChange={(e) =>
@@ -76,6 +78,8 @@ export default function ComplaintForm({
 
           <input
             required
+            id="roll-number"
+            maxLength={20}
             placeholder="Roll Number"
             value={form.roll}
             onChange={(e) =>
@@ -86,6 +90,8 @@ export default function ComplaintForm({
 
           <input
             required
+            id="department"
+            maxLength={80}
             placeholder="Department"
             value={form.department}
             onChange={(e) =>
@@ -109,6 +115,8 @@ export default function ComplaintForm({
 
           <input
             required
+            id="complaint-title"
+            maxLength={150}
             placeholder="Complaint Title"
             value={form.title}
             onChange={(e) =>
@@ -132,6 +140,8 @@ export default function ComplaintForm({
           <textarea
             rows={6}
             required
+            id="description"
+            maxLength={1000}
             placeholder="Describe your issue..."
             value={form.description}
             onChange={(e) =>


### PR DESCRIPTION
Fixes #1973

## Description
Added `id` and `maxLength` attributes to all input fields and 
textarea in `components/ComplaintForm.jsx` to improve accessibility 
and prevent oversized payloads being submitted to the server.

## Changes
- `Student Name` → `id="student-name"` + `maxLength={100}`
- `Roll Number` → `id="roll-number"` + `maxLength={20}`
- `Department` → `id="department"` + `maxLength={80}`
- `Complaint Title` → `id="complaint-title"` + `maxLength={150}`
- `Description` → `id="description"` + `maxLength={1000}`

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] My changes generate no new warnings
- [x] I have performed a self-review of my own code