### PR TITLE
fix(notifications): read standardized response envelope

### DIFF
--- a/components/NotificationBell.js
+++ b/components/NotificationBell.js
@@ -5,6 +5,7 @@ import { Bell, X } from "lucide-react";
 import toast from "react-hot-toast";
 import { useAuth } from "@/contexts/AuthContext";
 import { apiFetch } from "@/lib/apiClient";
+import { extractNotificationsFromResponse } from "@/lib/notificationResponse";
 
 // AbortController for fetch requests
 const createAbortController = () => {
@@ -97,7 +98,7 @@ export default function NotificationBell() {
         signal: abortControllerRef.current?.signal
       });
 
-      const fetchedNotifications = Array.isArray(data.notifications) ? data.notifications : [];
+      const fetchedNotifications = extractNotificationsFromResponse(data);
       const currentIds = new Set(
         fetchedNotifications
           .map((notification) => notification._id?.toString?.() || notification._id)

--- a/lib/__tests__/notificationResponse.test.js
+++ b/lib/__tests__/notificationResponse.test.js
@@ -1,0 +1,37 @@
+import { extractNotificationsFromResponse } from "@/lib/notificationResponse";
+
+describe("extractNotificationsFromResponse", () => {
+  test("reads notifications from the standardized API envelope", () => {
+    const notifications = [
+      { _id: "notice-1", message: "Attendance updated", read: false },
+    ];
+
+    expect(
+      extractNotificationsFromResponse({
+        success: true,
+        data: { notifications },
+      }),
+    ).toEqual(notifications);
+  });
+
+  test("keeps the legacy direct notifications fallback", () => {
+    const notifications = [
+      { _id: "notice-2", message: "New notice", read: true },
+    ];
+
+    expect(extractNotificationsFromResponse({ notifications })).toEqual(
+      notifications,
+    );
+  });
+
+  test("returns an empty array for malformed responses", () => {
+    expect(extractNotificationsFromResponse(null)).toEqual([]);
+    expect(extractNotificationsFromResponse({ success: true })).toEqual([]);
+    expect(
+      extractNotificationsFromResponse({
+        success: true,
+        data: { notifications: null },
+      }),
+    ).toEqual([]);
+  });
+});

--- a/lib/__tests__/notificationResponse.test.js
+++ b/lib/__tests__/notificationResponse.test.js
@@ -24,6 +24,20 @@ describe("extractNotificationsFromResponse", () => {
     );
   });
 
+  test("falls back when the standardized envelope is malformed", () => {
+    const notifications = [
+      { _id: "notice-3", message: "Fallback notice", read: false },
+    ];
+
+    expect(
+      extractNotificationsFromResponse({
+        success: true,
+        data: { notifications: {} },
+        notifications,
+      }),
+    ).toEqual(notifications);
+  });
+
   test("returns an empty array for malformed responses", () => {
     expect(extractNotificationsFromResponse(null)).toEqual([]);
     expect(extractNotificationsFromResponse({ success: true })).toEqual([]);

--- a/lib/notificationResponse.js
+++ b/lib/notificationResponse.js
@@ -1,0 +1,6 @@
+export function extractNotificationsFromResponse(response) {
+  const notifications =
+    response?.data?.notifications ?? response?.notifications;
+
+  return Array.isArray(notifications) ? notifications : [];
+}

--- a/lib/notificationResponse.js
+++ b/lib/notificationResponse.js
@@ -1,6 +1,11 @@
 export function extractNotificationsFromResponse(response) {
-  const notifications =
-    response?.data?.notifications ?? response?.notifications;
+  if (Array.isArray(response?.data?.notifications)) {
+    return response.data.notifications;
+  }
 
-  return Array.isArray(notifications) ? notifications : [];
+  if (Array.isArray(response?.notifications)) {
+    return response.notifications;
+  }
+
+  return [];
 }


### PR DESCRIPTION
## Related Issue
Closes #2274

## Description
Fixes the notification bell dropdown so it reads notifications from the standardized API response envelope returned by `/api/notifications`. The API route returns `{ success, data: { notifications } }`, while the UI was only checking `data.notifications`, causing real server notifications to render as an empty list.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (technical debt reduction, code health improvements)
- [ ] Documentation update

## Verification & Testing
1. **Local Test Execution**: `npm run test -- lib/__tests__/notificationResponse.test.js`
2. **Device / Viewport Testing**: Not a layout change; notification rendering logic only.
3. **Accessibility Verification**: No interactive markup or ARIA behavior changed.

## Checklist
- [x] My code follows the style guidelines of this project
- [x] My changes generate no new warnings or console errors in the targeted test
- [x] I have performed a self-review of my own code
- [x] No unrelated files or code changes are included

## Notes
`npm ci` is currently blocked because `package-lock.json` is out of sync with `package.json`, so dependencies were installed with `npm install --package-lock=false --ignore-scripts --no-audit --no-fund` for local targeted verification without lockfile churn.

CI status note: `CI Verify PR / verify` is currently failing in the repository-wide `npm run test` job with existing failures outside this PR, including missing `@/lib/errors`, stale API status expectations, `react-hot-toast` mock default-export errors, and `vi.setTimeout is not a function`. The focused notification response test added by this PR passes locally. Vercel is also blocked by the maintainer authorization gate.
