### PR TITLE
fix(cron): fail closed without cron secret

### DIFF
--- a/app/api/cron/attendance-risk/route.js
+++ b/app/api/cron/attendance-risk/route.js
@@ -1,4 +1,5 @@
 import { jsonError, jsonSuccess } from "@/lib/api-response";
+import { authorizeCronRequest } from "@/lib/cronAuth";
 import { connectDb } from "@/lib/mongodb";
 
 /**
@@ -14,9 +15,9 @@ import { connectDb } from "@/lib/mongodb";
  */
 export const GET = async (request) => {
   // Verify this is called by Vercel Cron (or an authorised internal caller)
-  const authHeader = request.headers.get("authorization");
-  if (authHeader !== `Bearer ${process.env.CRON_SECRET}`) {
-    return jsonError("Unauthorized", 401);
+  const cronAuth = authorizeCronRequest(request);
+  if (!cronAuth.authorized) {
+    return cronAuth.response;
   }
 
   try {

--- a/app/api/cron/attendance-risk/route.test.js
+++ b/app/api/cron/attendance-risk/route.test.js
@@ -1,6 +1,12 @@
 import { GET } from "./route";
 import { connectDb } from "@/lib/mongodb";
 
+vi.mock("@/lib/logger", () => ({
+  logger: {
+    error: vi.fn(),
+  },
+}));
+
 vi.mock("@/lib/mongodb", () => ({
   connectDb: vi.fn(),
 }));
@@ -34,7 +40,7 @@ describe("attendance risk cron authorization", () => {
     await expect(response.json()).resolves.toMatchObject({
       success: false,
       error: {
-        message: "Cron secret is not configured",
+        message: "Internal server error",
       },
     });
   });

--- a/app/api/cron/attendance-risk/route.test.js
+++ b/app/api/cron/attendance-risk/route.test.js
@@ -1,0 +1,41 @@
+import { GET } from "./route";
+import { connectDb } from "@/lib/mongodb";
+
+vi.mock("@/lib/mongodb", () => ({
+  connectDb: vi.fn(),
+}));
+
+function cronRequest(authorization) {
+  return new Request("https://learnova.test/api/cron/attendance-risk", {
+    headers: authorization ? { authorization } : {},
+  });
+}
+
+describe("attendance risk cron authorization", () => {
+  const originalCronSecret = process.env.CRON_SECRET;
+
+  afterEach(() => {
+    vi.clearAllMocks();
+
+    if (originalCronSecret === undefined) {
+      delete process.env.CRON_SECRET;
+    } else {
+      process.env.CRON_SECRET = originalCronSecret;
+    }
+  });
+
+  test("fails closed before connecting to the database when CRON_SECRET is missing", async () => {
+    delete process.env.CRON_SECRET;
+
+    const response = await GET(cronRequest("Bearer undefined"));
+
+    expect(response.status).toBe(500);
+    expect(connectDb).not.toHaveBeenCalled();
+    await expect(response.json()).resolves.toMatchObject({
+      success: false,
+      error: {
+        message: "Cron secret is not configured",
+      },
+    });
+  });
+});

--- a/app/api/cron/attendance-warnings/route.js
+++ b/app/api/cron/attendance-warnings/route.js
@@ -1,4 +1,5 @@
 import { NextResponse } from 'next/server';
+import { authorizeCronRequest } from '@/lib/cronAuth';
 import { connectDb } from '@/lib/mongodb';
 import { evaluateStudentAttendance } from '@/lib/attendanceUtils';
 
@@ -7,9 +8,9 @@ export const dynamic = 'force-dynamic';
 export async function GET(request) {
   try {
     // Basic authorization for cron endpoint
-    const authHeader = request.headers.get('authorization');
-    if (process.env.CRON_SECRET && authHeader !== `Bearer ${process.env.CRON_SECRET}`) {
-      return new NextResponse('Unauthorized', { status: 401 });
+    const cronAuth = authorizeCronRequest(request);
+    if (!cronAuth.authorized) {
+      return cronAuth.response;
     }
 
     const db = await connectDb();

--- a/app/api/cron/attendance-warnings/route.test.js
+++ b/app/api/cron/attendance-warnings/route.test.js
@@ -1,6 +1,12 @@
 import { GET } from "./route";
 import { connectDb } from "@/lib/mongodb";
 
+vi.mock("@/lib/logger", () => ({
+  logger: {
+    error: vi.fn(),
+  },
+}));
+
 vi.mock("@/lib/mongodb", () => ({
   connectDb: vi.fn(),
 }));
@@ -38,7 +44,7 @@ describe("attendance warnings cron authorization", () => {
     await expect(response.json()).resolves.toMatchObject({
       success: false,
       error: {
-        message: "Cron secret is not configured",
+        message: "Internal server error",
       },
     });
   });

--- a/app/api/cron/attendance-warnings/route.test.js
+++ b/app/api/cron/attendance-warnings/route.test.js
@@ -1,0 +1,45 @@
+import { GET } from "./route";
+import { connectDb } from "@/lib/mongodb";
+
+vi.mock("@/lib/mongodb", () => ({
+  connectDb: vi.fn(),
+}));
+
+vi.mock("@/lib/attendanceUtils", () => ({
+  evaluateStudentAttendance: vi.fn(),
+}));
+
+function cronRequest(authorization) {
+  return new Request("https://learnova.test/api/cron/attendance-warnings", {
+    headers: authorization ? { authorization } : {},
+  });
+}
+
+describe("attendance warnings cron authorization", () => {
+  const originalCronSecret = process.env.CRON_SECRET;
+
+  afterEach(() => {
+    vi.clearAllMocks();
+
+    if (originalCronSecret === undefined) {
+      delete process.env.CRON_SECRET;
+    } else {
+      process.env.CRON_SECRET = originalCronSecret;
+    }
+  });
+
+  test("fails closed before connecting to the database when CRON_SECRET is missing", async () => {
+    delete process.env.CRON_SECRET;
+
+    const response = await GET(cronRequest());
+
+    expect(response.status).toBe(500);
+    expect(connectDb).not.toHaveBeenCalled();
+    await expect(response.json()).resolves.toMatchObject({
+      success: false,
+      error: {
+        message: "Cron secret is not configured",
+      },
+    });
+  });
+});

--- a/lib/__tests__/cronAuth.test.js
+++ b/lib/__tests__/cronAuth.test.js
@@ -1,4 +1,11 @@
+import { logger } from "@/lib/logger";
 import { authorizeCronRequest } from "@/lib/cronAuth";
+
+vi.mock("@/lib/logger", () => ({
+  logger: {
+    error: vi.fn(),
+  },
+}));
 
 function cronRequest(authorization) {
   return new Request("https://learnova.test/api/cron/attendance-warnings", {
@@ -14,6 +21,8 @@ describe("authorizeCronRequest", () => {
   const originalCronSecret = process.env.CRON_SECRET;
 
   afterEach(() => {
+    vi.clearAllMocks();
+
     if (originalCronSecret === undefined) {
       delete process.env.CRON_SECRET;
     } else {
@@ -32,9 +41,12 @@ describe("authorizeCronRequest", () => {
       success: false,
       error: {
         code: "HTTP_500",
-        message: "Cron secret is not configured",
+        message: "Internal server error",
       },
     });
+    expect(logger.error).toHaveBeenCalledWith(
+      "[cronAuth] CRON_SECRET is not configured",
+    );
   });
 
   test("fails closed when CRON_SECRET is blank", async () => {
@@ -62,6 +74,19 @@ describe("authorizeCronRequest", () => {
     process.env.CRON_SECRET = "expected-secret";
 
     const result = authorizeCronRequest(cronRequest("Bearer expected-secret"));
+
+    expect(result).toEqual({
+      authorized: true,
+      response: null,
+    });
+  });
+
+  test("parses bearer scheme and surrounding whitespace robustly", () => {
+    process.env.CRON_SECRET = " expected-secret ";
+
+    const result = authorizeCronRequest(
+      cronRequest("  bearer   expected-secret   "),
+    );
 
     expect(result).toEqual({
       authorized: true,

--- a/lib/__tests__/cronAuth.test.js
+++ b/lib/__tests__/cronAuth.test.js
@@ -1,0 +1,71 @@
+import { authorizeCronRequest } from "@/lib/cronAuth";
+
+function cronRequest(authorization) {
+  return new Request("https://learnova.test/api/cron/attendance-warnings", {
+    headers: authorization ? { authorization } : {},
+  });
+}
+
+async function responseBody(response) {
+  return response.json();
+}
+
+describe("authorizeCronRequest", () => {
+  const originalCronSecret = process.env.CRON_SECRET;
+
+  afterEach(() => {
+    if (originalCronSecret === undefined) {
+      delete process.env.CRON_SECRET;
+    } else {
+      process.env.CRON_SECRET = originalCronSecret;
+    }
+  });
+
+  test("fails closed when CRON_SECRET is missing", async () => {
+    delete process.env.CRON_SECRET;
+
+    const result = authorizeCronRequest(cronRequest("Bearer undefined"));
+
+    expect(result.authorized).toBe(false);
+    expect(result.response.status).toBe(500);
+    await expect(responseBody(result.response)).resolves.toMatchObject({
+      success: false,
+      error: {
+        code: "HTTP_500",
+        message: "Cron secret is not configured",
+      },
+    });
+  });
+
+  test("fails closed when CRON_SECRET is blank", async () => {
+    process.env.CRON_SECRET = "   ";
+
+    const result = authorizeCronRequest(cronRequest("Bearer anything"));
+
+    expect(result.authorized).toBe(false);
+    expect(result.response.status).toBe(500);
+  });
+
+  test("rejects missing or incorrect authorization headers", async () => {
+    process.env.CRON_SECRET = "expected-secret";
+
+    const missing = authorizeCronRequest(cronRequest());
+    const wrong = authorizeCronRequest(cronRequest("Bearer wrong-secret"));
+
+    expect(missing.authorized).toBe(false);
+    expect(missing.response.status).toBe(401);
+    expect(wrong.authorized).toBe(false);
+    expect(wrong.response.status).toBe(401);
+  });
+
+  test("authorizes a matching bearer token", () => {
+    process.env.CRON_SECRET = "expected-secret";
+
+    const result = authorizeCronRequest(cronRequest("Bearer expected-secret"));
+
+    expect(result).toEqual({
+      authorized: true,
+      response: null,
+    });
+  });
+});

--- a/lib/cronAuth.js
+++ b/lib/cronAuth.js
@@ -1,34 +1,44 @@
-import { timingSafeEqual } from "crypto";
+import { createHash, timingSafeEqual } from "crypto";
 
 import { jsonError } from "@/lib/api-response";
+import { logger } from "@/lib/logger";
 
-const textEncoder = new TextEncoder();
+function digest(value) {
+  return createHash("sha256").update(value).digest();
+}
 
 function timingSafeStringEqual(actual, expected) {
-  const actualBytes = textEncoder.encode(actual);
-  const expectedBytes = textEncoder.encode(expected);
+  return timingSafeEqual(digest(actual), digest(expected));
+}
 
-  if (actualBytes.byteLength !== expectedBytes.byteLength) {
-    return false;
+function parseBearerToken(authHeader) {
+  if (typeof authHeader !== "string") {
+    return null;
   }
 
-  return timingSafeEqual(actualBytes, expectedBytes);
+  const match = authHeader.trim().match(/^Bearer\s+(.+)$/i);
+  if (!match) {
+    return null;
+  }
+
+  const token = match[1].trim();
+  return token || null;
 }
 
 export function authorizeCronRequest(request, secret = process.env.CRON_SECRET) {
   const configuredSecret = typeof secret === "string" ? secret.trim() : "";
-
   if (!configuredSecret) {
+    logger.error("[cronAuth] CRON_SECRET is not configured");
+
     return {
       authorized: false,
-      response: jsonError("Cron secret is not configured", 500),
+      response: jsonError("Internal server error", 500),
     };
   }
 
-  const authHeader = request.headers.get("authorization") || "";
-  const expectedHeader = `Bearer ${configuredSecret}`;
+  const token = parseBearerToken(request.headers.get("authorization"));
 
-  if (!timingSafeStringEqual(authHeader, expectedHeader)) {
+  if (!token || !timingSafeStringEqual(token, configuredSecret)) {
     return {
       authorized: false,
       response: jsonError("Unauthorized", 401),

--- a/lib/cronAuth.js
+++ b/lib/cronAuth.js
@@ -1,0 +1,42 @@
+import { timingSafeEqual } from "crypto";
+
+import { jsonError } from "@/lib/api-response";
+
+const textEncoder = new TextEncoder();
+
+function timingSafeStringEqual(actual, expected) {
+  const actualBytes = textEncoder.encode(actual);
+  const expectedBytes = textEncoder.encode(expected);
+
+  if (actualBytes.byteLength !== expectedBytes.byteLength) {
+    return false;
+  }
+
+  return timingSafeEqual(actualBytes, expectedBytes);
+}
+
+export function authorizeCronRequest(request, secret = process.env.CRON_SECRET) {
+  const configuredSecret = typeof secret === "string" ? secret.trim() : "";
+
+  if (!configuredSecret) {
+    return {
+      authorized: false,
+      response: jsonError("Cron secret is not configured", 500),
+    };
+  }
+
+  const authHeader = request.headers.get("authorization") || "";
+  const expectedHeader = `Bearer ${configuredSecret}`;
+
+  if (!timingSafeStringEqual(authHeader, expectedHeader)) {
+    return {
+      authorized: false,
+      response: jsonError("Unauthorized", 401),
+    };
+  }
+
+  return {
+    authorized: true,
+    response: null,
+  };
+}


### PR DESCRIPTION
## What
Closes #2284. This hardens the attendance cron endpoints so they fail closed when `CRON_SECRET` is missing or blank instead of running privileged attendance jobs without a valid configured secret.

## How
Added a shared `authorizeCronRequest` helper that validates the cron bearer token against a configured secret, rejects missing configuration with a server error, and rejects missing/incorrect tokens with 401. Wired both attendance cron routes through the helper before any database access.

## Testing
- `npm run test -- lib/__tests__/cronAuth.test.js app/api/cron/attendance-risk/route.test.js app/api/cron/attendance-warnings/route.test.js`
- `git diff --cached --check`

## Risks / Notes
This intentionally changes misconfigured cron deployments from permissive behavior to fail-closed behavior. Deployments must configure `CRON_SECRET` and send `Authorization: Bearer <CRON_SECRET>` for these jobs to execute.

CI status note: `CI Verify PR / verify` is failing in the repository-wide `npm run test` job, but this PR's focused tests pass both locally and in CI (`lib/__tests__/cronAuth.test.js`, `app/api/cron/attendance-warnings/route.test.js`, and `app/api/cron/attendance-risk/route.test.js`). The failing suites are unrelated pre-existing failures, including `components/__tests__/groqRoute.test.js`, `components/__tests__/settingsRoute.test.js`, notification route mocks, attendance/exceptions tests unable to resolve `@/lib/errors`, `react-hot-toast` mock default export errors, and `vi.setTimeout is not a function`. Vercel is also blocked by the maintainer authorization gate.
