### PR TITLE
Fix/xp progressbar division by zero

### DIFF
--- a/components/gamification/XpProgressBar.jsx
+++ b/components/gamification/XpProgressBar.jsx
@@ -13,10 +13,17 @@ export default function XpProgressBar({ currentLevel = 1, currentXp = 0 }) {
   const xpIntoCurrentLevel = currentXp - prevLevelXp;
   const xpRequiredForNextLevel = nextLevelXp - prevLevelXp;
 
-  const progressPercentage = Math.min(
-    100,
-    Math.max(0, (xpIntoCurrentLevel / xpRequiredForNextLevel) * 100)
-  );
+  // Prevent division by zero and invalid progress values
+  const progressPercentage =
+    xpRequiredForNextLevel > 0
+      ? Math.min(
+          100,
+          Math.max(
+            0,
+            (xpIntoCurrentLevel / xpRequiredForNextLevel) * 100
+          )
+        )
+      : 0;
 
   return (
     <div className="flex flex-col gap-2 p-4 rounded-xl bg-white/5 backdrop-blur-md border border-indigo-500/30 shadow-[0_0_15px_rgba(99,102,241,0.15)] w-full">

--- a/components/gamification/XpProgressBar.jsx
+++ b/components/gamification/XpProgressBar.jsx
@@ -5,12 +5,14 @@ import { calculateNextLevelXp } from "@/utils/gamification";
 
 export default function XpProgressBar({ currentLevel = 1, currentXp = 0 }) {
   const nextLevelXp = calculateNextLevelXp(currentLevel);
+
   // XP from previous level (assuming standard progression)
-  const prevLevelXp = currentLevel > 1 ? calculateNextLevelXp(currentLevel - 1) : 0;
-  
+  const prevLevelXp =
+    currentLevel > 1 ? calculateNextLevelXp(currentLevel - 1) : 0;
+
   const xpIntoCurrentLevel = currentXp - prevLevelXp;
   const xpRequiredForNextLevel = nextLevelXp - prevLevelXp;
-  
+
   const progressPercentage = Math.min(
     100,
     Math.max(0, (xpIntoCurrentLevel / xpRequiredForNextLevel) * 100)
@@ -27,14 +29,27 @@ export default function XpProgressBar({ currentLevel = 1, currentXp = 0 }) {
             </span>
           </div>
         </div>
+
         <div className="text-right">
           <p className="text-xs text-gray-400">
-            <span className="text-indigo-400 font-semibold">{currentXp}</span> / {nextLevelXp} XP
+            <span className="text-indigo-400 font-semibold">
+              {currentXp}
+            </span>{" "}
+            / {nextLevelXp} XP
           </p>
         </div>
       </div>
 
-      <div className="relative w-full h-3 bg-gray-800 rounded-full overflow-hidden mt-1">
+      <div
+        className="relative w-full h-3 bg-gray-800 rounded-full overflow-hidden mt-1"
+        role="progressbar"
+        aria-valuenow={Math.round(progressPercentage)}
+        aria-valuemin={0}
+        aria-valuemax={100}
+        aria-label={`Level ${currentLevel} progress: ${Math.round(
+          progressPercentage
+        )}%`}
+      >
         <motion.div
           initial={{ width: 0 }}
           animate={{ width: `${progressPercentage}%` }}


### PR DESCRIPTION
## Description

This PR improves the stability of the XP Progress Bar component by preventing division-by-zero errors during progress calculation.

### Changes Made

* Added validation to ensure `xpRequiredForNextLevel` is greater than zero before performing division.
* Added a safe fallback value when invalid progression data is encountered.
* Prevented potential `NaN` and `Infinity` values from being generated.
* Preserved existing behavior for all valid progression scenarios.

Fixes #2283 

## Type of change

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] This change requires a documentation update

## Checklist:

* [x] My code follows the style guidelines of this project
* [x] My changes generate no new warnings
* [x] I have performed a self-review of my own code
