### PR TITLE
fix: exclude authentication routes from middleware API protection

### DIFF
--- a/middleware.js
+++ b/middleware.js
@@ -38,10 +38,13 @@ const devRateLimitMap = new Map();
 
 const AUTH_RATE_LIMITED_PATHS = [
   "/api/auth/login",
+  "/api/signup",
   "/api/auth/signup",
   "/api/auth/forgot-password",
   "/api/auth/reset-password",
   "/api/auth/verify-otp",
+  "/api/auth/verify-email",
+  "/api/auth/logout",
 ];
 
 function isAuthRoute(pathname) {
@@ -394,7 +397,11 @@ export async function middleware(request) {
   );
 
   // General API route protection (non-dashboard routes under /api/)
-  if (pathname.startsWith("/api/") && pathname !== "/api/check-groq-config") {
+  if (
+    pathname.startsWith("/api/") &&
+    pathname !== "/api/check-groq-config" &&
+    !isAuthRoute(pathname)
+  ) {
     if (!matchedDashboard) {
       if (!isTokenValid) {
         return NextResponse.json({ error: "Unauthorized" }, { status: 401 });

--- a/middleware/__tests__/middleware.test.js
+++ b/middleware/__tests__/middleware.test.js
@@ -32,6 +32,8 @@ describe("Middleware Rate Limiting", () => {
       "/api/auth/forgot-password",
       "/api/auth/reset-password",
       "/api/auth/verify-otp",
+      "/api/auth/verify-email",
+      "/api/auth/logout",
     ];
 
     it("identifies all auth routes correctly", () => {
@@ -46,6 +48,8 @@ describe("Middleware Rate Limiting", () => {
       expect(isAuthRoute("/api/auth/reset-password")).toBe(true);
       expect(isAuthRoute("/api/auth/verify-otp")).toBe(true);
       expect(isAuthRoute("/api/auth/verify-otp/callback")).toBe(true);
+      expect(isAuthRoute("/api/auth/verify-email")).toBe(true);
+      expect(isAuthRoute("/api/auth/logout")).toBe(true);
     });
 
     it("does not match non-auth routes", () => {


### PR DESCRIPTION
## Description
Fixes authentication endpoints (e.g., login, signup, logout, reset-password, verify-email) under `/api/auth/` being incorrectly blocked with a `401 Unauthorized` response by the Next.js middleware's generic API route protection logic.

### Root Cause
The middleware applied token validation globally to all `/api/*` routes. It did not exclude the `/api/auth/*` routes, causing unauthenticated users trying to sign up or log in to get rejected before the request could reach the authentication handlers.

### Fix
- Excluded authentication routes (`isAuthRoute()`) from the generic API route protection block.
- Expanded the `AUTH_RATE_LIMITED_PATHS` array to cover additional public endpoints (`logout` and `verify-email`).
- Added robust unit test assertions in `middleware.test.js` to prevent regressions.

Fixes #2202

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] My changes generate no new warnings
- [x] I have performed a self-review of my own code