### PR TITLE
fix: unwrap attendance API responses

### DIFF
--- a/services/attendanceService.js
+++ b/services/attendanceService.js
@@ -19,6 +19,24 @@ function getTodayKey() {
   return getTodayKeyLocal();
 }
 
+function unwrapApiData(payload) {
+  return payload?.success === true && payload?.data !== undefined
+    ? payload.data
+    : payload;
+}
+
+function getApiErrorMessage(payload, fallback) {
+  if (typeof payload?.error === "string") {
+    return payload.error;
+  }
+
+  if (payload?.error?.message) {
+    return payload.error.message;
+  }
+
+  return payload?.message || fallback;
+}
+
 /**
  * Checks whether a user has already recorded attendance for today.
  */
@@ -124,10 +142,7 @@ export async function recordAttendance({
 
     try {
       const errorData = await response.json();
-
-      if (errorData?.message) {
-        errorMessage = errorData.message;
-      }
+      errorMessage = getApiErrorMessage(errorData, errorMessage);
     } catch {
     // Ignore invalid JSON responses
     }
@@ -135,7 +150,7 @@ export async function recordAttendance({
     throw new Error(errorMessage);
   }
 
-  const data = await response.json();
+  const data = unwrapApiData(await response.json());
   const isAlreadyRecorded = !!(data && data.alreadyRecorded);
 
   const newRate = isAlreadyRecorded ? null : await recalculateAttendanceRate(userId);


### PR DESCRIPTION
## Description

Fixes frontend attendance response parsing. recordAttendance now understands standardized API responses like { success: true, data: ... } and also reads nested error messages from { error: { message } }

Fixes #2130

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [ ] My code follows the style guidelines of this project
- [ ] My changes generate no new warnings
- [ ] I have performed a self-review of my own code
