### PR TITLE
test: cover timeout reset behavior

### DIFF
--- a/hooks/__tests__/useTimer.test.js
+++ b/hooks/__tests__/useTimer.test.js
@@ -1,0 +1,32 @@
+import { renderHook, act } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useTimeout } from "../useTimer";
+
+describe("useTimeout", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("reset clears and restarts the timeout", () => {
+    const callback = vi.fn();
+    const { result } = renderHook(() => useTimeout(callback, 1000));
+
+    act(() => {
+      vi.advanceTimersByTime(700);
+      result.current.reset();
+      vi.advanceTimersByTime(700);
+    });
+
+    expect(callback).not.toHaveBeenCalled();
+
+    act(() => {
+      vi.advanceTimersByTime(300);
+    });
+
+    expect(callback).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Description

Adds a regression test proving useTimeout.reset() restarts the timeout instead of only clearing it.

Fixes #2132

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [ ] My code follows the style guidelines of this project
- [ ] My changes generate no new warnings
- [ ] I have performed a self-review of my own code
