### PR TITLE
fix(backend): resolve null clientPromise export and repair notificati…

### DIFF
--- a/app/api/notifications/route.test.js
+++ b/app/api/notifications/route.test.js
@@ -6,7 +6,6 @@ import { assertApiSuccess } from "../../../testUtils/assertApiSuccess";
 import { assertApiError } from "../../../testUtils/assertApiError";
 
 vi.mock("../../../lib/error-handler", () => {
-  const { AppError } = require("../../../lib/errors");
   return {
     authenticateRequest: vi.fn(),
     withErrorHandler: (handler) => {
@@ -14,10 +13,10 @@ vi.mock("../../../lib/error-handler", () => {
         try {
           return await handler(request, ...args);
         } catch (error) {
-          if (error instanceof AppError) {
+          if (error && (error.statusCode !== undefined || error.name === "AppError")) {
             const payload = error.originalMessage !== undefined ? error.originalMessage : error.message;
             return {
-              status: error.statusCode,
+              status: error.statusCode || 500,
               json: async () => ({ error: payload }),
             };
           }
@@ -36,16 +35,17 @@ vi.mock("../../../lib/rateLimit", () => ({
   checkRateLimit: vi.fn().mockResolvedValue({ allowed: true, remaining: 9 }),
 }));
 
+const mockCursor = {
+  sort: vi.fn().mockReturnThis(),
+  limit: vi.fn().mockReturnThis(),
+  toArray: vi.fn().mockResolvedValue([]),
+};
+const mockCollection = {
+  find: vi.fn(() => mockCursor),
+  updateMany: vi.fn().mockResolvedValue({ modifiedCount: 1 }),
+};
+
 vi.mock("../../../lib/mongodb", () => {
-  const mockCursor = {
-    sort: vi.fn().mockReturnThis(),
-    limit: vi.fn().mockReturnThis(),
-    toArray: vi.fn().mockResolvedValue([]),
-  };
-  const mockCollection = {
-    find: vi.fn(() => mockCursor),
-    updateMany: vi.fn().mockResolvedValue({ modifiedCount: 1 }),
-  };
   const mockDb = {
     collection: vi.fn(() => mockCollection),
   };
@@ -55,8 +55,6 @@ vi.mock("../../../lib/mongodb", () => {
   return {
     __esModule: true,
     default: Promise.resolve(mockClient),
-    _mockCollection: mockCollection,
-    _mockCursor: mockCursor,
   };
 });
 
@@ -70,14 +68,9 @@ vi.mock("next/server", () => ({
 }));
 
 describe("notifications route", () => {
-  let mockCollection;
-  let mockCursor;
-
   beforeEach(() => {
     vi.clearAllMocks();
     checkRateLimit.mockResolvedValue({ allowed: true, remaining: 9 });
-    mockCollection = require("../../../lib/mongodb")._mockCollection;
-    mockCursor = require("../../../lib/mongodb")._mockCursor;
   });
 
   const createMockRequest = (url = "http://localhost/api/notifications", headers = {}) => {
@@ -184,7 +177,7 @@ describe("notifications route", () => {
     });
 
     test("rejects request with 401 if unauthorized", async () => {
-      const { UnauthorizedError } = require("@/lib/errors");
+      const { UnauthorizedError } = require("../../../lib/errors");
       authenticateRequest.mockRejectedValue(new UnauthorizedError("Unauthorized"));
 
       const response = await PATCH(createMockRequest());

--- a/app/api/notifications/seed/route.test.js
+++ b/app/api/notifications/seed/route.test.js
@@ -6,7 +6,6 @@ import { assertApiSuccess } from "../../../../testUtils/assertApiSuccess";
 import { assertApiError } from "../../../../testUtils/assertApiError";
 
 vi.mock("../../../../lib/error-handler", () => {
-  const { AppError } = require("../../../../lib/errors");
   return {
     authenticateRequest: vi.fn(),
     withErrorHandler: (handler) => {
@@ -14,10 +13,10 @@ vi.mock("../../../../lib/error-handler", () => {
         try {
           return await handler(request, ...args);
         } catch (error) {
-          if (error instanceof AppError) {
+          if (error && (error.statusCode !== undefined || error.name === "AppError")) {
             const payload = error.originalMessage !== undefined ? error.originalMessage : error.message;
             return {
-              status: error.statusCode,
+              status: error.statusCode || 500,
               json: async () => ({ error: payload }),
             };
           }
@@ -36,17 +35,16 @@ vi.mock("../../../../lib/rateLimit", () => ({
   checkRateLimit: vi.fn().mockResolvedValue({ allowed: true, remaining: 9 }),
 }));
 
+const mockCollection = {
+  insertMany: vi.fn().mockResolvedValue({ acknowledged: true }),
+};
+
 vi.mock("../../../../lib/mongodb", () => {
-  const mockCollection = {
-    insertMany: vi.fn().mockResolvedValue({ acknowledged: true }),
-  };
   const mockDb = {
     collection: vi.fn(() => mockCollection),
   };
   return {
     connectDb: vi.fn(() => Promise.resolve(mockDb)),
-    _mockCollection: mockCollection,
-    _mockDb: mockDb,
   };
 });
 
@@ -60,12 +58,9 @@ vi.mock("next/server", () => ({
 }));
 
 describe("notifications seed route", () => {
-  let mockCollection;
-
   beforeEach(() => {
     vi.clearAllMocks();
     checkRateLimit.mockResolvedValue({ allowed: true, remaining: 9 });
-    mockCollection = require("../../../../lib/mongodb")._mockCollection;
   });
 
   const createMockRequest = (headers = {}) => {

--- a/lib/mongodb.js
+++ b/lib/mongodb.js
@@ -5,8 +5,7 @@ const options = {
 };
 
 let client;
-let clientPromise = null;
-let clientPromiseThenable = null;
+let mongoClientPromise = null;
 
 const createClientPromise = async () => {
   const uri = process.env.MONGODB_URI;
@@ -22,20 +21,20 @@ const createClientPromise = async () => {
 };
 
 const getClientPromise = () => {
-  if (!clientPromise) {
+  if (!mongoClientPromise) {
     if (process.env.NODE_ENV === "development" && global._mongoClientPromise) {
-      clientPromise = global._mongoClientPromise;
+      mongoClientPromise = global._mongoClientPromise;
     } else {
-      clientPromise = createClientPromise();
+      mongoClientPromise = createClientPromise();
       if (process.env.NODE_ENV === "development") {
-        global._mongoClientPromise = clientPromise;
+        global._mongoClientPromise = mongoClientPromise;
       }
     }
   }
-  return clientPromise;
+  return mongoClientPromise;
 };
 
-clientPromiseThenable = {
+const clientPromise = {
   then(onFulfilled, onRejected) {
     return getClientPromise().then(onFulfilled, onRejected);
   },


### PR DESCRIPTION
### What happened?
The default export `clientPromise` in `lib/mongodb.js` was initialized as `null` but never assigned the actual connection promise before being exported. Any files importing the default export received `null` and crashed at runtime. Additionally, the unit tests had Vitest hoisting and path alias mismatches.

### Changes Made
- Refactored `lib/mongodb.js` using a clean `Thenable` wrapper to enable lazy connection loading while returning a valid resolvable object as the default export.
- Renamed internal cache to `mongoClientPromise` to prevent naming shadowing/collisions.
- Fixed ESM imports and module-scoped mocking variables in `app/api/notifications/route.test.js` and `app/api/notifications/seed/route.test.js` to ensure the route unit tests pass flawlessly.

### Verification
Ran unit tests successfully with 0 failures:
`npx vitest run app/api/notifications/route.test.js app/api/notifications/seed/route.test.js`
