### PR TITLE
fix(attendance): consume parsed dashboard API payloads

### DIFF
--- a/hooks/__tests__/useAttendance.test.js
+++ b/hooks/__tests__/useAttendance.test.js
@@ -1,0 +1,109 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { useAttendance } from "../useAttendance";
+import { apiFetch } from "@/lib/apiClient";
+import { getUserActivities } from "@/services/activityService";
+
+vi.mock("@/lib/apiClient", () => ({
+  apiFetch: vi.fn(),
+}));
+
+vi.mock("@/services/activityService", () => ({
+  getUserActivities: vi.fn(),
+}));
+
+vi.mock("@/lib/firebaseConfig", () => ({
+  db: {},
+}));
+
+vi.mock("firebase/firestore", () => ({
+  collection: vi.fn(),
+  getDocs: vi.fn(),
+  onSnapshot: vi.fn(),
+  query: vi.fn(),
+  where: vi.fn(),
+}));
+
+describe("useAttendance API payload handling", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getUserActivities.mockResolvedValue([]);
+  });
+
+  it("loads student gamification data from apiFetch's parsed success envelope", async () => {
+    const gamificationData = {
+      currentStreak: 5,
+      totalXp: 1200,
+      currentLevel: 4,
+      xpToNextLevel: 1800,
+      unlockedBadges: ["first-attendance"],
+      lastAttendanceDate: "2026-05-31",
+    };
+    const user = {
+      uid: "student-1",
+      getIdToken: vi.fn().mockResolvedValue("student-token"),
+    };
+
+    apiFetch.mockResolvedValueOnce({
+      success: true,
+      data: gamificationData,
+      meta: {},
+    });
+
+    const { result } = renderHook(() =>
+      useAttendance({ role: "student", user })
+    );
+
+    await waitFor(() => {
+      expect(result.current.gamificationData).toEqual(gamificationData);
+    });
+
+    expect(apiFetch).toHaveBeenCalledWith(
+      "/api/student/gamification",
+      expect.objectContaining({
+        headers: { Authorization: "Bearer student-token" },
+        signal: expect.any(Object),
+      })
+    );
+  });
+
+  it("loads institute dashboard data from apiFetch's parsed JSON payload", async () => {
+    const statsPayload = {
+      dashboardData: {
+        totalStudents: 42,
+        totalTeachers: 6,
+        totalClasses: 8,
+        todayAttendance: 87.5,
+        activeClasses: 4,
+        pendingRequests: 3,
+      },
+      classes: [{ id: "class-1", name: "Physics" }],
+      teachers: [{ id: "teacher-1", name: "Ada Lovelace" }],
+      attendanceRequests: [{ id: "request-1", status: "pending" }],
+    };
+    const user = {
+      uid: "institute-1",
+      getIdToken: vi.fn().mockResolvedValue("institute-token"),
+    };
+
+    apiFetch.mockResolvedValueOnce(statsPayload);
+
+    const { result } = renderHook(() =>
+      useAttendance({ role: "institute", user })
+    );
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+      expect(result.current.dashboardData).toEqual(statsPayload.dashboardData);
+    });
+
+    expect(result.current.error).toBeNull();
+    expect(result.current.classes).toEqual(statsPayload.classes);
+    expect(result.current.teachers).toEqual(statsPayload.teachers);
+    expect(result.current.attendanceRequests).toEqual(
+      statsPayload.attendanceRequests
+    );
+    expect(apiFetch).toHaveBeenCalledWith("/api/institute/stats", {
+      headers: { Authorization: "Bearer institute-token" },
+    });
+  });
+});

--- a/hooks/useAttendance.js
+++ b/hooks/useAttendance.js
@@ -13,6 +13,20 @@ import { getTodayKeyLocal } from "@/lib/dateUtils";
 import { getUserActivities } from "@/services/activityService";
 import { apiFetch } from "@/lib/apiClient";
 
+const isRecord = (value) =>
+  value !== null && typeof value === "object" && !Array.isArray(value);
+
+const unwrapApiPayload = (payload) => {
+  if (
+    isRecord(payload) &&
+    payload.success === true &&
+    Object.prototype.hasOwnProperty.call(payload, "data")
+  ) {
+    return payload.data;
+  }
+
+  return payload;
+};
 
 export const useAttendance = ({ role, user }) => {
   const [loading, setLoading] = useState(true);
@@ -71,10 +85,7 @@ export const useAttendance = ({ role, user }) => {
         headers: { Authorization: `Bearer ${token}` },
         signal: controller.signal,
       });
-      if (res.ok) {
-        const data = await res.json();
-        setGamificationData(data);
-      }
+      setGamificationData(unwrapApiPayload(res));
     } catch (err) {
       if (err.name !== "AbortError") {
         console.error("Failed to load gamification data", err);
@@ -140,16 +151,17 @@ export const useAttendance = ({ role, user }) => {
         headers: { Authorization: `Bearer ${token}` },
       });
       if (!mounted) return;
-      if (res.ok) {
-        const data = await res.json();
-        if (data.dashboardData) setDashboardData(data.dashboardData);
-        if (data.classes) setClasses(data.classes);
-        if (data.teachers) setTeachers(data.teachers);
-        if (data.attendanceRequests)
-          setAttendanceRequests(data.attendanceRequests);
-      } else {
-        setError("Failed to fetch institute data. Please try again.");
+      const data = unwrapApiPayload(res);
+
+      if (!isRecord(data)) {
+        throw new Error("Invalid institute stats response");
       }
+
+      if (data.dashboardData) setDashboardData(data.dashboardData);
+      if (data.classes) setClasses(data.classes);
+      if (data.teachers) setTeachers(data.teachers);
+      if (data.attendanceRequests)
+        setAttendanceRequests(data.attendanceRequests);
     } catch (err) {
       if (mounted) {
         setError(


### PR DESCRIPTION
## What
Fixes #2323 by updating `useAttendance` so student gamification and institute dashboard fetches consume the parsed payload returned by `apiFetch()` instead of treating it like a native `Response`.

## How
Added a small payload unwrap helper for Learnova's `{ success, data }` API envelope and removed the incorrect `res.ok` / `res.json()` checks from the attendance hook. Added focused hook tests for both affected dashboard paths.

## Testing
- `npx vitest run hooks/__tests__/useAttendance.test.js`
- `npx vitest run hooks/__tests__/useAttendance.test.js lib/__tests__/apiClient.test.js`
- `git diff --check -- hooks/useAttendance.js hooks/__tests__/useAttendance.test.js`
- `npx eslint hooks/useAttendance.js hooks/__tests__/useAttendance.test.js` currently exits before linting with `TypeError: scopeManager.addGlobals is not a function` from the repo ESLint toolchain.

## Risks / Notes
Low risk and limited to dashboard data loading in `hooks/useAttendance.js`. The persistent local `.github/pull_request_template.md` case-collision change was left unstaged and is not part of this PR.

CI note: `PR Checks` passed and `hooks/__tests__/useAttendance.test.js` passed inside the `verify` job. The full `verify` job is failing on unrelated upstream test debt: 21 failed test files / 59 failed tests, including existing failures in `components/__tests__/exceptionsUpdateRoute.test.js`, `components/__tests__/registerRoute.test.js`, `hooks/__tests__/useOfflineQueue.test.js`, `hooks/__tests__/useSessionMonitor.test.js`, and module-resolution failures such as `Cannot find module '@/lib/errors'`. Vercel is also blocked by the maintainer authorization gate.

Closes #2323
