### PR TITLE
fix: scope SSE notice broadcast by institute to prevent cross-institute data leakage

### DIFF
--- a/app/api/notices/stream/route.js
+++ b/app/api/notices/stream/route.js
@@ -38,25 +38,37 @@ function unregisterConnection(connId) {
   }
 }
 
-// ── Shared Notice Listener Bus ─────────────────────────────────────────────────
+// ── Shared Notice Listener Bus (institute-scoped) ──────────────────────────────
 const noticeListeners = new Map();
 
-function addNoticeListener(userId, cb) {
-  if (!noticeListeners.has(userId)) {
-    noticeListeners.set(userId, new Set());
+function addNoticeListener(instituteId, userId, cb) {
+  const instKey = instituteId || "global";
+  if (!noticeListeners.has(instKey)) {
+    noticeListeners.set(instKey, new Map());
   }
-  noticeListeners.get(userId).add(cb);
+  const userListeners = noticeListeners.get(instKey);
+  if (!userListeners.has(userId)) {
+    userListeners.set(userId, new Set());
+  }
+  userListeners.get(userId).add(cb);
 }
 
-function removeNoticeListener(userId, cb) {
-  const cbs = noticeListeners.get(userId);
+function removeNoticeListener(instituteId, userId, cb) {
+  const instKey = instituteId || "global";
+  const userListeners = noticeListeners.get(instKey);
+  if (!userListeners) return;
+  const cbs = userListeners.get(userId);
   if (!cbs) return;
   cbs.delete(cb);
-  if (cbs.size === 0) noticeListeners.delete(userId);
+  if (cbs.size === 0) userListeners.delete(userId);
+  if (userListeners.size === 0) noticeListeners.delete(instKey);
 }
 
 function broadcastNotice(doc) {
-  for (const [, cbs] of noticeListeners) {
+  const instKey = String(doc.instituteId) || "global";
+  const userListeners = noticeListeners.get(instKey);
+  if (!userListeners) return;
+  for (const [, cbs] of userListeners) {
     for (const cb of cbs) cb(doc);
   }
 }
@@ -201,7 +213,7 @@ export async function GET(request) {
             unregisterConnection(connId);
             connId = null;
           }
-          removeNoticeListener(userId, onNotice);
+          removeNoticeListener(instituteId, userId, onNotice);
           if (noticeListeners.size === 0) {
             stopChangeStream();
             stopPolling();
@@ -259,7 +271,7 @@ export async function GET(request) {
           }
         };
 
-        addNoticeListener(userId, onNotice);
+        addNoticeListener(instituteId, userId, onNotice);
 
         if (!sharedStream) {
           startChangeStream();


### PR DESCRIPTION
## Description

The Server-Sent Events notice stream at /api/notices/stream broadcasts new notices to ALL connected clients regardless of institute membership. While each client-side listener filters by instituteId before rendering, the broadcast function still sends notice data across institute boundaries at the transport level.

**Vulnerability:** A user from Institute A could receive notice data belonging to Institute B if both happen to have SSE connections open simultaneously. The roadcastNotice function iterates over all registered callbacks without scoping to the originating institute.

## Changes Made
- Changed 
oticeListeners from a single-level Map (userId -> Set<callback>) to a two-level Map (instituteId -> userId -> Set<callback>)
- roadcastNotice now only delivers to listeners registered under the matching instituteId
- ddNoticeListener / emoveNoticeListener now accept instituteId as the first parameter

## Related Issue
Closes #2278

## Type of Change
- [ ] Bug fix
- [x] Security improvement
- [ ] New feature
- [ ] Performance improvement

## Testing
1. Connect two SSE streams from different institute accounts
2. Publish a notice to Institute A
3. Verify Institute B's stream does NOT receive the event