### PR TITLE
fix: add Redis response caching to Groq AI API to avoid redundant LLM calls

### DIFF
--- a/app/api/groq/route.js
+++ b/app/api/groq/route.js
@@ -34,7 +34,7 @@ export const POST = withErrorHandler(async (request) => {
 
   try {
     logger.info(`[nova-ai] Making request to Groq API: ${GROQ_API_URL}`);
-    const content = await callGroq(sanitizedMessage);
+    const content = await callGroq(sanitizedMessage, [], decodedToken.uid);
     return jsonSuccess({ message: content });
   } catch (error) {
     logger.error(`[nova-ai] Groq API error: ${error.message}`);

--- a/lib/ai/groq.js
+++ b/lib/ai/groq.js
@@ -1,6 +1,25 @@
 import { z } from "zod";
+import crypto from "crypto";
 import { AppError, ValidationError } from "@/lib/errors";
 import { fetchWithTimeout } from "@/lib/fetch-with-timeout";
+import { Redis } from "@upstash/redis";
+
+function getCacheClient() {
+  const url = process.env.UPSTASH_REDIS_REST_URL;
+  const token = process.env.UPSTASH_REDIS_REST_TOKEN;
+  if (url && token) {
+    return new Redis({ url, token });
+  }
+  return null;
+}
+
+const CACHE_TTL_SECONDS = 3600;
+
+function buildCacheKey(userId, trimmedMessage, messages) {
+  const hist = (messages || []).map(m => `${m.role}:${m.content}`).join("|");
+  const hash = crypto.createHash("md5").update(`${trimmedMessage}||${hist}`).digest("hex");
+  return `groq_cache:${userId}:${hash}`;
+}
 
 export const GROQ_API_URL = "https://api.groq.com/openai/v1/chat/completions";
 const GROQ_SYSTEM_PROMPT = "You are Nova, the friendly AI assistant for Learnova - a Smart Student Engagement Ecosystem.";
@@ -109,7 +128,21 @@ export function extractGroqContent(data) {
   return content.trim() ? content : null;
 }
 
-export async function callGroq(trimmedMessage, messages = []) {
+export async function callGroq(trimmedMessage, messages = [], userId = "anonymous") {
+  const redis = getCacheClient();
+  const cacheKey = buildCacheKey(userId, trimmedMessage, messages);
+
+  if (redis) {
+    try {
+      const cached = await redis.get(cacheKey);
+      if (cached && typeof cached === "string" && cached.trim()) {
+        return cached;
+      }
+    } catch {
+      // cache miss — continue to call API
+    }
+  }
+
   const apiKey = process.env.GROQ_API_KEY;
   if (!apiKey) {
     throw new AppError("Groq API key is not configured", 500);
@@ -140,6 +173,14 @@ export async function callGroq(trimmedMessage, messages = []) {
   const content = extractGroqContent(data);
   if (!content) {
     throw new AppError("AI generated an empty response", 502);
+  }
+
+  if (redis) {
+    try {
+      await redis.set(cacheKey, content, { ex: CACHE_TTL_SECONDS });
+    } catch {
+      // non-blocking: cache write failure is acceptable
+    }
   }
 
   return content;


### PR DESCRIPTION
## Description

Every chat message sent to Nova AI triggers a new Groq API call, even when the user asks an identical question seconds later. This wastes API quota, increases latency (3-5s per call), and inflates costs unnecessarily.

## Changes Made
- Added Redis (Upstash) response caching to callGroq in lib/ai/groq.js
- Cache key: MD5 hash of {userId}||{message}||{conversationHistory}
- TTL: 1 hour (cached responses expire automatically)
- Graceful fallback: if Redis is unavailable, the cache is skipped and the API is called directly
- Non-blocking: cache misses/writes never throw errors that would break the response

## Related Issue
Closes #2279

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [x] Performance improvement

## Testing
1. Send a message to Nova AI - first call hits Groq API (~3-5s)
2. Send the exact same message again - response is instant (from Redis cache)
3. Verify that different users with the same question get separate cached entries (cache key includes userId)