### PR TITLE
fix: scope attendance settings to tenant to prevent global passcode o…

### DIFF
--- a/app/api/attendance/settings/route.js
+++ b/app/api/attendance/settings/route.js
@@ -23,15 +23,35 @@ const postSchema = z.object({
 });
 
 export const GET = withErrorHandler(async (request) => {
-  await requireAuth(request);
+  const decodedToken = await requireAuth(request);
 
   initializeFirebase();
 
+  const { getUserProfile } = await import("@/lib/firebase-admin");
+  const profile = await getUserProfile(decodedToken.uid);
+  if (!profile) {
+    return NextResponse.json(
+      { error: "User profile not found" },
+      { status: 404 }
+    );
+  }
+
+  const { getSettingsDocId } = await import("@/utils/passcodeUtils");
+  const settingsDocId = getSettingsDocId(profile);
+
   const db = admin.firestore();
-  const settingsDoc = await db
+  let settingsDoc = await db
     .collection("attendance_settings")
-    .doc("current_settings")
+    .doc(settingsDocId)
     .get();
+
+  if (!settingsDoc.exists) {
+    // Fallback for existing data
+    settingsDoc = await db
+      .collection("attendance_settings")
+      .doc("current_settings")
+      .get();
+  }
 
   if (!settingsDoc.exists) {
     return NextResponse.json(
@@ -69,10 +89,13 @@ export const POST = withErrorHandler(async (request) => {
   const now = new Date();
   const expiresAt = new Date(now.getTime() + expiresInMinutes * 60 * 1000);
 
+  const { getSettingsDocId } = await import("@/utils/passcodeUtils");
+  const settingsDocId = getSettingsDocId(profile);
+
   const db = admin.firestore();
   await db
     .collection("attendance_settings")
-    .doc("current_settings")
+    .doc(settingsDocId)
     .set(
       {
         passcode: hashPasscode(passcode),
@@ -99,10 +122,13 @@ export const DELETE = withErrorHandler(async (request) => {
   }
   initializeFirebase();
 
+  const { getSettingsDocId } = await import("@/utils/passcodeUtils");
+  const settingsDocId = getSettingsDocId(profile);
+
   const db = admin.firestore();
   await db
     .collection("attendance_settings")
-    .doc("current_settings")
+    .doc(settingsDocId)
     .update({
       active: false,
       passcode: admin.firestore.FieldValue.delete(),

--- a/app/api/attendance/validate-passcode/route.js
+++ b/app/api/attendance/validate-passcode/route.js
@@ -51,11 +51,31 @@ export const POST = withErrorHandler(async (request) => {
   
   const { passcode } = validation.data;
 
+  const { getUserProfile } = await import("@/lib/firebase-admin");
+  const profile = await getUserProfile(decodedToken.uid);
+  if (!profile) {
+    return NextResponse.json(
+      { valid: false, error: "User profile not found." },
+      { status: 404 }
+    );
+  }
+
+  const { getSettingsDocId } = await import("@/utils/passcodeUtils");
+  const settingsDocId = getSettingsDocId(profile);
+
   const db = admin.firestore();
-  const settingsDoc = await db
+  let settingsDoc = await db
     .collection("attendance_settings")
-    .doc("current_settings")
+    .doc(settingsDocId)
     .get();
+
+  if (!settingsDoc.exists) {
+    // Fallback for existing data
+    settingsDoc = await db
+      .collection("attendance_settings")
+      .doc("current_settings")
+      .get();
+  }
 
   if (!settingsDoc.exists) {
     return NextResponse.json(

--- a/utils/passcodeUtils.js
+++ b/utils/passcodeUtils.js
@@ -42,3 +42,15 @@ export function verifyPasscode(passcode, storedHash) {
     return false;
   }
 }
+
+/**
+ * Returns the tenant-scoped document ID for attendance settings.
+ * Logs a warning if the instituteId is missing, falling back to uid.
+ */
+export function getSettingsDocId(profile) {
+  if (!profile.instituteId) {
+    console.warn(`[Attendance Settings] User ${profile.uid} is missing instituteId. Falling back to uid.`);
+    return profile.uid;
+  }
+  return profile.instituteId;
+}


### PR DESCRIPTION
## Description

This PR addresses a critical state contamination issue in the attendance module where passcodes were previously written to a hardcoded global document (`"current_settings"`). In a multi-tenant platform, this caused institutes to constantly overwrite each other's attendance settings. 
The fix scopes attendance passcodes to the specific institute (or teacher) to ensure tenant isolation.

**Changes made:**

- Created a `getSettingsDocId` helper in `utils/passcodeUtils.js` to dynamically generate a tenant-scoped document ID (`profile.instituteId` with a fallback to `profile.uid`), complete with missing field warnings.
- Updated `app/api/attendance/settings/route.js` (GET, POST, DELETE) to manage attendance settings under the scoped document ID instead of a global ID.
- Updated `app/api/attendance/validate-passcode/route.js` to query the active passcode for the respective tenant when validating student attendance.
- Added a fallback query in the GET and validation routes to read from `"current_settings"` if the tenant-scoped document doesn't exist, preventing existing data from becoming orphaned during the transition.


Fixes #2041

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] My changes generate no new warnings
- [x] I have performed a self-review of my own code
