### PR TITLE
fix: prevent agenda card overflow with large task lists

### DIFF
--- a/components/productivity/AgendaListSection.jsx
+++ b/components/productivity/AgendaListSection.jsx
@@ -17,9 +17,9 @@ export function AgendaListSection({
   return (
     <motion.div
       className={`${isDark
-          ? "bg-black/40 border border-white/10 backdrop-blur-xl"
-          : "bg-white/80 border border-slate-200 shadow-xl backdrop-blur-xl"
-        } rounded-3xl p-6 min-h-[472px]`}
+        ? "bg-black/40 border border-white/10 backdrop-blur-xl"
+        : "bg-white/80 border border-slate-200 shadow-xl backdrop-blur-xl"
+      } rounded-3xl p-6 h-[472px] flex flex-col`}
       initial={{ opacity: 0, y: 20 }}
       whileInView={{ opacity: 1, y: 0 }}
       viewport={{ once: true, amount: 0.3 }}
@@ -82,7 +82,7 @@ export function AgendaListSection({
           </button>
         </div>
       </form>
-      <div className="space-y-3">
+      <div className="space-y-3 max-h-[320px] overflow-y-auto pr-2 scrollbar-thin scrollbar-thumb-purple-500/40 scrollbar-track-transparent">
         {agendaForSelectedDate.length === 0 ? (
           <div className={`text-sm ${isDark ? "text-slate-300" : "text-slate-600"}`}>
             No agenda yet. Add a focus item for this day.


### PR DESCRIPTION
## Description

This PR fixes a layout issue in the Productivity Dashboard where the Agenda card continuously expanded as more agenda items were added.

Previously, adding multiple agenda items caused the Agenda section to grow indefinitely, pushing the Academic Eligibility and Daily Summary cards downward and creating an unbalanced dashboard layout.

### Changes Made

* Replaced the Agenda card's flexible height behavior with a fixed-height layout.
* Converted the agenda items area into a scrollable container.
* Preserved the original dashboard card dimensions regardless of the number of agenda items.
* Improved overall dashboard consistency and usability.

### Before

* Agenda card height increased with every new agenda item.
* Right-side dashboard sections were pushed downward.
* Dashboard columns became visually misaligned.

### After

* Agenda card maintains a consistent height.
* Agenda items become scrollable when content exceeds the available space.
* Academic Eligibility and Daily Summary remain in their intended positions.
* Dashboard layout stays balanced.

### Visual Demo

**Before**

<img width="781" height="877" alt="Screenshot 2026-05-31 154428" src="https://github.com/user-attachments/assets/45cda1e5-eb71-44d4-9ca9-5ce478c1799e" />

**After**

https://github.com/user-attachments/assets/16731501-d080-444e-84e4-1ea2e8381ff4

## Related issue
Fixes #2311 

## Type of change

* [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

* [x] My code follows the style guidelines of this project
* [x] My changes generate no new warnings
* [x] I have performed a self-review of my own code