### PR TITLE
fix: change rate limiter fail-open to fail-closed with in-memory fallback

### DIFF
--- a/lib/rateLimit.js
+++ b/lib/rateLimit.js
@@ -25,6 +25,42 @@ async function ensureIndexes(collection) {
   indexEnsured = true;
 }
 
+// ─── In-memory fallback rate limiter ──────────────────────────────────────────
+// Used when both MongoDB and Upstash Redis are unreachable.
+// Has a STRICTER limit (3 requests/min instead of 10) to compensate for the
+// lack of a shared store and to minimize abuse during an outage.
+const IN_MEMORY_FALLBACK_WINDOW_MS = 60 * 1000;
+const IN_MEMORY_FALLBACK_MAX = 3;
+const fallbackMap = new Map();
+
+function checkInMemoryFallback(userId) {
+  const now = Date.now();
+  const key = `fallback:${userId}`;
+  const entry = fallbackMap.get(key);
+
+  if (!entry || now > entry.resetTime) {
+    fallbackMap.set(key, { count: 1, resetTime: now + IN_MEMORY_FALLBACK_WINDOW_MS });
+    return { allowed: true, remaining: IN_MEMORY_FALLBACK_MAX - 1 };
+  }
+
+  if (entry.count >= IN_MEMORY_FALLBACK_MAX) {
+    return { allowed: false, remaining: 0 };
+  }
+
+  entry.count += 1;
+  return { allowed: true, remaining: IN_MEMORY_FALLBACK_MAX - entry.count };
+}
+
+// Periodically evict stale entries from the fallback map to prevent memory leaks
+setInterval(() => {
+  const now = Date.now();
+  for (const [key, entry] of fallbackMap.entries()) {
+    if (now > entry.resetTime) {
+      fallbackMap.delete(key);
+    }
+  }
+}, 60 * 1000).unref();
+
 export async function checkRateLimit(userId) {
   try {
     const db = await connectDb();
@@ -75,10 +111,11 @@ export async function checkRateLimit(userId) {
     if (!hasRedis) {
       const errMsg = err instanceof Error ? err.message : String(err);
       console.error(
-        "[rate-limit] MongoDB failed and no Upstash Redis configured — granting pass:",
+        "[rate-limit] MongoDB failed and no Upstash Redis configured — falling back to in-memory limiter:",
         errMsg
       );
-      return { allowed: true, remaining: MAX_REQUESTS_PER_WINDOW - 1 };
+      // Fall back to an in-memory limiter with a stricter bound when both stores are down
+      return checkInMemoryFallback(userId);
     }
 
     try {
@@ -102,10 +139,10 @@ export async function checkRateLimit(userId) {
       return { allowed: true, remaining: MAX_REQUESTS_PER_WINDOW - current };
     } catch (redisErr) {
       console.error(
-        "[rate-limit] Both MongoDB and Upstash Redis failed — granting pass:",
+        "[rate-limit] Both MongoDB and Upstash Redis failed — falling back to in-memory limiter:",
         redisErr
       );
-      return { allowed: true, remaining: MAX_REQUESTS_PER_WINDOW - 1 };
+      return checkInMemoryFallback(userId);
     }
   }
 }

--- a/middleware.js
+++ b/middleware.js
@@ -83,8 +83,8 @@ async function rateLimit(ip, pathname, request) {
 
       return { allowed: true, remaining: limit - current };
     } catch (err) {
-      console.error("[rate-limit] Upstash Redis error, granting pass:", err);
-      return { allowed: true, remaining: limit - 1 };
+      console.error("[rate-limit] Upstash Redis error — denying request:", err);
+      return { allowed: false, remaining: 0, retryAfter: Math.ceil(windowMs / 1000) };
     }
   }
 


### PR DESCRIPTION
## Description
This PR fixes the rate limiter fail-open vulnerability where both rate limiting implementations granted unlimited access when their backing stores were unreachable.

## Problem
Both rate limiting implementations granted unlimited access when their backing stores were unreachable:

1. **Middleware rate limiter** (middleware.js): When Upstash Redis threw an error, it returned `{ allowed: true, remaining: limit - 1 }`, effectively granting a free pass during infrastructure outages.

2. **Server-side rate limiter** (lib/rateLimit.js): When MongoDB failed and no Redis was configured, it returned `{ allowed: true, remaining: MAX_REQUESTS_PER_WINDOW - 1 }`.

3. **Server-side Redis fallback**: When both MongoDB and Redis failed, it also returned a pass.

Attack scenario: an attacker who can exhaust Redis connections or trigger a credentials expiration bypasses all rate limits.

## Fix
- **middleware.js**: Changed Redis error catch to return `{ allowed: false }` with retryAfter header, denying requests when the rate limit store is unavailable.

- **lib/rateLimit.js**: Added `checkInMemoryFallback()` using a STRICTER in-memory limiter (3 req/min vs normal 10) when both stores are down, with periodic cleanup via setInterval to prevent memory leaks.

All fail-open 'granting pass' paths replaced with fail-closed or strict in-memory fallback behavior.

Closes #2372