### PR TITLE
fix: add ordering and limit to notices query to prevent unbounded reads

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   push:
     branches: [main, master]
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/contexts/FirestoreContext.js
+++ b/contexts/FirestoreContext.js
@@ -102,7 +102,9 @@ export function FirestoreProvider({ children }) {
       return query(
         collection(db, "notices"),
         where("targetAudience", "array-contains", userRole),
-        where("instituteId", "==", instituteId)
+        where("instituteId", "==", instituteId),
+        orderBy("createdAt", "desc"),
+        limit(100)
       );
     } catch {
       return null;


### PR DESCRIPTION
## Description
This PR adds ordering and limit to the notices Firestore query to prevent unbounded reads.

## Problem
The notices Firestore query had no orderBy or limit clause. As notices accumulate over time, every query fetches ALL documents matching the filter, leading to unbounded read costs, increasing latency, and potential timeouts.

## Fix
- Added orderBy('createdAt', 'desc') so newest notices appear first
- Added limit(100) to cap at 100 notices maximum

## Additional Fixes
- Fixed pre-existing upstream conflict markers in app/api/groq/route.js
- Fixed duplicate skillPath declaration in components/StudentDashboard.js
- Added FORCE_JAVASCRIPT_ACTIONS_TO_NODE24 to ci.yml for Node 20 deprecation

Closes #2373