### PR TITLE
[SECURITY] Add centralized, stronger authorization checks in API routes

### DIFF
--- a/app/api/activities/route.js
+++ b/app/api/activities/route.js
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import { jsonError, jsonSuccess } from "@/lib/api-response";
-import { withErrorHandler, authenticateRequest, parseJSON } from "@/lib/error-handler";
+import { withErrorHandler, parseJSON } from "@/lib/error-handler";
+import { requireAuth } from "@/lib/rbac";
 import { initFirebaseAdmin } from "@/lib/firebase-admin";
 import { getFirestore, FieldValue } from "firebase-admin/firestore";
 import { checkRateLimit } from "@/lib/rateLimit";
@@ -27,7 +28,7 @@ const activitySchema = z.object({
 });
 
 export const GET = withErrorHandler(async (request) => {
-  const decodedToken = await authenticateRequest(request);
+  const decodedToken = await requireAuth(request);
   initFirebaseAdmin();
   const db = getFirestore();
 
@@ -47,7 +48,7 @@ export const GET = withErrorHandler(async (request) => {
 });
 
 export const POST = withErrorHandler(async (request) => {
-  const decodedToken = await authenticateRequest(request);
+  const decodedToken = await requireAuth(request);
 
   const limited = await checkRateLimit(decodedToken.uid);
   if (!limited.allowed) {
@@ -79,7 +80,7 @@ export const POST = withErrorHandler(async (request) => {
 });
 
 export const DELETE = withErrorHandler(async (request) => {
-  const decodedToken = await authenticateRequest(request);
+  const decodedToken = await requireAuth(request);
   const { searchParams } = new URL(request.url);
   const activityId = searchParams.get("id");
 

--- a/app/api/analytics/attendance-risk/route.js
+++ b/app/api/analytics/attendance-risk/route.js
@@ -1,5 +1,6 @@
 import { jsonError, jsonSuccess } from "@/lib/api-response";
-import { withErrorHandler, authenticateRequest } from "@/lib/error-handler";
+import { withErrorHandler } from "@/lib/error-handler";
+import { requireRole } from "@/lib/rbac";
 import { connectDb } from "@/lib/mongodb";
 
 /**
@@ -18,25 +19,16 @@ import { connectDb } from "@/lib/mongodb";
  *  - good     : attendanceRate >= 80
  */
 export const GET = withErrorHandler(async (request) => {
-  const decodedToken = await authenticateRequest(request);
+  const { payload: decodedToken, profile } = await requireRole(request, ["teacher", "institute", "admin"]);
 
   const db = await connectDb();
 
-  // Fetch the caller's profile to get their instituteId / role
-  const userDoc = await db
-    .collection("users")
-    .findOne({ uid: decodedToken.uid });
-
-  if (!userDoc) {
+  // Use the Firestore profile returned by the shared RBAC helper.
+  if (!profile) {
     return jsonError("User not found", 404);
   }
 
-  const allowedRoles = ["teacher", "institute", "admin"];
-  if (!allowedRoles.includes(userDoc.role)) {
-    return jsonError("Forbidden: insufficient role", 403);
-  }
-
-  const instituteId = userDoc.instituteId || userDoc.uid;
+  const instituteId = profile.instituteId || profile.uid;
 
   // Two-week window dates
   const now = new Date();

--- a/app/api/attendance/heatmap/route.js
+++ b/app/api/attendance/heatmap/route.js
@@ -1,13 +1,14 @@
-import { withErrorHandler, authenticateRequest } from "@/lib/error-handler";
+import { withErrorHandler } from "@/lib/error-handler";
 import { ForbiddenError } from "@/lib/errors";
 import { getFirestore } from "firebase-admin/firestore";
 import { initFirebaseAdmin } from "@/lib/firebase-admin";
 import { checkRateLimit } from "@/lib/rateLimit";
+import { requireAuth } from "@/lib/rbac";
 import { fail, success } from "@/lib/api-response";
 
 export const GET = withErrorHandler(async (request) => {
   initFirebaseAdmin();
-  const decodedToken = await authenticateRequest(request);
+  const decodedToken = await requireAuth(request);
 
   const { searchParams } = new URL(request.url);
   const userId = searchParams.get("userId");

--- a/app/api/attendance/heatmap/route.test.js
+++ b/app/api/attendance/heatmap/route.test.js
@@ -1,10 +1,13 @@
 import { GET } from "./route";
-import { authenticateRequest } from "@/lib/error-handler";
+import { requireAuth } from "@/lib/rbac";
 import { getFirestore } from "firebase-admin/firestore";
 
 vi.mock("@/lib/error-handler", () => ({
-  authenticateRequest: vi.fn(),
   withErrorHandler: (handler) => handler,
+}));
+
+vi.mock("@/lib/rbac", () => ({
+  requireAuth: vi.fn(),
 }));
 
 vi.mock("@/lib/rateLimit", () => ({
@@ -34,7 +37,7 @@ describe("attendance heatmap route", () => {
   });
 
   test("returns empty array if userId or month parameter is missing", async () => {
-    authenticateRequest.mockResolvedValue({ uid: "user-123" });
+    requireAuth.mockResolvedValue({ uid: "user-123" });
 
     const request = {
       url: "http://localhost:3000/api/attendance/heatmap?userId=user-123",
@@ -48,7 +51,7 @@ describe("attendance heatmap route", () => {
   });
 
   test("rejects query with 403 Forbidden if uid does not match authenticated user", async () => {
-    authenticateRequest.mockResolvedValue({ uid: "user-123" });
+    requireAuth.mockResolvedValue({ uid: "user-123" });
 
     const request = {
       url: "http://localhost:3000/api/attendance/heatmap?userId=user-456&month=2026-05",
@@ -59,7 +62,7 @@ describe("attendance heatmap route", () => {
   });
 
   test("correctly fetches attendance records from Firestore with date range filter", async () => {
-    authenticateRequest.mockResolvedValue({ uid: "user-123" });
+    requireAuth.mockResolvedValue({ uid: "user-123" });
 
     const mockDocs = [
       {

--- a/app/api/attendance/record/route.js
+++ b/app/api/attendance/record/route.js
@@ -1,5 +1,6 @@
 import { jsonError, jsonSuccess } from "@/lib/api-response";
-import { withErrorHandler, authenticateRequest, parseJSON } from "@/lib/error-handler";
+import { withErrorHandler, parseJSON } from "@/lib/error-handler";
+import { requireAuth } from "@/lib/rbac";
 import { initFirebaseAdmin, getUserProfile } from "@/lib/firebase-admin";
 import { getFirestore, FieldValue } from "firebase-admin/firestore";
 import { awardXp } from "@/lib/gamification-service";
@@ -9,7 +10,7 @@ import { AppError } from "@/lib/errors";
 import { executeSaga } from "@/lib/transactionCoordinator";
 
 export const POST = withErrorHandler(async (request) => {
-  const decodedToken = await authenticateRequest(request);
+  const decodedToken = await requireAuth(request);
 
   const ip = request.headers.get("x-forwarded-for") || "127.0.0.1";
   const rateLimitResult = await checkRateLimit(`attendance_record_${ip}_${decodedToken.uid}`);

--- a/app/api/attendance/record/route.test.js
+++ b/app/api/attendance/record/route.test.js
@@ -1,5 +1,5 @@
 import { POST } from "./route";
-import { authenticateRequest, parseJSON } from "@/lib/error-handler";
+import { parseJSON } from "@/lib/error-handler";
 import { getUserProfile } from "@/lib/firebase-admin";
 import { getFirestore, FieldValue } from "firebase-admin/firestore";
 import { checkRateLimit } from "@/lib/rateLimit";
@@ -7,24 +7,16 @@ import { assertApiSuccess } from "@/testUtils/assertApiSuccess";
 import { assertApiError } from "@/testUtils/assertApiError";
 
 vi.mock("@/lib/error-handler", () => {
-  const { AppError } = require("@/lib/errors");
   return {
-    authenticateRequest: vi.fn(),
     withErrorHandler: (handler) => {
       return async (request, ...args) => {
         try {
           return await handler(request, ...args);
         } catch (error) {
-          if (error instanceof AppError) {
-            const payload = error.originalMessage !== undefined ? error.originalMessage : error.message;
-            return {
-              status: error.statusCode,
-              json: async () => ({ error: payload }),
-            };
-          }
+          const payload = error.originalMessage !== undefined ? error.originalMessage : error.message;
           return {
-            status: 500,
-            json: async () => ({ error: error.message || "Internal server error" }),
+            status: error.statusCode ?? 500,
+            json: async () => ({ error: payload || error.message || "Internal server error" }),
           };
         }
       };
@@ -32,6 +24,10 @@ vi.mock("@/lib/error-handler", () => {
     parseJSON: vi.fn(),
   };
 });
+
+vi.mock("@/lib/rbac", () => ({
+  requireAuth: vi.fn(),
+}));
 
 vi.mock("@/lib/rateLimit", () => ({
   checkRateLimit: vi.fn().mockResolvedValue({ allowed: true, remaining: 9 }),
@@ -91,7 +87,8 @@ describe("attendance record route", () => {
   };
 
   test("writes attendance to Firestore with canonical doc id + instituteId using transaction", async () => {
-    authenticateRequest.mockResolvedValue({ uid: "user-123" });
+    const { requireAuth } = await import("@/lib/rbac");
+    requireAuth.mockResolvedValue({ uid: "user-123" });
     parseJSON.mockResolvedValue({
       userId: "user-123",
       studentName: "Client Name",
@@ -143,7 +140,8 @@ describe("attendance record route", () => {
   });
 
   test("prevents duplicate check-in if document already exists", async () => {
-    authenticateRequest.mockResolvedValue({ uid: "user-123" });
+    const { requireAuth } = await import("@/lib/rbac");
+    requireAuth.mockResolvedValue({ uid: "user-123" });
     parseJSON.mockResolvedValue({
       userId: "user-123",
       studentName: "Client Name",
@@ -181,15 +179,20 @@ describe("attendance record route", () => {
   });
 
   test("rejects request if unauthorized", async () => {
-    const { UnauthorizedError } = require("@/lib/errors");
-    authenticateRequest.mockRejectedValue(new UnauthorizedError("Unauthorized"));
+    const { requireAuth } = await import("@/lib/rbac");
+    requireAuth.mockRejectedValue({
+      statusCode: 401,
+      message: "Unauthorized",
+      originalMessage: "Unauthorized",
+    });
 
     const response = await POST(createMockRequest());
     await assertApiError(response, 401, "Unauthorized");
   });
 
   test("rejects request with 403 Forbidden if attempting to submit for another user", async () => {
-    authenticateRequest.mockResolvedValue({ uid: "user-123" });
+    const { requireAuth } = await import("@/lib/rbac");
+    requireAuth.mockResolvedValue({ uid: "user-123" });
     parseJSON.mockResolvedValue({
       userId: "another-user-456",
       studentName: "Client Name",
@@ -203,7 +206,8 @@ describe("attendance record route", () => {
   });
 
   test("rejects request with 400 Bad Request if confidence score is invalid or below threshold", async () => {
-    authenticateRequest.mockResolvedValue({ uid: "user-123" });
+    const { requireAuth } = await import("@/lib/rbac");
+    requireAuth.mockResolvedValue({ uid: "user-123" });
 
     // Scenario 1: below 60
     parseJSON.mockResolvedValue({
@@ -231,7 +235,8 @@ describe("attendance record route", () => {
   });
 
   test("rejects request if rate limit exceeded", async () => {
-    authenticateRequest.mockResolvedValue({ uid: "user-123" });
+    const { requireAuth } = await import("@/lib/rbac");
+    requireAuth.mockResolvedValue({ uid: "user-123" });
     checkRateLimit.mockResolvedValue({ allowed: false });
 
     const response = await POST(createMockRequest());
@@ -239,7 +244,8 @@ describe("attendance record route", () => {
   });
 
   test("simulates concurrent double-click requests and guarantees single write via OCC retry simulation", async () => {
-    authenticateRequest.mockResolvedValue({ uid: "user-123" });
+    const { requireAuth } = await import("@/lib/rbac");
+    requireAuth.mockResolvedValue({ uid: "user-123" });
     parseJSON.mockResolvedValue({
       userId: "user-123",
       studentName: "Client Name",

--- a/app/api/auth/cleanup/__tests__/route.test.js
+++ b/app/api/auth/cleanup/__tests__/route.test.js
@@ -52,10 +52,13 @@ vi.mock("@/lib/error-handler", async () => {
         }
       };
     },
-    authenticateRequest: vi.fn(),
     parseJSON: vi.fn(),
   };
 });
+
+vi.mock("@/lib/rbac", () => ({
+  requireAuth: vi.fn(),
+}));
 
 describe("POST /api/auth/cleanup", () => {
   beforeEach(() => {
@@ -63,10 +66,10 @@ describe("POST /api/auth/cleanup", () => {
   });
 
   it("rejects unauthenticated requests with 401", async () => {
-    const { authenticateRequest } = await import("@/lib/error-handler");
+    const { requireAuth } = await import("@/lib/rbac");
     const { UnauthorizedError } = await import("@/lib/errors");
 
-    authenticateRequest.mockRejectedValue(new UnauthorizedError("Unauthorized"));
+    requireAuth.mockRejectedValue(new UnauthorizedError("Unauthorized"));
 
     const request = {
       headers: {
@@ -82,9 +85,10 @@ describe("POST /api/auth/cleanup", () => {
   });
 
   it("rejects requests where authenticated user tries to delete another user's account", async () => {
-    const { authenticateRequest, parseJSON } = await import("@/lib/error-handler");
+    const { requireAuth } = await import("@/lib/rbac");
+    const { parseJSON } = await import("@/lib/error-handler");
 
-    authenticateRequest.mockResolvedValue({ uid: "user-123", email: "a@test.com" });
+    requireAuth.mockResolvedValue({ uid: "user-123", email: "a@test.com" });
     parseJSON.mockResolvedValue({ uid: "user-456" });
 
     const request = {
@@ -101,10 +105,11 @@ describe("POST /api/auth/cleanup", () => {
   });
 
   it("allows authenticated user to delete their own orphaned account", async () => {
-    const { authenticateRequest, parseJSON } = await import("@/lib/error-handler");
+    const { requireAuth } = await import("@/lib/rbac");
+    const { parseJSON } = await import("@/lib/error-handler");
     const { initializeFirebase } = await import("@/lib/firebase-admin");
 
-    authenticateRequest.mockResolvedValue({ uid: "user-123", email: "a@test.com" });
+    requireAuth.mockResolvedValue({ uid: "user-123", email: "a@test.com" });
     parseJSON.mockResolvedValue({ uid: "user-123" });
     mockDeleteUser.mockResolvedValue();
 
@@ -124,9 +129,10 @@ describe("POST /api/auth/cleanup", () => {
   });
 
   it("returns 400 for missing UID", async () => {
-    const { authenticateRequest, parseJSON } = await import("@/lib/error-handler");
+    const { requireAuth } = await import("@/lib/rbac");
+    const { parseJSON } = await import("@/lib/error-handler");
 
-    authenticateRequest.mockResolvedValue({ uid: "user-123", email: "a@test.com" });
+    requireAuth.mockResolvedValue({ uid: "user-123", email: "a@test.com" });
     parseJSON.mockResolvedValue({});
 
     const request = {
@@ -143,9 +149,10 @@ describe("POST /api/auth/cleanup", () => {
   });
 
   it("returns 400 for non-string UID", async () => {
-    const { authenticateRequest, parseJSON } = await import("@/lib/error-handler");
+    const { requireAuth } = await import("@/lib/rbac");
+    const { parseJSON } = await import("@/lib/error-handler");
 
-    authenticateRequest.mockResolvedValue({ uid: "user-123", email: "a@test.com" });
+    requireAuth.mockResolvedValue({ uid: "user-123", email: "a@test.com" });
     parseJSON.mockResolvedValue({ uid: 12345 });
 
     const request = {
@@ -162,9 +169,10 @@ describe("POST /api/auth/cleanup", () => {
   });
 
   it("returns success when user was already deleted", async () => {
-    const { authenticateRequest, parseJSON } = await import("@/lib/error-handler");
+    const { requireAuth } = await import("@/lib/rbac");
+    const { parseJSON } = await import("@/lib/error-handler");
 
-    authenticateRequest.mockResolvedValue({ uid: "user-123", email: "a@test.com" });
+    requireAuth.mockResolvedValue({ uid: "user-123", email: "a@test.com" });
     parseJSON.mockResolvedValue({ uid: "user-123" });
 
     const notFoundError = new Error("User not found");
@@ -185,9 +193,10 @@ describe("POST /api/auth/cleanup", () => {
   });
 
   it("returns 500 on unexpected Firebase errors", async () => {
-    const { authenticateRequest, parseJSON } = await import("@/lib/error-handler");
+    const { requireAuth } = await import("@/lib/rbac");
+    const { parseJSON } = await import("@/lib/error-handler");
 
-    authenticateRequest.mockResolvedValue({ uid: "user-123", email: "a@test.com" });
+    requireAuth.mockResolvedValue({ uid: "user-123", email: "a@test.com" });
     parseJSON.mockResolvedValue({ uid: "user-123" });
     mockDeleteUser.mockRejectedValue(new Error("internal firebase error"));
 

--- a/app/api/auth/cleanup/route.js
+++ b/app/api/auth/cleanup/route.js
@@ -1,5 +1,6 @@
 import { jsonSuccess, jsonError } from "@/lib/api-response";
-import { withErrorHandler, authenticateRequest, parseJSON } from "@/lib/error-handler";
+import { withErrorHandler, parseJSON } from "@/lib/error-handler";
+import { requireAuth } from "@/lib/rbac";
 import { initializeFirebase } from "@/lib/firebase-admin";
 import admin from "firebase-admin";
 import { logger } from "@/lib/logger";
@@ -18,7 +19,7 @@ export const runtime = "nodejs";
  */
 export const POST = withErrorHandler(async (request) => {
   // 1. Authenticate request via Firebase token first to prevent unauthenticated/arbitrary deletion
-  const decodedToken = await authenticateRequest(request);
+  const decodedToken = await requireAuth(request);
 
   // 2. Parse request body securely with maxBytes limitation (1KB) to prevent DoS
   const body = await parseJSON(request, 1024);

--- a/app/api/auth/me/__tests__/route.test.js
+++ b/app/api/auth/me/__tests__/route.test.js
@@ -3,7 +3,10 @@ import { GET } from "@/app/api/auth/me/route";
 
 vi.mock("@/lib/error-handler", () => ({
   withErrorHandler: (fn) => fn,
-  authenticateRequest: vi.fn(),
+}));
+
+vi.mock("@/lib/rbac", () => ({
+  requireAuth: vi.fn(),
 }));
 
 vi.mock("@/lib/firebase-admin", () => ({
@@ -29,10 +32,10 @@ describe("GET /api/auth/me", () => {
   });
 
   it("returns user info with role from Firestore", async () => {
-    const { authenticateRequest } = await import("@/lib/error-handler");
+    const { requireAuth } = await import("@/lib/rbac");
     const { getUserProfile } = await import("@/lib/firebase-admin");
 
-    authenticateRequest.mockResolvedValue({
+    requireAuth.mockResolvedValue({
       uid: "user-123",
       email: "test@example.com",
       email_verified: true,
@@ -61,10 +64,10 @@ describe("GET /api/auth/me", () => {
   });
 
   it("returns rolesInSync: true when roles match", async () => {
-    const { authenticateRequest } = await import("@/lib/error-handler");
+    const { requireAuth } = await import("@/lib/rbac");
     const { getUserProfile } = await import("@/lib/firebase-admin");
 
-    authenticateRequest.mockResolvedValue({
+    requireAuth.mockResolvedValue({
       uid: "user-456",
       email: "sync@example.com",
       email_verified: true,
@@ -90,10 +93,10 @@ describe("GET /api/auth/me", () => {
   });
 
   it("handles missing Firestore profile gracefully", async () => {
-    const { authenticateRequest } = await import("@/lib/error-handler");
+    const { requireAuth } = await import("@/lib/rbac");
     const { getUserProfile } = await import("@/lib/firebase-admin");
 
-    authenticateRequest.mockResolvedValue({
+    requireAuth.mockResolvedValue({
       uid: "user-789",
       email: "nofirestore@example.com",
       email_verified: false,

--- a/app/api/auth/me/route.js
+++ b/app/api/auth/me/route.js
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
-import { withErrorHandler, authenticateRequest } from "@/lib/error-handler";
+import { withErrorHandler } from "@/lib/error-handler";
+import { requireAuth } from "@/lib/rbac";
 import { getUserProfile } from "@/lib/firebase-admin";
 import { checkRateLimit } from "@/lib/rateLimit";
 import { AppError } from "@/lib/errors";
@@ -18,7 +19,7 @@ export const dynamic = "force-dynamic";
  * custom claims can be stale for up to 1 hour after a role change.
  */
 export const GET = withErrorHandler(async (request) => {
-  const decodedToken = await authenticateRequest(request);
+  const decodedToken = await requireAuth(request);
   const ip = request.headers.get("x-forwarded-for") || "127.0.0.1";
   const rateLimitResult = await checkRateLimit(`auth_me_${ip}_${decodedToken.uid}`);
   if (!rateLimitResult.allowed) {

--- a/app/api/auth/session/route.js
+++ b/app/api/auth/session/route.js
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
-import { authenticateRequest, withErrorHandler } from "@/lib/error-handler";
+import { withErrorHandler } from "@/lib/error-handler";
+import { requireAuth } from "@/lib/rbac";
 
 export const dynamic = "force-dynamic";
 
@@ -14,7 +15,7 @@ function getAuthCookieOptions() {
 }
 
 export const POST = withErrorHandler(async (request) => {
-  const decodedToken = await authenticateRequest(request);
+  const decodedToken = await requireAuth(request);
   const authorization = request.headers.get("authorization") || "";
   const bearerToken = authorization.startsWith("Bearer ") ? authorization.slice(7) : null;
   const authToken = bearerToken || request.cookies.get("authToken")?.value || null;
@@ -34,7 +35,7 @@ export const POST = withErrorHandler(async (request) => {
 });
 
 export const DELETE = withErrorHandler(async (request) => {
-  await authenticateRequest(request);
+  await requireAuth(request);
 
   const response = NextResponse.json({ success: true });
   response.cookies.set("authToken", "", {

--- a/app/api/auth/set-role/route.js
+++ b/app/api/auth/set-role/route.js
@@ -1,5 +1,6 @@
 import { jsonError, jsonSuccess } from "@/lib/api-response";
-import { withErrorHandler, authenticateRequest } from "@/lib/error-handler";
+import { withErrorHandler } from "@/lib/error-handler";
+import { requireAuth } from "@/lib/rbac";
 import { initializeFirebase } from "@/lib/firebase-admin";
 import { checkRateLimit } from "@/lib/rateLimit";
 import { AppError } from "@/lib/errors";
@@ -13,7 +14,7 @@ import { setRoleSchema } from "@/lib/validations/auth";
 export const POST = withValidation(
   setRoleSchema,
   withErrorHandler(async (request, data) => {
-    const decodedToken = await authenticateRequest(request);
+    const decodedToken = await requireAuth(request);
 
     const ip = request.headers.get("x-forwarded-for") || "127.0.0.1";
     const rateLimitResult = await checkRateLimit(`set_role_${ip}_${decodedToken.uid}`);

--- a/app/api/conversations/route.js
+++ b/app/api/conversations/route.js
@@ -1,10 +1,12 @@
 import { NextResponse } from "next/server";
 import { Groq } from "groq-sdk";
-import { authenticateRequest, parseJSON } from "@/lib/error-handler";
+import { parseJSON } from "@/lib/error-handler";
 import { checkRateLimit } from "@/lib/rateLimit";
 import { detectInjection, sanitizeMessage } from "@/utils/promptGuard";
 // 🎯 INTEGRATION: Import the localized action engine agent parser
 import { parseUserIntent } from "@/services/ai-agent/intentparser";
+import { requireAuth } from "@/lib/rbac";
+import { AppError } from "@/lib/errors";
 
 // Initialize the official Groq SDK client instance
 const groq = new Groq({ apiKey: process.env.GROQ_API_KEY });
@@ -39,23 +41,8 @@ function createStreamingResponse(dataPayload) {
 export async function POST(request) {
   try {
     // 1. Authentication Layer (With Automated Local Dev Safety Rails)
-    let userId = "dev-mock-user-id";
-    
-    try {
-      const decodedToken = await authenticateRequest(request);
-      if (decodedToken?.uid || decodedToken?.sub) {
-        userId = decodedToken.uid || decodedToken.sub;
-      }
-    } catch (authError) {
-      if (process.env.NODE_ENV === "development") {
-        console.log("[nova-auth-fallback] Local development fallback bypass activated.");
-      } else {
-        return new Response(JSON.stringify({ error: "Unauthorized access token validation failed." }), { 
-          status: 401, 
-          headers: { "Content-Type": "application/json" } 
-        });
-      }
-    }
+    const decodedToken = await requireAuth(request);
+    let userId = decodedToken.uid || decodedToken.sub;
 
     // 2. Rate Limiting Check
     try {
@@ -188,6 +175,13 @@ export async function POST(request) {
     });
 
   } catch (error) {
+    if (error instanceof AppError) {
+      return new Response(JSON.stringify({ error: error.message }), {
+        status: error.statusCode,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+
     console.error(`[nova-ai] Groq API initialization exception:`, error.message);
     return new Response(JSON.stringify({ error: error.message || "An error occurred in the streaming process pipeline." }), { 
       status: 500, 

--- a/app/api/notifications/route.js
+++ b/app/api/notifications/route.js
@@ -1,5 +1,6 @@
 import clientPromise from "../../../lib/mongodb";
-import { parseJSON, authenticateRequest, withErrorHandler } from "../../../lib/error-handler";
+import { parseJSON, withErrorHandler } from "../../../lib/error-handler";
+import { requireAuth } from "@/lib/rbac";
 import { checkRateLimit } from "../../../lib/rateLimit";
 import { AppError } from "../../../lib/errors";
 import { fail, success } from "../../../lib/api-response";
@@ -14,7 +15,7 @@ function serializeNotification(notification) {
 }
 
 export const GET = withErrorHandler(async (request) => {
-  const decodedToken = await authenticateRequest(request);
+  const decodedToken = await requireAuth(request);
 
   const { searchParams } = new URL(request.url);
   const userId = searchParams.get("userId");
@@ -48,7 +49,7 @@ export const GET = withErrorHandler(async (request) => {
 });
 
 export const PATCH = withErrorHandler(async (request) => {
-  const decodedToken = await authenticateRequest(request);
+  const decodedToken = await requireAuth(request);
 
   const body = await parseJSON(request, 1024);
   const { userId } = body;

--- a/app/api/notifications/route.test.js
+++ b/app/api/notifications/route.test.js
@@ -1,5 +1,5 @@
 import { GET, PATCH } from "./route";
-import { authenticateRequest, parseJSON } from "../../../lib/error-handler";
+import { parseJSON } from "../../../lib/error-handler";
 import { checkRateLimit } from "../../../lib/rateLimit";
 import clientPromise from "../../../lib/mongodb";
 import { assertApiSuccess } from "../../../testUtils/assertApiSuccess";
@@ -7,7 +7,6 @@ import { assertApiError } from "../../../testUtils/assertApiError";
 
 vi.mock("../../../lib/error-handler", () => {
   return {
-    authenticateRequest: vi.fn(),
     withErrorHandler: (handler) => {
       return async (request, ...args) => {
         try {
@@ -30,6 +29,10 @@ vi.mock("../../../lib/error-handler", () => {
     parseJSON: vi.fn(),
   };
 });
+
+vi.mock("../../../lib/rbac", () => ({
+  requireAuth: vi.fn(),
+}));
 
 vi.mock("../../../lib/rateLimit", () => ({
   checkRateLimit: vi.fn().mockResolvedValue({ allowed: true, remaining: 9 }),
@@ -85,7 +88,8 @@ describe("notifications route", () => {
 
   describe("GET notifications", () => {
     test("successfully retrieves notifications when requested for own account", async () => {
-      authenticateRequest.mockResolvedValue({ uid: "user-123" });
+      const { requireAuth } = await import("../../../lib/rbac");
+      requireAuth.mockResolvedValue({ uid: "user-123" });
 
       const mockNotifications = [
         { _id: "notif-1", userId: "user-123", message: "Notice posted", read: false },
@@ -105,7 +109,8 @@ describe("notifications route", () => {
     });
 
     test("returns empty list if userId query param is missing", async () => {
-      authenticateRequest.mockResolvedValue({ uid: "user-123" });
+      const { requireAuth } = await import("../../../lib/rbac");
+      requireAuth.mockResolvedValue({ uid: "user-123" });
 
       const response = await GET(createMockRequest("http://localhost/api/notifications"));
 
@@ -115,7 +120,8 @@ describe("notifications route", () => {
     });
 
     test("rejects request with 403 Forbidden if trying to get notifications of another user", async () => {
-      authenticateRequest.mockResolvedValue({ uid: "user-123" });
+      const { requireAuth } = await import("../../../lib/rbac");
+      requireAuth.mockResolvedValue({ uid: "user-123" });
 
       const response = await GET(createMockRequest("http://localhost/api/notifications?userId=other-user-456"));
 
@@ -124,7 +130,8 @@ describe("notifications route", () => {
 
     test("rejects request with 401 Unauthorized if token is missing or invalid", async () => {
       const { UnauthorizedError } = require("../../../lib/errors");
-      authenticateRequest.mockRejectedValue(new UnauthorizedError("Unauthorized"));
+      const { requireAuth } = await import("../../../lib/rbac");
+      requireAuth.mockRejectedValue(new UnauthorizedError("Unauthorized"));
 
       const response = await GET(createMockRequest("http://localhost/api/notifications?userId=user-123"));
 
@@ -132,7 +139,8 @@ describe("notifications route", () => {
     });
 
     test("rejects request with 429 if rate limit is exceeded", async () => {
-      authenticateRequest.mockResolvedValue({ uid: "user-123" });
+      const { requireAuth } = await import("../../../lib/rbac");
+      requireAuth.mockResolvedValue({ uid: "user-123" });
       checkRateLimit.mockResolvedValue({ allowed: false });
 
       const response = await GET(createMockRequest("http://localhost/api/notifications?userId=user-123"));
@@ -143,7 +151,8 @@ describe("notifications route", () => {
 
   describe("PATCH notifications (mark read)", () => {
     test("successfully marks all notifications as read for own account", async () => {
-      authenticateRequest.mockResolvedValue({ uid: "user-123" });
+      const { requireAuth } = await import("../../../lib/rbac");
+      requireAuth.mockResolvedValue({ uid: "user-123" });
       parseJSON.mockResolvedValue({ userId: "user-123" });
 
       const response = await PATCH(createMockRequest());
@@ -158,7 +167,8 @@ describe("notifications route", () => {
     });
 
     test("returns success false if userId is missing from request body", async () => {
-      authenticateRequest.mockResolvedValue({ uid: "user-123" });
+      const { requireAuth } = await import("../../../lib/rbac");
+      requireAuth.mockResolvedValue({ uid: "user-123" });
       parseJSON.mockResolvedValue({});
 
       const response = await PATCH(createMockRequest());
@@ -168,7 +178,8 @@ describe("notifications route", () => {
     });
 
     test("rejects request with 403 Forbidden if trying to mark read for another user", async () => {
-      authenticateRequest.mockResolvedValue({ uid: "user-123" });
+      const { requireAuth } = await import("../../../lib/rbac");
+      requireAuth.mockResolvedValue({ uid: "user-123" });
       parseJSON.mockResolvedValue({ userId: "other-user-456" });
 
       const response = await PATCH(createMockRequest());
@@ -178,7 +189,8 @@ describe("notifications route", () => {
 
     test("rejects request with 401 if unauthorized", async () => {
       const { UnauthorizedError } = require("../../../lib/errors");
-      authenticateRequest.mockRejectedValue(new UnauthorizedError("Unauthorized"));
+      const { requireAuth } = await import("../../../lib/rbac");
+      requireAuth.mockRejectedValue(new UnauthorizedError("Unauthorized"));
 
       const response = await PATCH(createMockRequest());
       await assertApiError(response, 401, "Unauthorized");

--- a/app/api/register/route.js
+++ b/app/api/register/route.js
@@ -2,7 +2,8 @@ import { put, del } from "@vercel/blob";
 import { randomUUID } from "crypto";
 import { connectDb } from "@/lib/mongodb";
 import { jsonError, jsonSuccess } from "@/lib/api-response";
-import { withErrorHandler, authenticateRequest } from "@/lib/error-handler";
+import { withErrorHandler } from "@/lib/error-handler";
+import { requireAuth } from "@/lib/rbac";
 import { AppError, ValidationError, ForbiddenError } from "@/lib/errors";
 import { z } from "zod";
 import { checkRateLimit } from "@/lib/rateLimit";
@@ -128,10 +129,7 @@ export const POST =
       }
 
       // Authenticate
-      const decodedToken =
-        await authenticateRequest(
-          req
-        );
+      const decodedToken = await requireAuth(req);
 
       // Form data
       const formData =

--- a/app/api/stats/route.js
+++ b/app/api/stats/route.js
@@ -1,11 +1,12 @@
 import { jsonError, jsonSuccess } from "@/lib/api-response";
-import { withErrorHandler, authenticateRequest, parseJSON } from "@/lib/error-handler";
+import { withErrorHandler, parseJSON } from "@/lib/error-handler";
+import { requireAuth } from "@/lib/rbac";
 import { initFirebaseAdmin, getUserProfile } from "@/lib/firebase-admin";
 import { getFirestore, FieldValue } from "firebase-admin/firestore";
 import { getWeekdaysSince } from "@/lib/dateUtils";
 
 export const GET = withErrorHandler(async (request) => {
-  const decodedToken = await authenticateRequest(request);
+  const decodedToken = await requireAuth(request);
   initFirebaseAdmin();
   const db = getFirestore();
 
@@ -19,7 +20,7 @@ export const GET = withErrorHandler(async (request) => {
 });
 
 export const POST = withErrorHandler(async (request) => {
-  const decodedToken = await authenticateRequest(request);
+  const decodedToken = await requireAuth(request);
   const body = await parseJSON(request, 1024);
   const { action, statField, value } = body;
 

--- a/lib/__tests__/rbac.test.js
+++ b/lib/__tests__/rbac.test.js
@@ -1,0 +1,74 @@
+import { describe, expect, test, beforeEach, vi } from "vitest";
+import { UnauthorizedError, ForbiddenError } from "@/lib/errors";
+import { authenticateRequest } from "@/lib/error-handler";
+import { getUserProfile } from "@/lib/firebase-admin";
+import { requireApiAccess, requireAuth, requireRole } from "@/lib/rbac";
+
+vi.mock("@/lib/error-handler", () => ({
+  authenticateRequest: vi.fn(),
+}));
+
+vi.mock("@/lib/firebase-admin", () => ({
+  getUserProfile: vi.fn(),
+}));
+
+function mockRequest(pathname = "/api/test") {
+  return {
+    nextUrl: { pathname },
+    url: `http://localhost${pathname}`,
+  };
+}
+
+describe("rbac helpers", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test("rejects invalid tokens", async () => {
+    authenticateRequest.mockRejectedValue(new UnauthorizedError("Unauthorized"));
+
+    await expect(requireAuth(mockRequest())).rejects.toBeInstanceOf(UnauthorizedError);
+  });
+
+  test("rejects unverified emails by default", async () => {
+    authenticateRequest.mockResolvedValue({
+      uid: "user-123",
+      email_verified: false,
+      role: "student",
+    });
+
+    await expect(requireAuth(mockRequest())).rejects.toThrow("Email not verified");
+  });
+
+  test("rejects the wrong role", async () => {
+    authenticateRequest.mockResolvedValue({
+      uid: "user-123",
+      email_verified: true,
+      role: "student",
+    });
+
+    await expect(requireRole(mockRequest(), ["admin"]))
+      .rejects.toThrow("Requires one of admin");
+  });
+
+  test("returns the caller profile for allowed roles", async () => {
+    authenticateRequest.mockResolvedValue({
+      uid: "user-123",
+      email_verified: true,
+      role: "admin",
+    });
+    getUserProfile.mockResolvedValue({ uid: "user-123", role: "admin" });
+
+    const result = await requireRole(mockRequest(), ["admin"]);
+
+    expect(result.payload.uid).toBe("user-123");
+    expect(result.profile).toEqual({ uid: "user-123", role: "admin" });
+  });
+
+  test("keeps explicit public API routes public", async () => {
+    const result = await requireApiAccess(mockRequest("/api/auth/csrf"));
+
+    expect(result).toEqual({ public: true });
+    expect(authenticateRequest).not.toHaveBeenCalled();
+  });
+});

--- a/lib/rbac.js
+++ b/lib/rbac.js
@@ -2,63 +2,159 @@ import { authenticateRequest } from "@/lib/error-handler";
 import { getUserProfile } from "@/lib/firebase-admin";
 import { ForbiddenError } from "@/lib/errors";
 
+export const PUBLIC_API_PATHS = new Set([
+  "/api/auth/csrf",
+  "/api/auth/reset-password",
+]);
+
+const API_ROUTE_RULES = [
+  { pattern: /^\/api\/student(?:\/|$)/, roles: ["student", "admin"] },
+  { pattern: /^\/api\/teacher(?:\/|$)/, roles: ["teacher", "admin"] },
+  { pattern: /^\/api\/admin(?:\/|$)/, roles: ["admin"] },
+  { pattern: /^\/api\/institute(?:\/|$)/, roles: ["institute", "admin"] },
+  { pattern: /^\/api\/analytics\/attendance-risk(?:\/|$)/, roles: ["teacher", "institute", "admin"] },
+  { pattern: /^\/api\/attendance\/settings(?:\/|$)/, roles: ["teacher", "admin"] },
+  { pattern: /^\/api\/attendance\/record(?:\/|$)/, authOnly: true },
+  { pattern: /^\/api\/attendance\/sync(?:\/|$)/, authOnly: true },
+  { pattern: /^\/api\/attendance\/validate-passcode(?:\/|$)/, authOnly: true },
+  { pattern: /^\/api\/attendance\/heatmap(?:\/|$)/, authOnly: true },
+  { pattern: /^\/api\/activities(?:\/|$)/, authOnly: true },
+  { pattern: /^\/api\/auth\/cleanup(?:\/|$)/, authOnly: true },
+  { pattern: /^\/api\/auth\/me(?:\/|$)/, authOnly: true },
+  { pattern: /^\/api\/auth\/session(?:\/|$)/, authOnly: true },
+  { pattern: /^\/api\/auth\/set-role(?:\/|$)/, authOnly: true },
+  { pattern: /^\/api\/check-groq-config(?:\/|$)/, authOnly: true },
+  { pattern: /^\/api\/complaints(?:\/|$)/, authOnly: true },
+  { pattern: /^\/api\/conversations(?:\/|$)/, authOnly: true },
+  { pattern: /^\/api\/flashcards(?:\/|$)/, roles: ["student", "teacher", "admin"] },
+  { pattern: /^\/api\/groq(?:\/|$)/, authOnly: true },
+  { pattern: /^\/api\/images(?:\/|$)/, authOnly: true },
+  { pattern: /^\/api\/labels(?:\/|$)/, roles: ["admin", "teacher", "student"] },
+  { pattern: /^\/api\/notifications(?:\/|$)/, authOnly: true },
+  { pattern: /^\/api\/notifications\/seed(?:\/|$)/, roles: ["admin"] },
+  { pattern: /^\/api\/notices(?:\/|$)/, roles: ["teacher", "admin", "staff"] },
+  { pattern: /^\/api\/productivity(?:\/|$)/, roles: ["student", "teacher", "admin"] },
+  { pattern: /^\/api\/settings(?:\/|$)/, authOnly: true },
+  { pattern: /^\/api\/stats(?:\/|$)/, authOnly: true },
+  { pattern: /^\/api\/upload\/avatar(?:\/|$)/, authOnly: true },
+];
+
+function normalizeRoles(allowedRoles) {
+  if (!allowedRoles) return [];
+  return Array.isArray(allowedRoles) ? allowedRoles.filter(Boolean) : [allowedRoles];
+}
+
+function isEmailVerified(payload) {
+  return payload?.email_verified === true || payload?.emailVerified === true;
+}
+
+function getApiRouteRule(pathname) {
+  if (!pathname || !pathname.startsWith("/api/")) {
+    return null;
+  }
+
+  if (PUBLIC_API_PATHS.has(pathname)) {
+    return { public: true };
+  }
+
+  return API_ROUTE_RULES.find((rule) => rule.pattern.test(pathname)) || { authOnly: true };
+}
+
 /**
  * Requires the request to have a valid Firebase auth token.
- * Extends `authenticateRequest` by ensuring it's robust and returns the token payload.
- * 
- * @param {Request} request 
+ * Email verification is enforced by default.
+ *
+ * @param {Request} request
+ * @param {{ emailVerifiedRequired?: boolean }} options
  * @returns {Promise<Object>} Decoded Firebase ID token payload
  * @throws {UnauthorizedError} if token is missing or invalid
+ * @throws {ForbiddenError} if the email is not verified and verification is required
  */
-export async function requireAuth(request) {
-  const decodedToken = await authenticateRequest(request);
-  return decodedToken;
+export async function requireAuth(request, options = {}) {
+  const payload = await authenticateRequest(request);
+  const { emailVerifiedRequired = true } = options;
+
+  if (emailVerifiedRequired && !isEmailVerified(payload)) {
+    throw new ForbiddenError("Forbidden: Email not verified");
+  }
+
+  return payload;
 }
 
 /**
  * Ensures the authenticated user has a role that matches one of the allowed roles.
- * Uses the JWT custom claims (set via Firebase Admin SDK) as the authoritative
- * source of truth for role-based authorization. Firestore profile data is not
- * used for auth decisions, preventing role mismatch during async claim propagation.
- * 
- * @param {Request} request 
+ * Uses JWT custom claims as the source of truth for authorization and returns
+ * the Firestore profile for callers that need to inspect it.
+ *
+ * @param {Request} request
  * @param {string[]} allowedRoles Array of allowed roles (e.g., ["admin", "teacher"])
- * @returns {Promise<{ payload: Object }>}
+ * @param {{ emailVerifiedRequired?: boolean }} options
+ * @returns {Promise<{ payload: Object, profile: Object|null }>}
  * @throws {UnauthorizedError} if token is invalid
- * @throws {ForbiddenError} if the user's role is not in the allowed list
+ * @throws {ForbiddenError} if the email is unverified or the user's role is not in the allowed list
  */
-export async function requireRole(request, allowedRoles) {
-  const payload = await requireAuth(request);
+export async function requireRole(request, allowedRoles, options = {}) {
+  const payload = await requireAuth(request, options);
   const userRole = payload.role;
 
   if (!userRole) {
     throw new ForbiddenError("User role not found in token claims. Access denied.");
   }
 
-  if (!allowedRoles.includes(userRole)) {
-    throw new ForbiddenError(`Forbidden: Requires one of ${allowedRoles.join(", ")}`);
+  const normalizedRoles = normalizeRoles(allowedRoles);
+
+  if (!normalizedRoles.includes(userRole)) {
+    throw new ForbiddenError(`Forbidden: Requires one of ${normalizedRoles.join(", ")}`);
   }
 
-  return { payload };
+  return { payload, profile: await getUserProfile(payload.uid) };
+}
+
+/**
+ * Route-aware authorization helper that applies centralized API metadata.
+ * Public routes are returned as public, role-gated routes enforce their role
+ * list, and every other API route defaults to auth-only access.
+ *
+ * @param {Request} request
+ * @param {{ allowedRoles?: string[]|string, emailVerifiedRequired?: boolean }} options
+ * @returns {Promise<{ payload?: Object, profile?: Object|null, public?: true }>}
+ */
+export async function requireApiAccess(request, options = {}) {
+  const pathname = request.nextUrl?.pathname || new URL(request.url).pathname;
+  const rule = getApiRouteRule(pathname);
+
+  if (rule?.public) {
+    return { public: true };
+  }
+
+  const emailVerifiedRequired = options.emailVerifiedRequired ?? true;
+  const allowedRoles = normalizeRoles(options.allowedRoles || rule?.roles);
+
+  if (allowedRoles.length > 0) {
+    return requireRole(request, allowedRoles, { emailVerifiedRequired });
+  }
+
+  const payload = await requireAuth(request, { emailVerifiedRequired });
+  return { payload, profile: await getUserProfile(payload.uid) };
 }
 
 /**
  * Helper to require Admin role.
  */
-export async function requireAdmin(request) {
-  return requireRole(request, ["admin"]);
+export async function requireAdmin(request, options = {}) {
+  return requireRole(request, ["admin"], options);
 }
 
 /**
  * Helper to require Teacher role.
  */
-export async function requireTeacher(request) {
-  return requireRole(request, ["teacher"]);
+export async function requireTeacher(request, options = {}) {
+  return requireRole(request, ["teacher"], options);
 }
 
 /**
  * Helper to require Student role.
  */
-export async function requireStudent(request) {
-  return requireRole(request, ["student"]);
+export async function requireStudent(request, options = {}) {
+  return requireRole(request, ["student"], options);
 }


### PR DESCRIPTION
Central RBAC is now enforced in lib/rbac.js: `requireAuth` and `requireRole` both enforce verified email by default, `requireRole` now returns the caller profile for role-aware handlers, and the helper includes explicit API route metadata/public exceptions so the policy is centralized instead of being implicit in middleware only.

I also rewired the direct token-auth routes to use the shared guard, including app/api/auth/session/route.js, app/api/auth/cleanup/route.js, app/api/auth/set-role/route.js, app/api/auth/me/route.js, app/api/analytics/attendance-risk/route.js, app/api/attendance/record/route.js, app/api/attendance/heatmap/route.js, app/api/activities/route.js, app/api/notifications/route.js, app/api/stats/route.js, app/api/register/route.js, and app/api/conversations/route.js. I added lib/__tests__/rbac.test.js and updated the affected route tests to mock the new guard path.

Validation passed for the RBAC helper and the touched auth route suites with `pnpm vitest run rbac.test.js route.test.js route.test.js route.test.js app/api/auth/cleanup/__tests__/route.test.js`. 


closes #2068