### PR TITLE
feat(courses): add saved course shortlist

### DIFF
--- a/app/courses/page.jsx
+++ b/app/courses/page.jsx
@@ -2,7 +2,7 @@ import React from "react";
 import { Sparkles } from "lucide-react";
 import CourseFilters from "@/components/courses/CourseFilters";
 import CourseLibrary from "@/components/courses/CourseLibrary";
-import { getPaginatedCourses } from "@/lib/courses";
+import { COURSES, getPaginatedCourses } from "@/lib/courses";
 
 export const metadata = {
   title: "Courses · Learnova",
@@ -75,6 +75,7 @@ export default async function CoursesPage({ searchParams }) {
           q={q}
           total={total}
           limit={limit}
+          allCourses={COURSES}
         />
       </main>
     </div>

--- a/components/__tests__/CourseLibrary.test.jsx
+++ b/components/__tests__/CourseLibrary.test.jsx
@@ -1,0 +1,133 @@
+import React from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { vi } from "vitest";
+import CourseLibrary from "@/components/courses/CourseLibrary";
+import { COURSES, SAVED_COURSES_STORAGE_KEY } from "@/lib/courses";
+import toast from "react-hot-toast";
+
+vi.mock("next/link", async () => {
+  const React = await vi.importActual("react");
+
+  return {
+    default: ({ href, children, ...props }) =>
+      React.createElement("a", { href, ...props }, children),
+  };
+});
+
+vi.mock("framer-motion", async () => {
+  const React = await vi.importActual("react");
+
+  return {
+    motion: {
+      div: React.forwardRef(({ children, ...props }, ref) =>
+        React.createElement("div", { ref, ...props }, children)
+      ),
+    },
+    AnimatePresence: ({ children }) => React.createElement(React.Fragment, null, children),
+  };
+});
+
+vi.mock("react-hot-toast", () => ({
+  default: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+vi.mock("@/lib/apiClient", () => ({
+  apiFetch: vi.fn(),
+}));
+
+const renderCourseLibrary = (props = {}) =>
+  render(
+    <CourseLibrary
+      initialCourses={COURSES.slice(0, 6)}
+      initialHasMore={true}
+      category="all"
+      q=""
+      total={COURSES.length}
+      limit={6}
+      allCourses={COURSES}
+      {...props}
+    />
+  );
+
+const localStorageMock = (() => {
+  let store = {};
+
+  return {
+    getItem: vi.fn((key) => store[key] || null),
+    setItem: vi.fn((key, value) => {
+      store[key] = String(value);
+    }),
+    removeItem: vi.fn((key) => {
+      delete store[key];
+    }),
+    clear: vi.fn(() => {
+      store = {};
+    }),
+  };
+})();
+
+describe("CourseLibrary saved-course shortlist", () => {
+  beforeAll(() => {
+    Object.defineProperty(window, "localStorage", {
+      value: localStorageMock,
+      writable: true,
+    });
+  });
+
+  beforeEach(() => {
+    window.localStorage.clear();
+    vi.clearAllMocks();
+  });
+
+  test("saves a course to localStorage from the course card", async () => {
+    const user = userEvent.setup();
+
+    renderCourseLibrary();
+
+    await user.click(
+      screen.getByRole("button", {
+        name: /save advanced next\.js.*react architecture to saved courses/i,
+      })
+    );
+
+    expect(JSON.parse(window.localStorage.getItem(SAVED_COURSES_STORAGE_KEY))).toEqual([
+      "nextjs-mastery",
+    ]);
+    expect(toast.success).toHaveBeenCalledWith("Course saved for later");
+    expect(
+      screen.getByRole("button", {
+        name: /remove advanced next\.js.*react architecture from saved courses/i,
+      })
+    ).toBeInTheDocument();
+  });
+
+  test("shows saved courses that are outside the first paginated page", async () => {
+    const user = userEvent.setup();
+    window.localStorage.setItem(
+      SAVED_COURSES_STORAGE_KEY,
+      JSON.stringify(["figma-prototyping-advanced"])
+    );
+
+    renderCourseLibrary();
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /show saved courses/i })).toHaveTextContent(
+        "1"
+      );
+    });
+
+    await user.click(screen.getByRole("button", { name: /show saved courses/i }));
+
+    expect(
+      screen.getByText("Advanced Figma Prototyping & Micro-interactions")
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText("Advanced Next.js & React Architecture")
+    ).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /load more courses/i })).not.toBeInTheDocument();
+  });
+});

--- a/components/__tests__/CourseLibrary.test.jsx
+++ b/components/__tests__/CourseLibrary.test.jsx
@@ -105,6 +105,34 @@ describe("CourseLibrary saved-course shortlist", () => {
     ).toBeInTheDocument();
   });
 
+  test("keeps UI state unchanged when saved-course persistence fails", async () => {
+    const user = userEvent.setup();
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    window.localStorage.setItem.mockImplementationOnce(() => {
+      throw new Error("Storage unavailable");
+    });
+
+    renderCourseLibrary();
+
+    await user.click(
+      screen.getByRole("button", {
+        name: /save advanced next\.js.*react architecture to saved courses/i,
+      })
+    );
+
+    expect(window.localStorage.getItem(SAVED_COURSES_STORAGE_KEY)).toBeNull();
+    expect(toast.error).toHaveBeenCalledWith(
+      "Could not update saved courses on this device."
+    );
+    expect(
+      screen.getByRole("button", {
+        name: /save advanced next\.js.*react architecture to saved courses/i,
+      })
+    ).toBeInTheDocument();
+    expect(warnSpy).toHaveBeenCalled();
+    warnSpy.mockRestore();
+  });
+
   test("shows saved courses that are outside the first paginated page", async () => {
     const user = userEvent.setup();
     window.localStorage.setItem(

--- a/components/courses/CourseLibrary.jsx
+++ b/components/courses/CourseLibrary.jsx
@@ -2,11 +2,28 @@
 
 import React, { useState, useEffect } from "react";
 import Link from "next/link";
-import { Clock, Star, ArrowRight, BookOpen, Search, RotateCcw, Loader2 } from "lucide-react";
+import {
+  Clock,
+  Star,
+  ArrowRight,
+  BookOpen,
+  Search,
+  RotateCcw,
+  Loader2,
+  Bookmark,
+  BookmarkCheck,
+} from "lucide-react";
 import { motion, AnimatePresence } from "framer-motion";
 import toast from "react-hot-toast";
 import Badge from "@/components/ui/Badge";
 import { apiFetch } from "@/lib/apiClient";
+import { safeLocalStorageGet, safeLocalStorageSet } from "@/lib/storage";
+import {
+  COURSES,
+  SAVED_COURSES_STORAGE_KEY,
+  getSavedCourses,
+  sanitizeSavedCourseIds,
+} from "@/lib/courses";
 
 
 const getDifficultyVariant = (difficulty) => {
@@ -28,11 +45,14 @@ export default function CourseLibrary({
   q,
   total,
   limit = 6,
+  allCourses = COURSES,
 }) {
   const [courses, setCourses] = useState(initialCourses);
   const [page, setPage] = useState(1);
   const [isLoading, setIsLoading] = useState(false);
   const [hasMore, setHasMore] = useState(initialHasMore);
+  const [savedCourseIds, setSavedCourseIds] = useState([]);
+  const [showSavedOnly, setShowSavedOnly] = useState(false);
 
   // Sync state if initial courses change (e.g. search filter or category chip select re-fetches from server)
   useEffect(() => {
@@ -40,6 +60,11 @@ export default function CourseLibrary({
     setPage(1);
     setHasMore(initialHasMore);
   }, [initialCourses, initialHasMore]);
+
+  useEffect(() => {
+    const savedIds = safeLocalStorageGet(SAVED_COURSES_STORAGE_KEY, []);
+    setSavedCourseIds(sanitizeSavedCourseIds(savedIds, allCourses));
+  }, [allCourses]);
 
   const loadMoreCourses = async () => {
     if (isLoading) return;
@@ -67,28 +92,82 @@ export default function CourseLibrary({
     }
   };
 
+  const handleToggleSavedCourse = (course) => {
+    setSavedCourseIds((currentIds) => {
+      const existingIds = sanitizeSavedCourseIds(currentIds, allCourses);
+      const isAlreadySaved = existingIds.includes(course.id);
+      const nextIds = isAlreadySaved
+        ? existingIds.filter((id) => id !== course.id)
+        : [...existingIds, course.id];
+
+      if (safeLocalStorageSet(SAVED_COURSES_STORAGE_KEY, nextIds)) {
+        toast.success(
+          isAlreadySaved
+            ? "Course removed from saved list"
+            : "Course saved for later"
+        );
+      } else {
+        toast.error("Could not update saved courses on this device.");
+      }
+
+      return nextIds;
+    });
+  };
+
+  const savedCourses = getSavedCourses(savedCourseIds, {
+    courses: allCourses,
+    q,
+    category,
+  });
+  const visibleCourses = showSavedOnly ? savedCourses : courses;
+  const visibleTotal = showSavedOnly ? savedCourses.length : total;
+  const savedCourseIdSet = new Set(savedCourseIds);
+
   return (
     <div className="space-y-8">
       {/* Search Result Counter */}
-      <div className="flex justify-end">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <button
+          type="button"
+          onClick={() => setShowSavedOnly((current) => !current)}
+          aria-pressed={showSavedOnly}
+          aria-label={showSavedOnly ? "Show all courses" : "Show saved courses"}
+          className={`inline-flex w-full items-center justify-center gap-2 rounded-xl border px-4 py-2 text-sm font-bold transition-all duration-200 sm:w-auto ${
+            showSavedOnly
+              ? "border-amber-400/50 bg-amber-400/15 text-amber-200 shadow-lg shadow-amber-500/10"
+              : "border-slate-800 bg-slate-900/60 text-slate-300 hover:border-amber-400/40 hover:text-amber-200"
+          }`}
+        >
+          {showSavedOnly ? (
+            <BookmarkCheck className="h-4 w-4 fill-amber-300 text-amber-300" />
+          ) : (
+            <Bookmark className="h-4 w-4" />
+          )}
+          <span>{showSavedOnly ? "All courses" : "Saved courses"}</span>
+          <span className="rounded-full bg-slate-950/80 px-2 py-0.5 text-xs text-white">
+            {savedCourseIds.length}
+          </span>
+        </button>
         <div className="text-sm font-medium text-slate-400 bg-slate-900/40 border border-slate-800/80 px-4 py-2 rounded-xl backdrop-blur-sm shadow-sm">
-          Showing <span className="text-indigo-400 font-bold">{courses.length}</span> of{" "}
-          <span className="text-white">{total}</span> courses
+          Showing <span className="text-indigo-400 font-bold">{visibleCourses.length}</span> of{" "}
+          <span className="text-white">{visibleTotal}</span>{" "}
+          {showSavedOnly ? "saved courses" : "courses"}
         </div>
       </div>
 
-      {courses.length > 0 ? (
+      {visibleCourses.length > 0 ? (
         <div className="space-y-12">
           {/* Courses Grid */}
           <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6 pt-4">
             <AnimatePresence mode="popLayout">
-              {courses.map((course, index) => {
+              {visibleCourses.map((course, index) => {
                 const instructorInitials = course.instructor
                   .split(" ")
                   .filter((n) => n.length > 0)
                   .map((n) => n[0])
                   .join("")
                   .substring(0, 2);
+                const isSaved = savedCourseIdSet.has(course.id);
 
                 return (
                   <motion.div
@@ -108,6 +187,27 @@ export default function CourseLibrary({
                         className={`w-full h-40 bg-gradient-to-tr ${course.color} rounded-xl relative flex items-center justify-center p-6 text-center select-none shadow-inner group-hover:brightness-105 transition-all duration-300`}
                       >
                         <div className="absolute inset-0 bg-black/10 mix-blend-overlay rounded-xl" />
+                        <button
+                          type="button"
+                          onClick={() => handleToggleSavedCourse(course)}
+                          aria-pressed={isSaved}
+                          aria-label={
+                            isSaved
+                              ? `Remove ${course.title} from saved courses`
+                              : `Save ${course.title} to saved courses`
+                          }
+                          className={`absolute right-3 top-3 z-20 inline-flex h-9 w-9 items-center justify-center rounded-full border backdrop-blur-md transition-all duration-200 active:scale-95 ${
+                            isSaved
+                              ? "border-amber-200/60 bg-amber-300 text-slate-950 shadow-lg shadow-amber-500/20"
+                              : "border-white/30 bg-black/20 text-white/85 hover:border-amber-200/60 hover:text-amber-200"
+                          }`}
+                        >
+                          {isSaved ? (
+                            <BookmarkCheck className="h-4 w-4 fill-current" />
+                          ) : (
+                            <Bookmark className="h-4 w-4" />
+                          )}
+                        </button>
                         <BookOpen className="w-10 h-10 text-white/30 absolute left-4 bottom-4 group-hover:scale-110 group-hover:rotate-6 transition-all duration-300" />
                         <span className="text-lg font-black text-white tracking-wider leading-snug drop-shadow-md">
                           {course.categoryLabel}
@@ -169,7 +269,7 @@ export default function CourseLibrary({
           </div>
 
           {/* Load More Button */}
-          {hasMore && (
+          {!showSavedOnly && hasMore && (
             <div className="flex justify-center pt-6">
               <button
                 onClick={loadMoreCourses}
@@ -203,16 +303,29 @@ export default function CourseLibrary({
           </h3>
 
           <p className="text-sm text-slate-400 max-w-md leading-relaxed mb-8 relative z-10">
-            No courses matching your criteria. Try adjusting your search query, or clear your filters to explore our full selection of classes.
+            {showSavedOnly
+              ? "No saved courses match the current filters. Save courses from the library or clear your filters to review your shortlist."
+              : "No courses matching your criteria. Try adjusting your search query, or clear your filters to explore our full selection of classes."}
           </p>
 
-          <Link
-            href="/courses"
-            className="inline-flex items-center gap-2 px-5 py-3 rounded-full bg-indigo-600 hover:bg-indigo-500 active:bg-indigo-700 text-sm font-bold text-white shadow-lg shadow-indigo-600/20 active:scale-95 transition-all duration-200 select-none relative z-10"
-          >
-            <RotateCcw className="w-4 h-4" />
-            Reset All Filters
-          </Link>
+          {showSavedOnly ? (
+            <button
+              type="button"
+              onClick={() => setShowSavedOnly(false)}
+              className="inline-flex items-center gap-2 px-5 py-3 rounded-full bg-indigo-600 hover:bg-indigo-500 active:bg-indigo-700 text-sm font-bold text-white shadow-lg shadow-indigo-600/20 active:scale-95 transition-all duration-200 select-none relative z-10"
+            >
+              <RotateCcw className="w-4 h-4" />
+              View All Courses
+            </button>
+          ) : (
+            <Link
+              href="/courses"
+              className="inline-flex items-center gap-2 px-5 py-3 rounded-full bg-indigo-600 hover:bg-indigo-500 active:bg-indigo-700 text-sm font-bold text-white shadow-lg shadow-indigo-600/20 active:scale-95 transition-all duration-200 select-none relative z-10"
+            >
+              <RotateCcw className="w-4 h-4" />
+              Reset All Filters
+            </Link>
+          )}
         </div>
       )}
     </div>

--- a/components/courses/CourseLibrary.jsx
+++ b/components/courses/CourseLibrary.jsx
@@ -19,7 +19,6 @@ import Badge from "@/components/ui/Badge";
 import { apiFetch } from "@/lib/apiClient";
 import { safeLocalStorageGet, safeLocalStorageSet } from "@/lib/storage";
 import {
-  COURSES,
   SAVED_COURSES_STORAGE_KEY,
   getSavedCourses,
   sanitizeSavedCourseIds,
@@ -45,7 +44,7 @@ export default function CourseLibrary({
   q,
   total,
   limit = 6,
-  allCourses = COURSES,
+  allCourses = [],
 }) {
   const [courses, setCourses] = useState(initialCourses);
   const [page, setPage] = useState(1);
@@ -100,15 +99,18 @@ export default function CourseLibrary({
         ? existingIds.filter((id) => id !== course.id)
         : [...existingIds, course.id];
 
-      if (safeLocalStorageSet(SAVED_COURSES_STORAGE_KEY, nextIds)) {
-        toast.success(
-          isAlreadySaved
-            ? "Course removed from saved list"
-            : "Course saved for later"
-        );
-      } else {
+      const didPersist = safeLocalStorageSet(SAVED_COURSES_STORAGE_KEY, nextIds);
+
+      if (!didPersist) {
         toast.error("Could not update saved courses on this device.");
+        return existingIds;
       }
+
+      toast.success(
+        isAlreadySaved
+          ? "Course removed from saved list"
+          : "Course saved for later"
+      );
 
       return nextIds;
     });

--- a/lib/__tests__/courses.test.js
+++ b/lib/__tests__/courses.test.js
@@ -1,4 +1,9 @@
-import { getPaginatedCourses, COURSES } from "../courses";
+import {
+  getPaginatedCourses,
+  getSavedCourses,
+  sanitizeSavedCourseIds,
+  COURSES,
+} from "../courses";
 
 describe("getPaginatedCourses pagination and filtering helper", () => {
   test("should load the first page with correct defaults", () => {
@@ -43,5 +48,26 @@ describe("getPaginatedCourses pagination and filtering helper", () => {
     expect(courses.length).toBe(0);
     expect(total).toBe(0);
     expect(hasMore).toBe(false);
+  });
+
+  test("should sanitize saved course ids and remove duplicates", () => {
+    const savedIds = sanitizeSavedCourseIds([
+      "nextjs-mastery",
+      "missing-course",
+      "nextjs-mastery",
+      "python-data-science",
+    ]);
+
+    expect(savedIds).toEqual(["nextjs-mastery", "python-data-science"]);
+  });
+
+  test("should return saved courses after applying active filters", () => {
+    const savedCourses = getSavedCourses(
+      ["nextjs-mastery", "python-data-science", "ui-ux-design-fundamentals"],
+      { q: "python", category: "data-science" }
+    );
+
+    expect(savedCourses).toHaveLength(1);
+    expect(savedCourses[0].id).toBe("python-data-science");
   });
 });

--- a/lib/__tests__/courses.test.js
+++ b/lib/__tests__/courses.test.js
@@ -1,4 +1,5 @@
 import {
+  filterCourses,
   getPaginatedCourses,
   getSavedCourses,
   sanitizeSavedCourseIds,
@@ -41,6 +42,25 @@ describe("getPaginatedCourses pagination and filtering helper", () => {
     courses.forEach(course => {
       expect(course.category).toBe("design");
     });
+  });
+
+  test("should match categories with multiple hyphens using normalized ids", () => {
+    const courses = [
+      {
+        id: "career-ready-web-dev",
+        title: "Career Ready Web Development",
+        description: "A practical web development track.",
+        instructor: "Learnova Team",
+        category: "career-ready-web-dev",
+      },
+    ];
+
+    const { id } = filterCourses({
+      courses,
+      category: "careerreadywebdev",
+    })[0];
+
+    expect(id).toBe("career-ready-web-dev");
   });
 
   test("should return empty results gracefully for mismatched query", () => {

--- a/lib/courses.js
+++ b/lib/courses.js
@@ -182,26 +182,60 @@ export const COURSES = [
   }
 ];
 
+export const SAVED_COURSES_STORAGE_KEY = "learnova_saved_courses";
+
+const normalizeSearchText = (value = "") => String(value).trim().toLowerCase();
+
+/**
+ * Filter Courses
+ */
+export function filterCourses({ courses = COURSES, q = "", category = "all" } = {}) {
+  const normalizedQuery = normalizeSearchText(q);
+  const activeCategory = category || "all";
+
+  return courses.filter((course) => {
+    const matchesSearch = normalizedQuery
+      ? course.title.toLowerCase().includes(normalizedQuery) ||
+        course.description.toLowerCase().includes(normalizedQuery) ||
+        course.instructor.toLowerCase().includes(normalizedQuery)
+      : true;
+
+    const matchesCategory =
+      activeCategory === "all"
+        ? true
+        : course.category === activeCategory ||
+          course.category.replace("-", "") === activeCategory ||
+          activeCategory.includes(course.category);
+
+    return matchesSearch && matchesCategory;
+  });
+}
+
+export function sanitizeSavedCourseIds(ids, courses = COURSES) {
+  if (!Array.isArray(ids)) {
+    return [];
+  }
+
+  const validCourseIds = new Set(courses.map((course) => course.id));
+  return [...new Set(ids)].filter((id) => validCourseIds.has(id));
+}
+
+export function getSavedCourses(savedCourseIds = [], options = {}) {
+  const courses = options.courses || COURSES;
+  const savedIds = new Set(sanitizeSavedCourseIds(savedCourseIds, courses));
+
+  return filterCourses({
+    courses,
+    q: options.q || "",
+    category: options.category || "all",
+  }).filter((course) => savedIds.has(course.id));
+}
+
 /**
  * Filter and Paginate Courses
  */
 export function getPaginatedCourses({ q = "", category = "all", page = 1, limit = 12 }) {
-  const filtered = COURSES.filter((course) => {
-    const matchesSearch = q
-      ? course.title.toLowerCase().includes(q.toLowerCase()) ||
-        course.description.toLowerCase().includes(q.toLowerCase()) ||
-        course.instructor.toLowerCase().includes(q.toLowerCase())
-      : true;
-
-    const matchesCategory =
-      category === "all"
-        ? true
-        : course.category === category ||
-          course.category.replace("-", "") === category ||
-          category.includes(course.category);
-
-    return matchesSearch && matchesCategory;
-  });
+  const filtered = filterCourses({ q, category });
 
   const startIndex = (page - 1) * limit;
   const endIndex = page * limit;

--- a/lib/courses.js
+++ b/lib/courses.js
@@ -185,6 +185,8 @@ export const COURSES = [
 export const SAVED_COURSES_STORAGE_KEY = "learnova_saved_courses";
 
 const normalizeSearchText = (value = "") => String(value).trim().toLowerCase();
+const normalizeCategoryId = (value = "") =>
+  String(value).trim().toLowerCase().replace(/-/g, "");
 
 /**
  * Filter Courses
@@ -192,6 +194,7 @@ const normalizeSearchText = (value = "") => String(value).trim().toLowerCase();
 export function filterCourses({ courses = COURSES, q = "", category = "all" } = {}) {
   const normalizedQuery = normalizeSearchText(q);
   const activeCategory = category || "all";
+  const normalizedActiveCategory = normalizeCategoryId(activeCategory);
 
   return courses.filter((course) => {
     const matchesSearch = normalizedQuery
@@ -204,8 +207,8 @@ export function filterCourses({ courses = COURSES, q = "", category = "all" } = 
       activeCategory === "all"
         ? true
         : course.category === activeCategory ||
-          course.category.replace("-", "") === activeCategory ||
-          activeCategory.includes(course.category);
+          normalizeCategoryId(course.category) === normalizedActiveCategory ||
+          normalizedActiveCategory.includes(normalizeCategoryId(course.category));
 
     return matchesSearch && matchesCategory;
   });


### PR DESCRIPTION
## What
Adds a saved-course shortlist to the Learnova course library so students can bookmark interesting courses, revisit them on the same device, and switch into a saved-only view while browsing. Closes #2389.

## How
The course helpers now expose shared filtering plus saved-course sanitization utilities. `CourseLibrary` uses the existing safe localStorage helpers to load, persist, and validate saved course IDs, renders accessible save/unsave controls on course cards, shows a saved count, and hides load-more pagination while the saved-only view is active. Follow-up review feedback is addressed by keeping UI state unchanged when persistence fails, passing the full course list from the server page instead of importing it as a client default, and normalizing category IDs across all hyphens.

## Testing
- `npx vitest run lib/__tests__/courses.test.js components/__tests__/CourseLibrary.test.jsx`
- `git diff --check`
- PR `verify`, `checks`, and `GitGuardian Security Checks` pass on commit `472cc514922517fe1115d9e851f5ed5688852f8d`
- `npm run build` / CI build are blocked by upstream files outside this PR: `components/StudentDashboard.js:236 Identifier skillPath has already been declared` and committed merge conflict markers in `app/api/groq/route.js` starting at line 6.

## Risks / Notes
Saved courses are intentionally device-local for this first pass and do not sync across authenticated devices. Vercel also requires maintainer authorization. The build blocker appears unrelated to this PR because the failing files are unchanged by this branch and the same redeclaration/conflict markers are present on `origin/master`.