### PR TITLE
fix(security): allow React Refresh in development CSP

### DIFF
--- a/middleware.js
+++ b/middleware.js
@@ -150,7 +150,9 @@ function buildPageCsp() {
 
   const cspDirectives = [
     "default-src 'self'",
-    "script-src 'self' 'unsafe-inline' https://apis.google.com https://www.gstatic.com https://www.googletagmanager.com",
+    process.env.NODE_ENV === "development"
+  ? "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://apis.google.com https://www.gstatic.com https://www.googletagmanager.com"
+  : "script-src 'self' 'unsafe-inline' https://apis.google.com https://www.gstatic.com https://www.googletagmanager.com",
     "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
     "font-src 'self' https://fonts.gstatic.com",
     "img-src 'self' data: blob: https://lh3.googleusercontent.com https://*.public.blob.vercel-storage.com https://github.com https://www.google-analytics.com",


### PR DESCRIPTION
## Description

This PR fixes a development-mode issue where the application rendered a blank screen after pulling the latest changes and running `npm run dev`.

The issue was caused by the Content Security Policy (CSP) blocking `unsafe-eval`, which is required by Next.js React Refresh during development. As a result, the main application content failed to render while only the footer remained visible.

### Changes Made

* Updated the CSP `script-src` directive in `middleware.js`.
* Allowed `'unsafe-eval'` only in development mode.
* Preserved the existing production CSP configuration.
* Restored proper React Refresh functionality during local development.

### Before

* Running `npm run dev` resulted in a mostly blank screen.
* Only the footer component was visible.
* Browser console showed:

```text
Uncaught EvalError: Evaluating a string as JavaScript violates the Content Security Policy directive because 'unsafe-eval' is not an allowed source of script.
```

### After

* Application loads normally in development mode.
* React Fast Refresh works correctly.
* No CSP-related React Refresh errors.
* Production CSP remains unchanged.

### Why This Change Is Safe

The relaxed CSP rule is applied only when:

```js
process.env.NODE_ENV === "development"
```

Production builds continue using the original stricter CSP policy.

## Related Issue

Fixes #2405 

## Type of Change

* [x] Bug fix

## Checklist

* [x] Tested locally using `npm run dev`
* [x] Verified React Refresh works correctly
* [x] Confirmed production CSP remains unchanged
* [x] Self-reviewed code changes
* [x] No unrelated files modified