### PR TITLE
fix(productivity): validate session date ranges

### DIFF
--- a/app/api/productivity/session/route.js
+++ b/app/api/productivity/session/route.js
@@ -8,6 +8,7 @@ import { z } from "zod";
 
 const DEFAULT_DAYS_BACK = 7;
 const MAX_SESSION_PAYLOAD_BYTES = 1024 * 10;
+const DAY_MS = 24 * 60 * 60 * 1000;
 
 const sessionSchema = z.object({
   duration: z
@@ -22,6 +23,41 @@ const sessionSchema = z.object({
     message: "type must be either 'focus' or 'break'",
   }),
 });
+
+function parseDateParam(value, fieldName) {
+  const parsedDate = new Date(value);
+
+  if (!Number.isFinite(parsedDate.getTime())) {
+    throw new ValidationError(`${fieldName} must be a valid date string`);
+  }
+
+  return parsedDate;
+}
+
+export function parseSessionDateRange(searchParams, now = new Date()) {
+  const rawEndDate = searchParams.get("endDate");
+  const rawStartDate = searchParams.get("startDate");
+
+  const endDate = rawEndDate ? parseDateParam(rawEndDate, "endDate") : now;
+  const startDate = rawStartDate
+    ? parseDateParam(rawStartDate, "startDate")
+    : new Date(endDate.getTime() - DEFAULT_DAYS_BACK * DAY_MS);
+
+  if (startDate.getTime() > endDate.getTime()) {
+    throw new ValidationError("startDate must be before or equal to endDate");
+  }
+
+  const daySpan = Math.max(
+    1,
+    Math.ceil((endDate.getTime() - startDate.getTime()) / DAY_MS)
+  );
+
+  return {
+    startDate: startDate.toISOString(),
+    endDate: endDate.toISOString(),
+    daySpan,
+  };
+}
 
 /**
  * POST /api/productivity/session
@@ -97,10 +133,7 @@ export const GET = withErrorHandler(async (request) => {
   }
 
   const { searchParams } = new URL(request.url);
-  const endDate = searchParams.get("endDate") || new Date().toISOString();
-  const startDate =
-    searchParams.get("startDate") ||
-    new Date(Date.now() - DEFAULT_DAYS_BACK * 24 * 60 * 60 * 1000).toISOString();
+  const { startDate, endDate, daySpan } = parseSessionDateRange(searchParams);
 
   const db = await connectDb();
   const userId = decodedToken.uid;
@@ -116,11 +149,6 @@ export const GET = withErrorHandler(async (request) => {
 
   const focusSessions = sessions.filter((s) => s.type === "focus");
   const totalFocusMinutes = focusSessions.reduce((sum, s) => sum + s.duration, 0);
-
-  const daySpan = Math.max(
-    1,
-    Math.ceil((new Date(endDate) - new Date(startDate)) / (1000 * 60 * 60 * 24))
-  );
 
   return NextResponse.json({
     sessions: sessions.map(({ _id, ...rest }) => rest),

--- a/app/api/productivity/session/route.test.js
+++ b/app/api/productivity/session/route.test.js
@@ -1,0 +1,68 @@
+import { ValidationError } from "@/lib/errors";
+import { parseSessionDateRange } from "./route";
+
+describe("parseSessionDateRange", () => {
+  const now = new Date("2026-06-01T00:00:00.000Z");
+
+  test("defaults to the previous seven days when query params are missing", () => {
+    const result = parseSessionDateRange(new URLSearchParams(), now);
+
+    expect(result).toEqual({
+      startDate: "2026-05-25T00:00:00.000Z",
+      endDate: "2026-06-01T00:00:00.000Z",
+      daySpan: 7,
+    });
+  });
+
+  test("uses a valid explicit date range", () => {
+    const result = parseSessionDateRange(
+      new URLSearchParams({
+        startDate: "2026-05-01T00:00:00.000Z",
+        endDate: "2026-05-04T12:00:00.000Z",
+      }),
+      now
+    );
+
+    expect(result).toEqual({
+      startDate: "2026-05-01T00:00:00.000Z",
+      endDate: "2026-05-04T12:00:00.000Z",
+      daySpan: 4,
+    });
+  });
+
+  test("rejects invalid startDate values before querying sessions", () => {
+    expect(() =>
+      parseSessionDateRange(
+        new URLSearchParams({
+          startDate: "not-a-date",
+          endDate: "2026-05-04T00:00:00.000Z",
+        }),
+        now
+      )
+    ).toThrow(ValidationError);
+  });
+
+  test("rejects invalid endDate values before querying sessions", () => {
+    expect(() =>
+      parseSessionDateRange(
+        new URLSearchParams({
+          startDate: "2026-05-01T00:00:00.000Z",
+          endDate: "also-bad",
+        }),
+        now
+      )
+    ).toThrow("endDate must be a valid date string");
+  });
+
+  test("rejects reversed date ranges", () => {
+    expect(() =>
+      parseSessionDateRange(
+        new URLSearchParams({
+          startDate: "2026-05-05T00:00:00.000Z",
+          endDate: "2026-05-01T00:00:00.000Z",
+        }),
+        now
+      )
+    ).toThrow("startDate must be before or equal to endDate");
+  });
+});


### PR DESCRIPTION
## Description
Validates `GET /api/productivity/session` date-range query params before they are used in the MongoDB `completedAt` range query or in the `averagePerDay` calculation. Invalid date strings and reversed ranges now return a 400 validation error instead of producing misleading/null stats from `NaN` date math.

Fixes #2415

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Changes Made
- Added `parseSessionDateRange` for productivity session history query validation.
- Preserved the existing seven-day default range when query params are omitted.
- Rejects invalid `startDate`/`endDate` values and ranges where `startDate` is after `endDate`.
- Added focused tests for default, valid, invalid, and reversed ranges.

## Testing
- `npm test -- app/api/productivity/session/route.test.js` ✅
- `git diff --check` ✅
- `npx eslint app/api/productivity/session/route.js app/api/productivity/session/route.test.js` blocked by existing project tooling gap: Next ESLint config requires `typescript`, but `typescript` is not listed in `package.json`.
- GitHub `verify`, `checks`, and GitGuardian jobs passed ✅
- GitHub `build (18.x)` and `build (20.x)` currently fail before this change runs due upstream `master` compile blockers:
  - `app/api/groq/route.js` contains unresolved merge conflict markers.
  - `components/StudentDashboard.js` declares `skillPath` twice at lines 223 and 236.
- Local `npm run build` reproduces the same upstream blockers; it also reports a missing `react-is` dependency through Recharts after dependency installation.
- Vercel is blocked by maintainer-side deployment authorization.

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] My changes generate no new warnings in the focused test path
- [x] I have performed a self-review of my own code
