### PR TITLE
"fix: prevent page scrolling during keyboard reordering"

### DIFF
--- a/frontend/CurriculumBuilder.jsx
+++ b/frontend/CurriculumBuilder.jsx
@@ -1,8 +1,10 @@
 // Accessible drag keyboard handlers
 export function handleBuilderKeyboard(event, item, moveCallback) {
   if (event.key === 'ArrowUp') {
+    event.preventDefault();
     moveCallback(item, -1);
   } else if (event.key === 'ArrowDown') {
+    event.preventDefault();
     moveCallback(item, 1);
   }
 }


### PR DESCRIPTION
Summary

Prevents the browser's default scrolling behavior when using ArrowUp and ArrowDown keys for keyboard-based item reordering.

Changes Made

- Added "event.preventDefault()" for ArrowUp key handling.
- Added "event.preventDefault()" for ArrowDown key handling.

Testing

- Verified items can still be reordered using the keyboard.
- Verified the page no longer scrolls while reordering items.

Fixes 
#2309 