### PR TITLE
fix: make hero section stat pills visible in light mode

### DIFF
--- a/app/page.js
+++ b/app/page.js
@@ -303,8 +303,8 @@ export default function Page() {
                         onMouseLeave={() => setHoveredRing(null)}
                         className={`group block p-4 rounded-2xl border transition-all duration-500 cursor-pointer
                           ${isSelected
-                            ? "bg-purple-950/20 border-purple-500/40 translate-x-2 shadow-lg shadow-purple-500/5"
-                            : "bg-white/[0.02] dark:bg-black/20 border-white/5 hover:border-white/10 hover:bg-white/[0.04]"
+                            ? "bg-purple-100 dark:bg-purple-950/20 border-purple-400 dark:border-purple-500/40 translate-x-2 shadow-lg shadow-purple-500/5"
+                            : "bg-gray-100/80 dark:bg-black/20 border-gray-200 dark:border-white/5 hover:border-gray-300 dark:hover:border-white/10 hover:bg-gray-100 dark:hover:bg-white/[0.04]"
                           }`}
                       >
                         {stat.href ? (


### PR DESCRIPTION
## Description
The impact metric pills (99.8%, 45%, 25K+) on the hero section were invisible in light mode due to hardcoded dark-only transparent background and border classes with no light mode alternatives.

Changes made to `app/page.js`:
- Default pill: `bg-gray-100/80 dark:bg-black/20 border-gray-200 dark:border-white/5`
- Selected pill: `bg-purple-100 dark:bg-purple-950/20 border-purple-400 dark:border-purple-500/40`
- No changes to stat values, labels, or any other part of the page

Fixes #2361

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] My changes generate no new warnings
- [x] I have performed a self-review of my own code
