### PR TITLE
fix(wellness): restore single absolute Selected Mood badge on active card (#2058)

### DIFF
--- a/components/MoodTracker.js
+++ b/components/MoodTracker.js
@@ -135,10 +135,15 @@ export default function MoodTracker() {
                   <p className="text-lg font-semibold">{mood.label}</p>
                   <p className="mt-2 text-sm text-slate-400 dark:text-slate-400">{mood.description}</p>
                 </div>
-                <div className={`flex h-12 w-12 items-center justify-center rounded-2xl ${isActive ? "bg-white/15 text-white ring-1 ring-white/20 shadow-[0_0_0_1px_rgba(255,255,255,0.14)]" : "bg-white/10 text-slate-100 border border-slate-800 dark:bg-slate-800/90 dark:border-slate-700"}`}>
+                <div className={`flex h-12 w-12 items-center justify-center rounded-2xl ${isActive ? "bg-white/15 text-white ring-1 ring-white/20 shadow-[0_0_0_1px_rgba(255,255,255,0.14)] mt-6" : "bg-white/10 text-slate-100 border border-slate-800 dark:bg-slate-800/90 dark:border-slate-700"}`}>
                   <Icon className="h-6 w-6" />
                 </div>
               </div>
+              {isActive && (
+                <div className="absolute right-4 top-4 rounded-full bg-white/10 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.35em] text-violet-100 ring-1 ring-violet-500/30">
+                  Selected mood
+                </div>
+              )}
             </motion.button>
           );
         })}

--- a/components/__tests__/MoodTracker.test.jsx
+++ b/components/__tests__/MoodTracker.test.jsx
@@ -1,0 +1,66 @@
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import "@testing-library/jest-dom/vitest";
+import MoodTracker from "../MoodTracker";
+
+// Mock framer-motion since it can be problematic in jsdom/vitest environment
+vi.mock("framer-motion", () => ({
+  motion: {
+    button: ({ children, whileHover, whileTap, ...props }) => (
+      <button {...props}>{children}</button>
+    ),
+  },
+  AnimatePresence: ({ children }) => <>{children}</>,
+}));
+
+// Mock localStorage
+const localStorageMock = (() => {
+  let store = {};
+  return {
+    getItem: (key) => store[key] || null,
+    setItem: (key, value) => {
+      store[key] = value.toString();
+    },
+    clear: () => {
+      store = {};
+    },
+  };
+})();
+
+Object.defineProperty(window, "localStorage", {
+  value: localStorageMock,
+});
+
+describe("MoodTracker Component", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  test("should render the MoodTracker title and moods", () => {
+    render(<MoodTracker />);
+    expect(screen.getByText("Mood Tracker")).toBeInTheDocument();
+    expect(screen.getAllByText("Happy").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Calm").length).toBeGreaterThan(0);
+  });
+
+  test("should render the 'Selected mood' badge exactly once for the active mood", () => {
+    render(<MoodTracker />);
+
+    // By default, "happy" is the active mood.
+    // Let's verify that the "Selected mood" badge is rendered exactly once.
+    const badges = screen.getAllByText("Selected mood");
+    expect(badges).toHaveLength(1);
+  });
+
+  test("should update the active mood and keep only a single 'Selected mood' badge", () => {
+    render(<MoodTracker />);
+
+    // Find the "Calm" mood button and click it
+    const calmButton = screen.getByRole("button", { name: /Calm/i });
+    fireEvent.click(calmButton);
+
+    // Verify that the "Selected mood" badge is still rendered exactly once on the page
+    const badges = screen.getAllByText("Selected mood");
+    expect(badges).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Description
This PR restores the `"Selected mood"` label badge to the active mood card in `MoodTracker.js`, addressing the issue where it was completely removed. 

Key changes include:
- Restored the absolute-positioned top-right `"Selected mood"` badge.
- Added a top margin (`mt-6`) to the active icon container to push it down and prevent any overlapping with the badge.
- Created a new unit test suite [components/__tests__/MoodTracker.test.jsx](file:///d:/Projects/GSSoC%202026/Learnova/components/__tests__/MoodTracker.test.jsx) that asserts that only a single badge is rendered for the selected mood.

Closes #2058

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] My changes generate no new warnings
- [x] I have performed a self-review of my own code
