### PR TITLE
fix: add missing /metrics/attendance and /metrics/efficiency route pages

### DIFF
--- a/app/metrics/attendance/page.js
+++ b/app/metrics/attendance/page.js
@@ -1,0 +1,44 @@
+import Link from "next/link";
+
+export const metadata = {
+  title: "Attendance Tracking Accuracy | Learnova",
+  description: "How Learnova achieves 99.8% attendance tracking accuracy.",
+};
+
+export default function AttendanceMetricsPage() {
+  return (
+    <main className="min-h-screen bg-[#0f172a] text-white px-6 py-20 max-w-5xl mx-auto">
+      <div className="mb-6">
+        <Link
+          href="/"
+          className="text-sm text-purple-400 hover:text-purple-300 transition-colors"
+        >
+          ← Back to Home
+        </Link>
+      </div>
+
+      <span className="text-xs font-semibold uppercase tracking-widest text-purple-400">
+        Platform Metrics
+      </span>
+      <h1 className="mt-3 text-4xl font-bold tracking-tight">
+        99.8% Attendance Tracking Accuracy
+      </h1>
+      <p className="mt-4 text-slate-400 text-lg max-w-2xl">
+        Learnova's AI Attendance Engine uses face recognition and multi-factor
+        validation to eliminate proxy attendance and manual errors. Detailed
+        benchmark data coming soon.
+      </p>
+
+      <div className="mt-12 rounded-xl border border-white/10 bg-white/5 p-8">
+        <p className="text-slate-400 text-sm">
+          Full methodology and institution-level data will be published here.
+          In the meantime, explore the{" "}
+          <Link href="/case-studies/impact" className="text-purple-400 underline hover:text-purple-300">
+            Impact Reports
+          </Link>{" "}
+          page.
+        </p>
+      </div>
+    </main>
+  );
+}

--- a/app/metrics/efficiency/page.js
+++ b/app/metrics/efficiency/page.js
@@ -1,0 +1,44 @@
+import Link from "next/link";
+
+export const metadata = {
+  title: "Admin Workload Reduction | Learnova",
+  description: "How Learnova reduces administrative workload by 45%.",
+};
+
+export default function EfficiencyMetricsPage() {
+  return (
+    <main className="min-h-screen bg-[#0f172a] text-white px-6 py-20 max-w-5xl mx-auto">
+      <div className="mb-6">
+        <Link
+          href="/"
+          className="text-sm text-purple-400 hover:text-purple-300 transition-colors"
+        >
+          ← Back to Home
+        </Link>
+      </div>
+
+      <span className="text-xs font-semibold uppercase tracking-widest text-purple-400">
+        Platform Metrics
+      </span>
+      <h1 className="mt-3 text-4xl font-bold tracking-tight">
+        45% Admin Workload Reduction
+      </h1>
+      <p className="mt-4 text-slate-400 text-lg max-w-2xl">
+        By automating attendance, compliance audits, and report generation,
+        Learnova gives administrators back significant time each week. Full
+        efficiency breakdown coming soon.
+      </p>
+
+      <div className="mt-12 rounded-xl border border-white/10 bg-white/5 p-8">
+        <p className="text-slate-400 text-sm">
+          Detailed workflow analysis and time-savings data will be published
+          here. In the meantime, explore the{" "}
+          <Link href="/case-studies/impact" className="text-purple-400 underline hover:text-purple-300">
+            Impact Reports
+          </Link>{" "}
+          page.
+        </p>
+      </div>
+    </main>
+  );
+}


### PR DESCRIPTION
## Description
Three links in the "Measurable Academic Operational Efficiency" section on the landing page were returning 404 — /metrics/attendance and /metrics/efficiency had no corresponding route pages in the Next.js App Router.
This PR creates the two missing stub pages with proper metadata, back navigation, and styling consistent with the existing codebase.

Fixes #2304

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] My changes generate no new warnings
- [x] I have performed a self-review of my own code
