### PR TITLE
fix: enforce profile match in /api/images and rollback orphan avatar uploads (closes #1795)

### DIFF
--- a/app/api/images/route.js
+++ b/app/api/images/route.js
@@ -80,7 +80,7 @@ export const POST = withErrorHandler(async (request) => {
       faceDescriptor,
     });
   } catch (error) {
-    await del(blobUrl).catch(() => {});
+    await Promise.resolve(del(blobUrl)).catch(() => {});
     throw error;
   }
 

--- a/components/__tests__/imagesRoute.test.js
+++ b/components/__tests__/imagesRoute.test.js
@@ -3,13 +3,16 @@ import { GET, POST } from "@/app/api/images/route";
 import { requireAuth } from "@/lib/rbac";
 import { connectDb } from "@/lib/mongodb";
 import { getUserProfile } from "@/lib/firebase-admin";
+import { NotFoundError } from "@/lib/errors";
 import {
   extractImageFileFromFormData,
   fetchAndValidateImage,
   getUserImageFromDb,
   updateUserImageInDb,
   uploadAvatarToBlob,
+  validateFaceDescriptor,
 } from "@/lib/images/imagesService";
+import { del } from "@vercel/blob";
 
 vi.mock("next/server", () => {
   class MockNextResponse {
@@ -46,6 +49,10 @@ vi.mock("@/lib/firebase-admin", () => ({
   getUserProfile: vi.fn(),
 }));
 
+vi.mock("@vercel/blob", () => ({
+  del: vi.fn(),
+}));
+
 vi.mock("@/lib/images/imagesService", () => ({
   extractImageFileFromFormData: vi.fn(),
   fetchAndValidateImage: vi.fn(),
@@ -63,6 +70,7 @@ vi.mock("@/lib/images/imagesService", () => ({
 describe("/api/images route orchestration", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    validateFaceDescriptor.mockReturnValue(null);
   });
 
   test("GET returns own image when requested id matches authenticated user", async () => {
@@ -120,7 +128,7 @@ describe("/api/images route orchestration", () => {
     const body = await response.json();
 
     expect(response.status).toBe(403);
-    expect(body.error.message).toBe("You can only view your own profile image");
+    expect(body.error).toBe("You can only view your own profile image");
   });
 
   test("GET allows admin to view any user's image", async () => {
@@ -201,7 +209,7 @@ describe("/api/images route orchestration", () => {
     const body = await response.json();
 
     expect(response.status).toBe(404);
-    expect(body.error.message).toBe("User not found");
+    expect(body.error).toBe("User not found");
   });
 
   test("POST orchestrates auth, file extraction, upload and DB update", async () => {
@@ -220,7 +228,10 @@ describe("/api/images route orchestration", () => {
     const req = {
       headers: { get: vi.fn() },
       formData: vi.fn().mockResolvedValue({
-        get: vi.fn().mockReturnValue(fakeFile),
+        get: vi.fn((key) => {
+          if (key === "faceDescriptor") return null;
+          return fakeFile;
+        }),
       }),
     };
 
@@ -240,6 +251,39 @@ describe("/api/images route orchestration", () => {
     expect(updateUserImageInDb).toHaveBeenCalledWith({
       firebaseUid: "firebase-uid-1",
       imageUrl: "https://public.blob.vercel-storage.com/avatar.jpg",
+      faceDescriptor: null,
     });
+  });
+
+  test("POST rolls back uploaded blob when Mongo profile is missing", async () => {
+    const fakeFile = {
+      type: "image/jpeg",
+      size: 1024,
+      arrayBuffer: vi.fn().mockResolvedValue(new ArrayBuffer(1024)),
+    };
+
+    requireAuth.mockResolvedValue({ uid: "firebase-uid-1" });
+    extractImageFileFromFormData.mockReturnValue(fakeFile);
+    uploadAvatarToBlob.mockResolvedValue({
+      blobUrl: "https://public.blob.vercel-storage.com/avatar.jpg",
+    });
+    updateUserImageInDb.mockRejectedValue(new NotFoundError("User profile not found"));
+
+    const req = {
+      headers: { get: vi.fn() },
+      formData: vi.fn().mockResolvedValue({
+        get: vi.fn((key) => {
+          if (key === "faceDescriptor") return null;
+          return fakeFile;
+        }),
+      }),
+    };
+
+    const response = await POST(req);
+    const body = await response.json();
+
+    expect(response.status).toBe(404);
+    expect(body.error).toBe("User profile not found");
+    expect(del).toHaveBeenCalledWith("https://public.blob.vercel-storage.com/avatar.jpg");
   });
 });

--- a/lib/images/__tests__/imagesService.test.js
+++ b/lib/images/__tests__/imagesService.test.js
@@ -156,6 +156,23 @@ describe("imagesService helpers", () => {
     );
   });
 
+  test("updateUserImageInDb throws when no Mongo profile matches firebase uid", async () => {
+    const updateOne = vi.fn().mockResolvedValue({ matchedCount: 0 });
+
+    connectDb.mockResolvedValue({
+      collection: vi.fn().mockReturnValue({
+        updateOne,
+      }),
+    });
+
+    await expect(
+      updateUserImageInDb({
+        firebaseUid: "missing-user",
+        imageUrl: "https://public.blob.vercel-storage.com/new.jpg",
+      })
+    ).rejects.toThrow("User profile not found");
+  });
+
   test("validateFaceDescriptor validates correct length and formats", () => {
     expect(validateFaceDescriptor(null)).toBeNull();
     expect(validateFaceDescriptor(undefined)).toBeNull();

--- a/lib/images/imagesService.js
+++ b/lib/images/imagesService.js
@@ -197,10 +197,16 @@ export async function updateUserImageInDb({ firebaseUid, imageUrl, faceDescripto
     updateDoc.$unset = { faceDescriptor: "" };
   }
 
-  await users.updateOne(
+  const result = await users.updateOne(
     { firebaseUid },
     updateDoc
   );
+
+  if (result.matchedCount === 0) {
+    throw new NotFoundError("User profile not found");
+  }
+
+  return result;
 }
 
 export function getImageResponseHeaders(contentType) {


### PR DESCRIPTION
## Description
This PR fixes a consistency bug in the avatar upload flow (`POST /api/images`).

Previously, avatar upload could return success even when no MongoDB user matched `firebaseUid` (`updateOne` with `matchedCount: 0`), which could leave uploaded blob files orphaned.

Fixes #1795
### Changes Made
- Enforced `matchedCount` validation in `updateUserImageInDb`:
  - throws `NotFoundError("User profile not found")` when no Mongo profile is matched.
- Kept avatar rollback reliable in route handler:
  - blob cleanup now uses a safe promise wrapper in the error path.
- Added/updated tests to lock behavior:
  - service test for `matchedCount: 0` failure.
  - route test verifying blob rollback when profile is missing.
  - adjusted route assertions to current API error response shape.

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:
- [X] My code follows the style guidelines of this project
- [X] My changes generate no new warnings
- [x] I have performed a self-review of my own code
