### PR TITLE
fix: reset LazyImage state when image source changes

### DIFF
--- a/components/LazyImage.jsx
+++ b/components/LazyImage.jsx
@@ -1,16 +1,30 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 
-export default function LazyImage({ src, alt, className = "", skeletonClassName = "", fallbackSrc = "/assets/default-fallback.png", ...props }) {
+export default function LazyImage({
+  src,
+  alt,
+  className = "",
+  skeletonClassName = "",
+  fallbackSrc = "/assets/default-fallback.png",
+  ...props
+}) {
   const [loaded, setLoaded] = useState(false);
   const [error, setError] = useState(false);
+
+  useEffect(() => {
+    setLoaded(false);
+    setError(false);
+  }, [src]);
 
   return (
     <div className={`relative overflow-hidden ${className}`}>
       {/* Loading Skeleton */}
       {!loaded && !error && (
-        <div className={`absolute inset-0 bg-slate-200 dark:bg-slate-800 animate-pulse ${skeletonClassName}`} />
+        <div
+          className={`absolute inset-0 bg-slate-200 dark:bg-slate-800 animate-pulse ${skeletonClassName}`}
+        />
       )}
 
       <img
@@ -18,7 +32,9 @@ export default function LazyImage({ src, alt, className = "", skeletonClassName 
         alt={alt}
         onLoad={() => setLoaded(true)}
         onError={() => setError(true)}
-        className={`w-full h-full object-cover transition-opacity duration-500 ease-in-out ${loaded ? "opacity-100" : "opacity-0"}`}
+        className={`w-full h-full object-cover transition-opacity duration-500 ease-in-out ${
+          loaded ? "opacity-100" : "opacity-0"
+        }`}
         {...props}
       />
     </div>


### PR DESCRIPTION

Fixes #2404 

## Description

This PR fixes an issue in the `LazyImage` component where the internal `loaded` and `error` states were not reset when the `src` prop changed.

### Changes Made

* Added a `useEffect` hook that listens for changes to the `src` prop.
* Reset `loaded` to `false` whenever a new image source is provided.
* Reset `error` to `false` whenever a new image source is provided.

### Why

Previously, the component reused stale state from the previous image. This could cause:

* The loading skeleton not to appear for newly requested images.
* The fallback image to remain visible even after switching to a valid image source.
* Incorrect loading and error behavior when image sources changed dynamically.

### Result

The component now correctly treats every new `src` value as a fresh image request, ensuring consistent loading indicators and proper fallback handling.

