### PR TITLE
fix(navbar): correct active link detection for nested routes (#2443)

### DIFF
--- a/components/Navbar.js
+++ b/components/Navbar.js
@@ -366,7 +366,7 @@ export function Navbar() {
                   key={item.href}
                   href={item.href}
                   label={item.label}
-                  isActive={pathname === item.href}
+                  isActive={isRouteActive(item.href)}
                 />
               ))}
             </div>


### PR DESCRIPTION
📌 Fix: Active Navbar Highlight (#2443)

Fixed an issue where active navigation links were not correctly highlighted for nested routes.

✅ Changes
Updated route matching logic to support nested paths using startsWith
Kept home route (/) as exact match
🎯 Result
/about/team now correctly highlights About
/activity/123 correctly highlights Activities
Improved navigation UX consistency