### PR TITLE
feat: add recent search history with local storage support

### DIFF
--- a/components/SearchModal.js
+++ b/components/SearchModal.js
@@ -40,6 +40,9 @@ export default function SearchModal({ isOpen, onClose }) {
   const [selectedCategory, setSelectedCategory] = useState("All");
   const [debouncedQuery, setDebouncedQuery] = useState(query);
 
+  const [recentSearches, setRecentSearches] = useState([]);
+  const [showRecentSearches, setShowRecentSearches] = useState(false);
+
   // Setup debounce timer for keystroke throttling (300ms delay)
   useEffect(() => {
     const handler = setTimeout(() => {
@@ -54,6 +57,14 @@ export default function SearchModal({ isOpen, onClose }) {
   const [selectedIndex, setSelectedIndex] = useState(0);
   const inputRef = useRef(null);
   const modalRef = useRef(null);
+
+  useEffect(() => {
+    const savedSearches = JSON.parse(
+      localStorage.getItem("recentSearches") || "[]"
+    );
+  
+    setRecentSearches(savedSearches);
+  }, []);
 
   const getDashboardLink = () => {
     if (!userProfile?.role) return "/profile";
@@ -145,7 +156,32 @@ export default function SearchModal({ isOpen, onClose }) {
     return () => document.removeEventListener("keydown", handleKeyDown);
   }, [isOpen, filteredItems, selectedIndex]);
 
+  const saveSearch = (searchTerm) => {
+    if (!searchTerm.trim()) return;
+  
+    const updated = [
+      searchTerm,
+      ...recentSearches.filter(
+        (item) => item.toLowerCase() !== searchTerm.toLowerCase()
+      ),
+    ].slice(0, 10);
+  
+    setRecentSearches(updated);
+  
+    localStorage.setItem(
+      "recentSearches",
+      JSON.stringify(updated)
+    );
+  };
+  
+  const clearRecentSearches = () => {
+    setRecentSearches([]);
+    localStorage.removeItem("recentSearches");
+  };
+
   const handleNavigate = (href) => {
+    saveSearch(query);
+  
     router.push(href);
     onClose();
   };
@@ -175,6 +211,10 @@ export default function SearchModal({ isOpen, onClose }) {
             type="text"
             placeholder="Search pages and actions..."
             value={query}
+            onFocus={() => setShowRecentSearches(true)}
+            onBlur={() => {
+              setTimeout(() => setShowRecentSearches(false), 200);
+            }}
             onChange={(e) => setQuery(e.target.value)}
             className="flex-1 bg-transparent text-white placeholder-white/40 focus:outline-none text-base"
           />
@@ -186,6 +226,38 @@ export default function SearchModal({ isOpen, onClose }) {
             <X className="h-4 w-4" />
           </button>
         </div>
+
+        {showRecentSearches &&
+          !query &&
+          recentSearches.length > 0 && (
+            <div className="px-4 py-3 border-b border-white/10">
+              <div className="flex items-center justify-between mb-2">
+                <span className="text-xs text-white/50">
+                  Recent Searches
+                </span>
+        
+                <button
+                  onClick={clearRecentSearches}
+                  className="text-xs text-red-400 hover:text-red-300"
+                >
+                  Clear All
+                </button>
+              </div>
+        
+              <div className="flex flex-wrap gap-2">
+                {recentSearches.map((search, index) => (
+                  <button
+                    key={index}
+                    onClick={() => setQuery(search)}
+                    className="px-3 py-1 rounded-full bg-white/10 text-xs text-white/70 hover:bg-white/20"
+                  >
+                    {search}
+                  </button>
+                ))}
+              </div>
+            </div>
+        )}
+
         {/* ==================== CATEGORY FILTER PILLS ==================== */}
         <div className="flex flex-wrap items-center gap-1.5 px-4 py-2 bg-slate-950/20 border-b border-white/5">
           {categoriesList.map((cat) => (


### PR DESCRIPTION
## Type of Change

* [x] New feature
* [ ] Bug fix
* [ ] Code refactor
* [ ] Documentation update

## Related Issue

Closes #2407 

## What This PR Does

This PR introduces a recent search history feature to the global search modal.

### Changes Made

* Added support for storing recent search queries in Local Storage.
* Display recent searches when the search input is focused.
* Allow users to quickly reuse previous searches by clicking on search history chips.
* Prevent duplicate search entries by moving existing searches to the top.
* Limit stored search history to the 10 most recent searches.
* Added a "Clear All" option to remove saved search history.

## Benefits

* Reduces repetitive typing for frequent users.
* Improves navigation efficiency.
* Provides quick access to previously used searches.
* Persists search history across browser sessions.

## Testing

* Verified that searches are saved after navigation.
* Verified that recent searches persist after page refresh.
* Verified that clicking a recent search restores the query.
* Verified that the "Clear All" button removes stored history.
* Verified that duplicate searches are not stored multiple times.