### PR TITLE
Performance: Cap and trim conversation history before sending to Groq

### DIFF
--- a/app/api/conversations/route.js
+++ b/app/api/conversations/route.js
@@ -68,6 +68,22 @@ export async function POST(request) {
       });
     }
 
+    // 3b. Cap conversation history to prevent unbounded token growth
+    const MAX_MESSAGES = 20;
+    const MAX_TOTAL_CHARS = 15000;
+    let trimmedMessages = messages.slice(-MAX_MESSAGES);
+    let totalChars = trimmedMessages.reduce((sum, m) => sum + ((m.text || m.content || "").length), 0);
+    if (totalChars > MAX_TOTAL_CHARS) {
+      // Keep the last message (current query) and drop from earlier messages until under limit
+      const lastMsg = trimmedMessages[trimmedMessages.length - 1];
+      const earlier = trimmedMessages.slice(0, -1);
+      while (earlier.length > 0 && totalChars > MAX_TOTAL_CHARS) {
+        const dropped = earlier.shift();
+        totalChars -= (dropped.text || dropped.content || "").length;
+      }
+      trimmedMessages = [...earlier, lastMsg];
+    }
+
     // 4. Content Safety and Prompt Injection Interception
     const lastMsgObj = messages[messages.length - 1];
     const latestMessage = lastMsgObj?.text || lastMsgObj?.content || "";
@@ -119,9 +135,10 @@ export async function POST(request) {
 
     // 5. Structure Context Array & Inject Grounding Guardrails
     const sanitizedInput = sanitizeMessage(trimmedMessage);
-    const processedMessages = messages.map((msg, index) => {
+    const processedMessages = trimmedMessages.map((msg, index) => {
       const isBotMessage = msg.isBot || msg.role === "assistant";
-      const rawText = index === messages.length - 1 ? sanitizedInput : (msg.text || msg.content || "");
+      const isLast = index === trimmedMessages.length - 1;
+      const rawText = isLast ? sanitizedInput : (msg.text || msg.content || "");
       
       return {
         role: isBotMessage ? "assistant" : "user",


### PR DESCRIPTION
Fixes #2477

Adds a 20-message cap and 15KB character limit to conversation history sent to Groq. Older messages are dropped first, keeping the latest user query intact.