### PR TITLE
Security: Stop trusting spoofable IP headers in role setup rate limiting

### DIFF
--- a/app/api/auth/set-role/route.js
+++ b/app/api/auth/set-role/route.js
@@ -16,8 +16,7 @@ export const POST = withValidation(
   withErrorHandler(async (request, data) => {
     const decodedToken = await requireAuth(request);
 
-    const ip = request.headers.get("x-forwarded-for") || "127.0.0.1";
-    const rateLimitResult = await checkRateLimit(`set_role_${ip}_${decodedToken.uid}`);
+    const rateLimitResult = await checkRateLimit(`set_role_${decodedToken.uid}`);
     if (!rateLimitResult.allowed) {
       throw new AppError("Too many attempts. Please try again later.", 429);
     }


### PR DESCRIPTION
Fixes #2473

Removes \x-forwarded-for\ from the rate limit key in the role setup endpoint. The key now uses only the authenticated UID, preventing header spoofing bypass.