### PR TITLE
Security: Restrict institute settings fields to privileged users

### DIFF
--- a/app/api/settings/route.js
+++ b/app/api/settings/route.js
@@ -122,6 +122,14 @@ export const PATCH = withErrorHandler(async (request) => {
   }
 
   const { userId: bodyUserId, ...settings } = parsed.data;
+
+  // Restrict institute-level settings to privileged roles only
+  if (settings.institute) {
+    const profile = await getUserProfile(decodedToken.uid);
+    if (!profile || !["admin", "institute"].includes(profile.role)) {
+      throw new ForbiddenError("Forbidden: Only institute admins can modify institute settings.");
+    }
+  }
   
   let targetUserId = decodedToken.uid;
   let isOperatorAdmin = false;


### PR DESCRIPTION
Fixes #2470

Adds role check before allowing writes to the \institute\ subdocument in settings. Only users with \dmin\ or \institute\ role can modify institute-level settings.