### PR TITLE
DevOps: Stop deleting package-lock in PR checks

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -20,9 +20,7 @@ jobs:
           cache: 'npm'
 
       - name: 📚 Install dependencies
-        run: |
-          rm -rf node_modules package-lock.json
-          npm install
+        run: npm ci
 
       - name: 🔍 Check for secrets in files
         run: echo "✅ Using GitHub's native secret scanning"


### PR DESCRIPTION
Fixes #2511

Replaces \m -rf node_modules package-lock.json && npm install\ with \
pm ci\ to preserve deterministic dependency resolution.