### PR TITLE
DevOps: Stop deleting package-lock in main CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,9 +28,7 @@ jobs:
           cache: npm
 
       - name: 📚 Install dependencies
-        run: |
-          rm -rf node_modules package-lock.json
-          npm install --legacy-peer-deps
+        run: npm ci
 
       - name: 🧪 Run unit tests
         run: npm test


### PR DESCRIPTION
Fixes #2510

Replaces \m -rf node_modules package-lock.json && npm install --legacy-peer-deps\ with \
pm ci\ to preserve deterministic dependency resolution.