### PR TITLE
Performance: Add limits to user activity history reads

### DIFF
--- a/app/api/activities/route.js
+++ b/app/api/activities/route.js
@@ -36,6 +36,7 @@ export const GET = withErrorHandler(async (request) => {
     .collection("activities")
     .where("userId", "==", decodedToken.uid)
     .orderBy("timestamp", "desc")
+    .limit(100)
     .get();
 
   const activities = snapshot.docs.map((doc) => ({


### PR DESCRIPTION
Fixes #2507

Adds \.limit(100)\ to the Firestore query in activities GET handler to prevent unbounded reads.