### PR TITLE
Security: Enforce institute boundaries in attendance heatmap queries

### DIFF
--- a/app/api/attendance/heatmap/route.js
+++ b/app/api/attendance/heatmap/route.js
@@ -1,7 +1,7 @@
 import { withErrorHandler } from "@/lib/error-handler";
 import { ForbiddenError } from "@/lib/errors";
 import { getFirestore } from "firebase-admin/firestore";
-import { initFirebaseAdmin } from "@/lib/firebase-admin";
+import { initFirebaseAdmin, getUserProfile } from "@/lib/firebase-admin";
 import { checkRateLimit } from "@/lib/rateLimit";
 import { requireAuth } from "@/lib/rbac";
 import { fail, success } from "@/lib/api-response";
@@ -20,6 +20,18 @@ export const GET = withErrorHandler(async (request) => {
     const role = decodedToken.role;
     if (role !== "admin" && role !== "teacher") {
       throw new ForbiddenError("Forbidden: Cannot query attendance for another user");
+    }
+    // Enforce institute boundaries: teacher can only query users within their institute
+    if (role !== "admin") {
+      const callerProfile = await getUserProfile(decodedToken.uid);
+      const targetProfile = await getUserProfile(requestedUserId);
+      if (
+        !callerProfile?.instituteId ||
+        !targetProfile?.instituteId ||
+        callerProfile.instituteId !== targetProfile.instituteId
+      ) {
+        throw new ForbiddenError("Forbidden: Cannot query attendance for users outside your institute");
+      }
     }
     targetUserId = requestedUserId;
   } else {


### PR DESCRIPTION
Fixes #2504

Adds institute boundary check when teachers query another user's attendance. Non-admin callers must share the same \instituteId\ with the target user.