### PR TITLE
DevOps: Add concurrency control to contributor sync workflow

### DIFF
--- a/.github/workflows/update-contributors.yml
+++ b/.github/workflows/update-contributors.yml
@@ -7,6 +7,10 @@ on:
     - cron: '0 2 * * *'   # daily at 02:00 UTC
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   update:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Fixes #2532

Adds concurrency group with cancel-in-progress to prevent concurrent contributor sync runs from racing.