### PR TITLE
Performance: Add indexes for pending_operations hot paths

### DIFF
--- a/lib/transactionCoordinator.js
+++ b/lib/transactionCoordinator.js
@@ -3,6 +3,25 @@ import { initializeFirebase } from "@/lib/firebase-admin";
 import admin from "firebase-admin";
 import { logger } from "@/lib/logger";
 
+let indexEnsured = false;
+
+async function ensureIndexes() {
+  if (indexEnsured) return;
+  try {
+    const db = await connectDb();
+    const col = db.collection("pending_operations");
+    await Promise.all([
+      col.createIndex({ operationId: 1 }, { unique: true, sparse: true }),
+      col.createIndex({ status: 1, updatedAt: 1 }),
+      col.createIndex({ status: 1, createdAt: 1 }),
+      col.createIndex({ createdAt: 1 }, { expireAfterSeconds: 30 * 24 * 60 * 60 }),
+    ]);
+    indexEnsured = true;
+  } catch (err) {
+    logger.warn("[TransactionCoordinator] Failed to ensure indexes:", err.message);
+  }
+}
+
 /**
  * TransactionCoordinator
  *
@@ -276,6 +295,7 @@ export async function executeSaga({ operationType, uid, steps }) {
 export async function findExistingOperation(idempotencyKey) {
   try {
     const db = await connectDb();
+    await ensureIndexes();
     return await db.collection("pending_operations").findOne({
       operationId: idempotencyKey,
       status: "completed",
@@ -322,6 +342,7 @@ export async function markIdempotent(idempotencyKey, result) {
 export async function findStaleOperations(timeoutMs = 300000) {
   try {
     const db = await connectDb();
+    await ensureIndexes();
     const cutoff = new Date(Date.now() - timeoutMs);
     return await db
       .collection("pending_operations")
@@ -342,6 +363,7 @@ export async function findStaleOperations(timeoutMs = 300000) {
 export async function cleanupOldOperations(maxAgeMs = 7 * 24 * 60 * 60 * 1000) {
   try {
     const db = await connectDb();
+    await ensureIndexes();
     const cutoff = new Date(Date.now() - maxAgeMs);
     const result = await db
       .collection("pending_operations")


### PR DESCRIPTION
Fixes #2530

Adds ensureIndexes() bootstrapper that creates indexes on operationId, status+updatedAt, status+createdAt, and createdAt TTL for the pending_operations collection.