### PR TITLE
Security: Remove the global attendance passcode fallback

### DIFF
--- a/app/api/attendance/settings/route.js
+++ b/app/api/attendance/settings/route.js
@@ -46,14 +46,11 @@ export const GET = withErrorHandler(async (request) => {
     .get();
 
   if (!settingsDoc.exists) {
-    // Fallback for existing data
-    settingsDoc = await db
-      .collection("attendance_settings")
-      .doc("current_settings")
-      .get();
+    return NextResponse.json(
+      { error: "Attendance settings not configured" },
+      { status: 404 }
+    );
   }
-
-  if (!settingsDoc.exists) {
     return NextResponse.json(
       { error: "Attendance settings not configured" },
       { status: 404 }

--- a/app/api/attendance/validate-passcode/route.js
+++ b/app/api/attendance/validate-passcode/route.js
@@ -70,14 +70,11 @@ export const POST = withErrorHandler(async (request) => {
     .get();
 
   if (!settingsDoc.exists) {
-    // Fallback for existing data
-    settingsDoc = await db
-      .collection("attendance_settings")
-      .doc("current_settings")
-      .get();
+    return NextResponse.json(
+      { valid: false, error: "Attendance settings not configured" },
+      { status: 404 }
+    );
   }
-
-  if (!settingsDoc.exists) {
     return NextResponse.json(
       { valid: false, error: "Attendance settings not configured" },
       { status: 404 }


### PR DESCRIPTION
Fixes #2526

Removes fallback to \ttendance_settings/current_settings\ global document in both passcode validation and settings GET. Returns 404 when tenant-specific doc is missing.