### PR TITLE
fix: sync attendance check-ins to MongoDB attendance collection

### DIFF
--- a/app/api/attendance/record/route.js
+++ b/app/api/attendance/record/route.js
@@ -8,6 +8,8 @@ import { getLocalDateKey } from "@/lib/dateUtils";
 import { checkRateLimit } from "@/lib/rateLimit";
 import { AppError } from "@/lib/errors";
 import { executeSaga } from "@/lib/transactionCoordinator";
+import { connectDb } from "@/lib/mongodb";
+
 
 export const POST = withErrorHandler(async (request) => {
   const decodedToken = await requireAuth(request);
@@ -90,6 +92,36 @@ export const POST = withErrorHandler(async (request) => {
           });
         },
         compensate: null, // Attendance writes are append-only
+      },
+      {
+        name: "write_mongodb_attendance",
+        execute: async () => {
+          if (alreadyRecorded) {
+            return;
+          }
+          const mongoDB = await connectDb();
+          await mongoDB.collection("attendance").updateOne(
+            { userId, date: normalizedDate },
+            {
+              $set: {
+                userId,
+                studentName: resolvedName,
+                email: resolvedEmail,
+                instituteId,
+                timestamp: new Date(),
+                date: normalizedDate,
+                status: "present",
+                confidenceScore: normalizedConfidence,
+                offlineSynced: false,
+              },
+            },
+            { upsert: true }
+          );
+        },
+        compensate: async () => {
+          const mongoDB = await connectDb();
+          await mongoDB.collection("attendance").deleteOne({ userId, date: normalizedDate });
+        },
       },
       {
         name: "award_xp",

--- a/app/api/attendance/record/route.test.js
+++ b/app/api/attendance/record/route.test.js
@@ -46,6 +46,19 @@ vi.mock("@/lib/dateUtils", () => ({
   getLocalDateKey: vi.fn(() => "2026-05-25"),
 }));
 
+vi.mock("@/lib/mongodb", () => {
+  const mockDb = {
+    collection: vi.fn(() => ({
+      updateOne: vi.fn().mockResolvedValue({}),
+      deleteOne: vi.fn().mockResolvedValue({}),
+    })),
+  };
+  return {
+    connectDb: vi.fn().mockResolvedValue(mockDb),
+  };
+});
+
+
 vi.mock("firebase-admin/firestore", () => ({
   getFirestore: vi.fn(),
   FieldValue: {

--- a/app/api/attendance/sync/route.js
+++ b/app/api/attendance/sync/route.js
@@ -8,7 +8,9 @@ import { checkRateLimit } from "@/lib/rateLimit";
 import { AppError } from "@/lib/errors";
 import { awardXp } from "@/lib/gamification-service";
 import { executeSaga } from "@/lib/transactionCoordinator";
+import { connectDb } from "@/lib/mongodb";
 import { z } from "zod";
+
 
 export const dynamic = "force-dynamic";
 
@@ -179,6 +181,34 @@ async function handleSync(request) {
             });
           },
           compensate: null, // Attendance writes are append-only; no rollback needed
+        },
+        {
+          name: "write_mongodb_attendance",
+          execute: async () => {
+            const mongoDB = await connectDb();
+            await mongoDB.collection("attendance").updateOne(
+              { userId: decodedToken.uid, date: recordDate },
+              {
+                $set: {
+                  userId: decodedToken.uid,
+                  studentName: serverIdentity.studentName,
+                  email: serverIdentity.email,
+                  instituteId,
+                  timestamp: new Date(record.queuedAt),
+                  date: recordDate,
+                  status: "present",
+                  confidenceScore: normalizedConfidence,
+                  offlineSynced: true,
+                  queuedAt: new Date(record.queuedAt),
+                },
+              },
+              { upsert: true }
+            );
+          },
+          compensate: async () => {
+            const mongoDB = await connectDb();
+            await mongoDB.collection("attendance").deleteOne({ userId: decodedToken.uid, date: recordDate });
+          },
         },
         {
           name: "award_xp",

--- a/package-lock.json
+++ b/package-lock.json
@@ -73,8 +73,8 @@
         "@testing-library/user-event": "^14.6.1",
         "@types/winston": "^2.4.4",
         "@vitejs/plugin-react": "^4.3.4",
-        "@vitest/coverage-v8": "^3.2.3",
-        "@vitest/ui": "^3.2.3",
+        "@vitest/coverage-v8": "3.2.4",
+        "@vitest/ui": "3.2.4",
         "eslint": "^10.4.0",
         "identity-obj-proxy": "^3.0.0",
         "jest": "^30.4.2",
@@ -83,7 +83,7 @@
         "postinstall-postinstall": "^2.1.0",
         "tailwindcss": "^4",
         "tw-animate-css": "^1.3.8",
-        "vitest": "^3.2.3"
+        "vitest": "3.2.4"
       }
     },
     "node_modules/@adobe/css-tools": {


### PR DESCRIPTION
## Description
This PR resolves Bug 2, where student attendance check-ins were only being written to Firestore (`attendance_records` collection). Because the nightly risk scoring cron job (`app/api/cron/attendance-risk/route.js`), low attendance warnings cron job (`app/api/cron/attendance-warnings/route.js`), and teacher analytics risk endpoint (`app/api/analytics/attendance-risk/route.js`) all aggregate data from MongoDB's `attendance` collection, the collection remained empty, breaking all dependent analytical dashboards and notification utilities in production.
## Changes Made
1. **Online Check-in Sync:** Updated `app/api/attendance/record/route.js` to import `connectDb` and added a `write_mongodb_attendance` step to the transactional saga to upsert online check-in events to MongoDB.
2. **Offline Batch Sync:** Updated `app/api/attendance/sync/route.js` to also import `connectDb` and insert a corresponding `write_mongodb_attendance` step to synchronize flushed offline check-ins to MongoDB.
3. **Database Mocking:** Configured a local mock wrapper for the `@/lib/mongodb` module in `app/api/attendance/record/route.test.js` to prevent tests from attempting live database connections.
## Verification
- Ran the full local test suite:
  ```bash
  npm run test