### PR TITLE
[Security] Add auth rejection tests for conversations endpoint and document DEV_BYPASS_AUTH opt-in

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,3 +36,9 @@ NEXT_PUBLIC_EMAILJS_USER_ID=your_user_id_here
 # ─── Content Security Policy ────────────────────────────────
 # Optional: Set a URL to receive CSP violation reports.
 # CSP_REPORT_URL=https://your-csp-endpoint.example.com/report
+
+# ─── Development Auth Bypass (OPT-IN ONLY, never use in production) ──
+# WARNING: Only set this to "true" in local development environments.
+# This bypasses Firebase token validation for AI API endpoints.
+# Never set this in production or preview deployments.
+# DEV_BYPASS_AUTH=true

--- a/app/api/conversations/__tests__/route.test.js
+++ b/app/api/conversations/__tests__/route.test.js
@@ -1,0 +1,77 @@
+import { POST } from "@/app/api/conversations/route";
+import { requireAuth } from "@/lib/rbac";
+import { checkRateLimit } from "@/lib/rateLimit";
+import { detectInjection } from "@/utils/promptGuard";
+
+vi.mock("@/lib/rbac", () => ({
+  requireAuth: vi.fn(),
+}));
+
+vi.mock("@/lib/rateLimit", () => ({
+  checkRateLimit: vi.fn(),
+}));
+
+vi.mock("@/utils/promptGuard", () => ({
+  detectInjection: vi.fn(),
+  sanitizeMessage: vi.fn((msg) => msg),
+}));
+
+vi.mock("@/services/ai-agent/intentparser", () => ({
+  parseUserIntent: vi.fn().mockResolvedValue(null),
+}));
+
+const createMockRequest = (headers, body) => ({
+  headers: {
+    get: (name) => headers[name.toLowerCase()] || null,
+  },
+  json: vi.fn().mockResolvedValue(body),
+  text: vi.fn().mockResolvedValue(JSON.stringify(body)),
+});
+
+describe("POST /api/conversations - Auth Security", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    requireAuth.mockReset();
+    checkRateLimit.mockResolvedValue({ allowed: true, remaining: 9 });
+    detectInjection.mockReturnValue({ isInjection: false });
+  });
+
+  test("rejects unauthenticated request with 401 when requireAuth throws", async () => {
+    requireAuth.mockRejectedValue(new Error("Unauthorized"));
+
+    const req = createMockRequest({}, { messages: [{ text: "Hello" }] });
+    const response = await POST(req);
+    const body = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(body.error).toBe("Unauthorized");
+  });
+
+  test("rejects request with invalid auth token", async () => {
+    requireAuth.mockRejectedValue(new Error("Unauthorized"));
+
+    const req = createMockRequest(
+      { authorization: "Bearer invalid-token" },
+      { messages: [{ text: "Hello" }] }
+    );
+    const response = await POST(req);
+    const body = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(body.error).toBe("Unauthorized");
+  });
+
+  test("accepts valid authenticated request", async () => {
+    requireAuth.mockResolvedValue({ uid: "user-123", sub: "user-123" });
+    checkRateLimit.mockResolvedValue({ allowed: true, remaining: 9 });
+    detectInjection.mockReturnValue({ isInjection: false });
+
+    const req = createMockRequest(
+      { authorization: "Bearer valid-token" },
+      { messages: [{ role: "user", content: "Hello" }] }
+    );
+    const response = await POST(req);
+
+    expect(response.status).toBe(200);
+  });
+});


### PR DESCRIPTION
## Description

Adds auth rejection tests for the conversations streaming endpoint and documents the DEV_BYPASS_AUTH environment variable as an explicit opt-in safety pattern.

## Changes

1. **New test file:** `app/api/conversations/__tests__/route.test.js`
   - Verifies 401 Unauthorized when requireAuth throws (no token)
   - Verifies 401 with invalid bearer token
   - Verifies 200 for valid authenticated requests

2. **Updated `.env.example`:**
   - Documented DEV_BYPASS_AUTH environment variable with explicit warnings
   - Pattern prevents silent auth bypass via NODE_ENV checks

## Why

The conversations endpoint previously had a silent dev-mode auth bypass that fell back to a hardcoded mock userId when NODE_ENV was "development". While this was fixed upstream with requireAuth(), this PR adds:
- Test coverage ensuring auth rejection works correctly
- An explicit documented opt-in pattern (DEV_BYPASS_AUTH) so any future dev bypass requires a conscious env var set, not a silent NODE_ENV check

Fixes #2569
