### PR TITLE
fix: redirect unauthenticated users during activity enrollment

### DIFF
--- a/app/activity/page.js
+++ b/app/activity/page.js
@@ -316,7 +316,7 @@ export default function ActivityPage() {
 
   const handleEnrollActivity = async (activity) => {
     if (!user) {
-      toast.error("Please login to enroll.");
+      router.push("/auth");
       return;
     }
 


### PR DESCRIPTION
## Summary

This PR improves the activity enrollment experience by redirecting unauthenticated users directly to the authentication page when they attempt to enroll.

## Changes Made

* Updated activity enrollment handler
* Added automatic navigation to `/auth` for unauthenticated users
* Prevented enrollment execution before authentication
* Preserved existing enrollment behavior for authenticated users
## Fixes #2580 
## Benefits

* Creates a smoother enrollment flow
* Reduces confusion for new users
* Provides a clear path to authentication
* Improves overall user experience

## Testing

* Verified unauthenticated users are redirected to `/auth`
* Verified authenticated users can enroll successfully
* Confirmed no regressions in activity enrollment behavior
* Tested navigation flow locally
