### PR TITLE
[FIX]: Move google site verification token to environment variable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -33,6 +33,12 @@ NEXT_PUBLIC_EMAILJS_SERVICE_ID=your_service_id_here
 NEXT_PUBLIC_EMAILJS_TEMPLATE_ID=your_template_id_here
 NEXT_PUBLIC_EMAILJS_USER_ID=your_user_id_here
 
+# ─── Google Search Console ────────────────────────────────
+# Ownership verification token from Google Search Console.
+# Found at: Search Console → Settings → Ownership verification → HTML tag.
+# Safe to leave empty in local development (SEO meta tag will be omitted).
+NEXT_PUBLIC_GOOGLE_SITE_VERIFICATION=your_token_here
+
 # ─── Content Security Policy ────────────────────────────────
 # Optional: Set a URL to receive CSP violation reports.
 # CSP_REPORT_URL=https://your-csp-endpoint.example.com/report

--- a/app/layout.js
+++ b/app/layout.js
@@ -158,7 +158,7 @@ export const metadata = {
     images: ["/og-image.jpg"],
   },
   other: {
-    "google-site-verification": "3qjYnT7GW81-zwJBwv3wJABvxbiSOgDyAlTCKxh9nEs",
+    "google-site-verification": process.env.NEXT_PUBLIC_GOOGLE_SITE_VERIFICATION ?? "",
   },
 };
 

--- a/lib/seo/siteMetadata.js
+++ b/lib/seo/siteMetadata.js
@@ -78,6 +78,6 @@ export const metadata = {
     apple: "/icons/apple-touch-icon.png",
   },
   verification: {
-    google: "3qjYnT7GW81-zwJBwv3wJABvxbiSOgDyAlTCKxh9nEs",
+    google: process.env.NEXT_PUBLIC_GOOGLE_SITE_VERIFICATION ?? "",
   },
 };


### PR DESCRIPTION
## Description

Removes the hardcoded Google Search Console verification token from version-controlled source and replaces it with the `NEXT_PUBLIC_GOOGLE_SITE_VERIFICATION` environment variable.

**Changes:**
- `app/layout.js` — replace hardcoded token string with `process.env.NEXT_PUBLIC_GOOGLE_SITE_VERIFICATION ?? ''`
- `lib/seo/siteMetadata.js` — fix same token in `verification.google` field (second instance found during safety scan; currently unused module but patched for consistency and to prevent future regression)
- `.env.example` — document the new variable with section header, where-to-find instructions, and dev-safety note

The nullish coalescing fallback (`''`) ensures the meta tag is omitted gracefully in local development when the variable is not set, rather than rendering a blank verification tag.

**Security:** eliminates token ownership cloning risk for repository forks and removes GSC account fingerprinting from public source history.

Closes #2599 

---

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

---

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My changes generate no new warnings
- [x] I have performed a self-review of my own code