### PR TITLE
[FIX]: secure development mock authentication flow

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -37,8 +37,13 @@ NEXT_PUBLIC_EMAILJS_USER_ID=your_user_id_here
 # Optional: Set a URL to receive CSP violation reports.
 # CSP_REPORT_URL=https://your-csp-endpoint.example.com/report
 
-# ─── Development Auth Bypass (OPT-IN ONLY, never use in production) ──
-# WARNING: Only set this to "true" in local development environments.
-# This bypasses Firebase token validation for AI API endpoints.
-# Never set this in production or preview deployments.
-# DEV_BYPASS_AUTH=true
+# ─── Development Mock Authentication (OPT-IN ONLY) ──────────
+# Enables mock authentication when Firebase credentials are absent in local dev.
+# Requires BOTH: NODE_ENV=development AND this flag set to "true".
+#
+# When enabled: loginWithGoogle() returns a simulated user without real Firebase.
+# When disabled (default): missing Firebase credentials cause auth to fail normally.
+#
+# ⚠️  WARNING: NEVER set this to "true" on staging, preview, or production.
+# ⚠️  Setting this on any deployed environment is a critical security risk.
+# NEXT_PUBLIC_ENABLE_DEV_MOCK_AUTH=false

--- a/app/activity/[id]/page.js
+++ b/app/activity/[id]/page.js
@@ -19,7 +19,7 @@ import {
 } from "lucide-react";
 import ShareButton from "@/components/ui/ShareButton";
 import toast from "react-hot-toast";
-import { db } from "@/lib/firebaseConfig";
+import { db, isMockAuthMode, MOCK_USER } from "@/lib/firebaseConfig";
 import { doc, getDoc } from "firebase/firestore";
 import { useAuth } from "@/hooks/useAuth";
 import { updateActivityProgress } from "@/services/activityService";
@@ -82,16 +82,16 @@ const Confetti = () => {
   );
 };
 
-const MOCK_USER = { uid: "mock-student-uid-947", email: "mock.student@learnova.edu" };
-
 export default function ActivityGame() {
   const params = useParams();
   const router = useRouter();
   const { user: realUser, loading: authLoading } = useAuth();
 
-  // Temporary local development-only authentication bypass for offline testing
-  const isDev = process.env.NODE_ENV === "development";
-  const user = realUser || (isDev ? MOCK_USER : null);
+  // Development-only authentication bypass — requires explicit opt-in.
+  // Set NEXT_PUBLIC_ENABLE_DEV_MOCK_AUTH=true in .env.local to enable.
+  // Uses the centralized MOCK_USER from lib/firebaseConfig (single source of truth).
+  // NEVER set the opt-in flag on staging, preview, or production deployments.
+  const user = realUser || (isMockAuthMode ? MOCK_USER : null);
 
   const [mounted, setMounted] = useState(false);
   const [activityData, setActivityData] = useState(null);

--- a/components/CommentSection.jsx
+++ b/components/CommentSection.jsx
@@ -8,15 +8,10 @@ import {
   normalizeStoredComments,
 } from "@/lib/commentStorage";
 import { safeLocalStorageGet, safeLocalStorageSet } from "@/lib/storage";
+import { useAuth } from "@/hooks/useAuth";
 
-// REMOVE db AND useAuth IMPORTS FOR NOW TO PREVENT CRASHES
 const CommentSection = ({ noticeId }) => {
-  // 1. FAKE USER BYPASS: This pretends you are logged in as a Teacher or Student
-  const mockUser = {
-    uid: "mock_user_123",
-    displayName: "Prem Shaw",
-    role: "Contributor" // Displays a premium-looking badge next to your name
-  };
+  const { user } = useAuth();
 
   const [comments, setComments] = useState([]);
   const [newComment, setNewComment] = useState("");
@@ -56,8 +51,8 @@ const CommentSection = ({ noticeId }) => {
 
     const freshComment = {
       id: `comment_${Date.now()}`,
-      userName: mockUser.displayName,
-      userRole: mockUser.role,
+      userName: user?.displayName || "Anonymous",
+      userRole: user?.role || "Member",
       text: newComment.trim(),
     };
 
@@ -138,7 +133,7 @@ const CommentSection = ({ noticeId }) => {
         />
         <button
           type="submit"
-          disabled={!newComment.trim()}
+          disabled={!newComment.trim() || !user}
           className="absolute right-2 top-1/2 -translate-y-1/2 rounded-xl bg-indigo-500 p-1.5 text-white transition hover:bg-indigo-600 disabled:bg-slate-300 dark:disabled:bg-slate-800 disabled:text-slate-400 dark:disabled:text-slate-500"
         >
           <Send className="h-3.5 w-3.5" />

--- a/lib/firebaseConfig.js
+++ b/lib/firebaseConfig.js
@@ -53,13 +53,27 @@ const missingFirebaseConfig = requiredFirebaseConfig.filter((key) => {
 
 export const isFirebaseConfigured = missingFirebaseConfig.length === 0;
 
-export const isMockAuthMode = !isFirebaseConfigured && process.env.NODE_ENV === "development";
+// Mock authentication mode requires ALL THREE conditions to be true:
+// 1. Firebase credentials are missing (not configured)
+// 2. Running in local development (NODE_ENV === "development")
+// 3. Developer has explicitly opted in (NEXT_PUBLIC_ENABLE_DEV_MOCK_AUTH === "true")
+//
+// This prevents accidental mock auth activation on staging/preview deployments
+// where Firebase env vars may be absent but real users are accessing the app.
+// NEVER set NEXT_PUBLIC_ENABLE_DEV_MOCK_AUTH=true in production or preview environments.
+export const isMockAuthMode =
+  !isFirebaseConfigured &&
+  process.env.NODE_ENV === "development" &&
+  process.env.NEXT_PUBLIC_ENABLE_DEV_MOCK_AUTH === "true";
 
+// Central mock user definition — single source of truth for all dev mock auth.
+// Only consumed when isMockAuthMode is true.
+// Do NOT create additional MOCK_USER objects in page components or services.
 export const MOCK_USER = {
   uid: "mock_developer_user_123",
   email: "test-contributor@learnova.com",
   displayName: "Learnova Contributor",
-  photoURL: "https://api.dicebear.com/7.x/bottts/svg?seed=learnova", 
+  photoURL: "https://api.dicebear.com/7.x/bottts/svg?seed=learnova",
   emailVerified: true,
   role: "student", // Adapts gracefully to view dashboard route layers
 };


### PR DESCRIPTION
## Description

Eliminates automatically-activated authentication bypasses and hardcoded mock user
credentials from source code, replacing them with a single explicit opt-in mechanism.

**Problems fixed:**
- `isMockAuthMode` auto-triggered on any `NODE_ENV=development` environment with
  missing Firebase credentials — including staging and CI preview deployments
- Duplicate `MOCK_USER` in `app/activity/[id]/page.js` with different hardcoded
  credentials (`mock-student-uid-947` / `mock.student@learnova.edu`), inconsistent
  with the centralized object in `lib/firebaseConfig.js`
- `CommentSection.jsx` always-active `mockUser` (`uid: mock_user_123`, display name:
  `"Prem Shaw"`) active in **all** environments, not just development
- Activity page auth bypass gated only on `NODE_ENV` — no explicit opt-in required

**Changes:**
- `lib/firebaseConfig.js` — `isMockAuthMode` now requires all three conditions:
  `!isFirebaseConfigured && NODE_ENV=development && NEXT_PUBLIC_ENABLE_DEV_MOCK_AUTH=true`
- `app/activity/[id]/page.js` — removed local duplicate `MOCK_USER`; imports
  centralized `isMockAuthMode` and `MOCK_USER` from `firebaseConfig`
- `components/CommentSection.jsx` — removed hardcoded `mockUser`; added `useAuth`
  integration; submit disabled when no user is authenticated
- `.env.example` — documents `NEXT_PUBLIC_ENABLE_DEV_MOCK_AUTH` with warnings

**Verified:** `grep` for `mock-student-uid-947`, `mock.student@learnova.edu`,
`mock_user_123` returns **zero matches** across the entire codebase.

Closes #2601 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My changes generate no new warnings
- [x] I have performed a self-review of my own code