### PR TITLE
fix: correct MongoDB pagination termination in reconciliation job

### DIFF
--- a/app/api/admin/reconciliation-job/route.js
+++ b/app/api/admin/reconciliation-job/route.js
@@ -82,21 +82,23 @@ export const POST = withErrorHandler(async (request) => {
     const mongoUids = new Set();
     const mongoUsersMap = new Map();
     let mongoCursor = null;
+    let lastBatchSize = 0;
     do {
-      let mongoQuery = mongoDB.collection("users").find({}).limit(PAGE_SIZE);
+      let mongoQuery = mongoDB.collection("users").find({}).sort({ _id: 1 }).limit(PAGE_SIZE);
       if (mongoCursor) {
         mongoQuery = mongoQuery.skip(mongoCursor);
       }
       const mongoBatch = await mongoQuery.toArray();
-      if (mongoBatch.length === 0) break;
+      lastBatchSize = mongoBatch.length;
+      if (lastBatchSize === 0) break;
       mongoBatch.forEach((u) => {
         if (u.firebaseUid) {
           mongoUids.add(u.firebaseUid);
           mongoUsersMap.set(u.firebaseUid, u);
         }
       });
-      mongoCursor = (mongoCursor || 0) + mongoBatch.length;
-    } while (mongoCursor && mongoUids.size === mongoCursor);
+      mongoCursor = (mongoCursor || 0) + lastBatchSize;
+    } while (lastBatchSize === PAGE_SIZE);
 
     // Bulk-reconcile: Firestore → MongoDB
     const mongoBulkOps = [];


### PR DESCRIPTION
## Summary

Fixes the broken `while`-loop condition in the MongoDB user pagination loop inside `app/api/admin/reconciliation-job/route.js`.

## Problem

The existing loop:
```js
} while (mongoCursor && mongoUids.size === mongoCursor);
```

`mongoCursor` increments by `mongoBatch.length` (total documents fetched), but `mongoUids.size` only increments for users **with** a `firebaseUid`. If *any* user document lacks a `firebaseUid`, `mongoUids.size < mongoCursor`, causing the loop to abort prematurely — silently leaving the rest of the collection unprocessed.

Additionally, MongoDB `find({}).skip(n)` without a `.sort()` has **non-deterministic ordering**, meaning `skip()` could skip wrong documents or return duplicates across pages.

## Changes

- **Fix termination condition**: `while (lastBatchSize === PAGE_SIZE)` — the correct idiomatic pattern; stop only when we get a partial (or empty) batch.
- **Add `.sort({ _id: 1 })`**: guarantees stable, consistent document ordering for `skip()`-based pagination.
- **Track `lastBatchSize`**: cleaner variable to check batch size vs duplicating `mongoBatch.length`.

## Testing

- Manual code review confirms the logic is now correct.
- The fix is a minimal, focused change with no unrelated modifications.

Closes #2499