### PR TITLE
Performance: Skip Mongo writes when attendance record retries are already idempotent

### DIFF
--- a/app/api/attendance/record/route.js
+++ b/app/api/attendance/record/route.js
@@ -57,7 +57,6 @@ export const POST = withErrorHandler(async (request) => {
   const resolvedName = userProfile?.fullName || decodedToken.name || decodedToken.displayName || decodedToken.email?.split("@")[0] || "Unknown User";
   const resolvedEmail = userProfile?.email || decodedToken.email || "unknown@learnova.edu";
 
-  let alreadyRecorded = false;
   const sagaResult = await executeSaga({
     operationType: "attendance_record",
     uid: decodedToken.uid,
@@ -95,8 +94,8 @@ export const POST = withErrorHandler(async (request) => {
       },
       {
         name: "write_mongodb_attendance",
-        execute: async () => {
-          if (alreadyRecorded) {
+        execute: async (ctx) => {
+          if (ctx._alreadyRecorded) {
             return;
           }
           const mongoDB = await connectDb();


### PR DESCRIPTION
Fixes #2608

- Removed unused outer \lreadyRecorded\ variable
- Changed MongoDB step \execute\ to receive \ctx\ and check \ctx._alreadyRecorded\ (set by the Firestore step when the doc already exists)