### PR TITLE
Security: Surface attendance saga failures instead of returning 201

### DIFF
--- a/app/api/attendance/record/route.js
+++ b/app/api/attendance/record/route.js
@@ -144,8 +144,12 @@ export const POST = withErrorHandler(async (request) => {
   }
 
   if (!sagaResult.success) {
-    // Attendance was written but XP award failed — log for reconciliation
-    console.error(`[attendance] XP award failed for user ${userId}: ${sagaResult.error}`);
+    if (sagaResult.failedStep === "award_xp") {
+      console.error(`[attendance] XP award failed for user ${userId}: ${sagaResult.error}`);
+    } else {
+      console.error(`[attendance] Saga failed at step "${sagaResult.failedStep}" for user ${userId}: ${sagaResult.error}`);
+      return jsonError("Attendance recording failed", 502);
+    }
   }
 
   return jsonSuccess({ alreadyRecorded: false }, 201);


### PR DESCRIPTION
Fixes #2609

- Returns 502 when saga fails on \write_attendance\ or \write_mongodb_attendance\ step (prevents silent data loss)
- Still returns 201 when only \ward_xp\ step fails (attendance was written, XP failure is non-critical)