### PR TITLE
Security: Do not mark offline attendance sync records successful on saga failure

### DIFF
--- a/app/api/attendance/sync/route.js
+++ b/app/api/attendance/sync/route.js
@@ -222,9 +222,15 @@ async function handleSync(request) {
       ],
     });
 
-    successfulIds.push(record.id);
-
-    processedUserDates.add(userDateKey);
+    if (sagaResult.success) {
+      successfulIds.push(record.id);
+      processedUserDates.add(userDateKey);
+    } else {
+      console.error(`[attendance-sync] Saga failed for user ${decodedToken.uid} date ${recordDate}: ${sagaResult.error}`);
+      if (record.id !== undefined) {
+        rejectedIds.push(record.id);
+      }
+    }
   }
 
   return NextResponse.json({


### PR DESCRIPTION
Fixes #2610

- Only adds record to \successfulIds\ and \processedUserDates\ when \sagaResult.success\ is true
- Adds failed records to \ejectedIds\ so they stay in the client's retry queue