### PR TITLE
Performance: Remove the 100-institute cap from admin totals

### DIFF
--- a/app/api/admin/stats/route.js
+++ b/app/api/admin/stats/route.js
@@ -31,6 +31,18 @@ export const GET = withErrorHandler(async (request) => {
     const usersCountSnap = await db.collection("users").count().get();
     totalUsers = usersCountSnap.data().count || 0;
 
+    const totalCountSnap = await db.collection("institutes").count().get();
+    const totalInstitutes = totalCountSnap.data().count || 0;
+
+    const activeCountSnap = await db.collection("institutes").where("status", "==", "active").count().get();
+    const activeInstitutes = activeCountSnap.data().count || 0;
+
+    // Fetch the aggregate sum of issues field for pending issues count
+    const allInstitutesSnap = await db.collection("institutes")
+      .select("issues")
+      .get();
+    const pendingIssues = allInstitutesSnap.docs.reduce((sum, doc) => sum + (doc.data().issues || 0), 0);
+
     const instSnapshot = await db.collection("institutes")
       .select("name", "status", "issues")
       .limit(100)
@@ -80,9 +92,7 @@ export const GET = withErrorHandler(async (request) => {
     );
   }
 
-  const totalInstitutes = institutes.length;
-  const activeInstitutes = institutes.filter((inst) => inst.status === "active").length;
-  const pendingIssues = institutes.reduce((sum, inst) => sum + (inst.issues || 0), 0);
+  // Totals are computed from dedicated count queries (not from the truncated list)
 
   const platformStats = {
     totalInstitutes,


### PR DESCRIPTION
Fixes #2611

- Replaced truncated \	otalInstitutes\/ \ctiveInstitutes\/ \pendingIssues\ (computed from .limit(100) list) with dedicated count and aggregation queries
- Keeps .limit(100) only for the institutes list display