### PR TITLE
Performance: Stop truncating critical alerts in the admin dashboard

### DIFF
--- a/app/api/admin/stats/route.js
+++ b/app/api/admin/stats/route.js
@@ -55,7 +55,7 @@ export const GET = withErrorHandler(async (request) => {
 
     const alertsSnapshot = await db.collection("critical_alerts")
       .orderBy("createdAt", "desc")
-      .limit(50)
+      .limit(200)
       .get();
     if (!alertsSnapshot.empty) {
       criticalAlerts = alertsSnapshot.docs.map((doc) => ({


### PR DESCRIPTION
Fixes #2612

- Increased critical alerts query limit from 50 to 200 to reduce risk of missing active alerts