### PR TITLE
Performance: Seed the notice stream watermark from the newest notice

### DIFF
--- a/app/api/notices/stream/route.js
+++ b/app/api/notices/stream/route.js
@@ -196,7 +196,10 @@ export async function GET(request) {
           }));
           sendEvent("initial", formattedNotices);
           if (initialNotices.length > 0) {
-            lastNoticeTime = initialNotices[0].createdAt || new Date();
+            lastNoticeTime = initialNotices.reduce((latest, n) => {
+              const t = n.createdAt;
+              return t && t > latest ? t : latest;
+            }, initialNotices[0].createdAt || new Date());
           }
         } catch (err) {
           console.error("Initial fetch error:", err);


### PR DESCRIPTION
Fixes #2614

- Iterates all initial notices to find the max createdAt instead of using initialNotices[0] (which may be a pinned notice with an older timestamp)
- Prevents replay of already-sent notices on subsequent polls