### PR TITLE
Performance: Align flashcard cursor pagination with the sort order

### DIFF
--- a/app/api/flashcards/route.js
+++ b/app/api/flashcards/route.js
@@ -19,7 +19,13 @@ export const GET = withErrorHandler(async (request) => {
   const cursor = url.searchParams.get("cursor") || undefined;
 
   const items = await FlashcardModel.getUserFlashcards(payload.uid, { courseId, cursor });
-  const nextCursor = items.length > 0 ? items[items.length - 1]._id.toString() : null;
+  const nextCursor = items.length > 0
+    ? JSON.stringify({
+        dueDate: items[items.length - 1].dueDate,
+        updatedAt: items[items.length - 1].updatedAt,
+        _id: items[items.length - 1]._id.toString(),
+      })
+    : null;
   return NextResponse.json({ items, nextCursor });
 });
 

--- a/lib/models/flashcardModel.js
+++ b/lib/models/flashcardModel.js
@@ -50,11 +50,16 @@ export async function getUserFlashcards(firebaseUid, { courseId, limit = 200, cu
   const query = { firebaseUid };
   if (courseId) query.courseId = courseId;
   if (cursor) {
-    query._id = { $gt: typeof cursor === "string" ? new ObjectId(cursor) : cursor };
+    const parsed = typeof cursor === "string" ? JSON.parse(cursor) : cursor;
+    query.$or = [
+      { dueDate: { $gt: parsed.dueDate } },
+      { dueDate: parsed.dueDate, updatedAt: { $lt: parsed.updatedAt } },
+      { dueDate: parsed.dueDate, updatedAt: parsed.updatedAt, _id: { $gt: new ObjectId(parsed._id) } },
+    ];
   }
   const items = await db.collection(COLLECTION)
     .find(query)
-    .sort({ dueDate: 1, updatedAt: -1 })
+    .sort({ dueDate: 1, updatedAt: -1, _id: 1 })
     .limit(limit)
     .toArray();
   return items;


### PR DESCRIPTION
Fixes #2616

- Replaced single \_id\ cursor with a compound cursor encoding \{ dueDate, updatedAt, _id }\ that matches the sort order
- Added \_id: 1\ to the sort as a stable tiebreaker
- Encoded \
extCursor\ as JSON string containing all three sort fields

Previously, pagination used an \_id\ cursor while sorting by \dueDate\ and \updatedAt\, causing cards to be skipped or repeated as due dates changed between pages.