### PR TITLE
feat: add timetable calendar subscription support (#2353)

### DIFF
--- a/app/api/timetable/ical/[token]/feed.ics/route.js
+++ b/app/api/timetable/ical/[token]/feed.ics/route.js
@@ -1,0 +1,127 @@
+import { initFirebaseAdmin } from "@/lib/firebase-admin";
+import { getFirestore } from "firebase-admin/firestore";
+import { NextResponse } from "next/server";
+
+const byDayMap = {
+  Sunday: "SU",
+  Monday: "MO",
+  Tuesday: "TU",
+  Wednesday: "WE",
+  Thursday: "TH",
+  Friday: "FR",
+  Saturday: "SA",
+};
+
+const getNextWeekdayDate = (dayName, timeStr) => {
+  const weekdays = {
+    Sunday: 0, Monday: 1, Tuesday: 2, Wednesday: 3, Thursday: 4, Friday: 5, Saturday: 6,
+  };
+  const targetDay = weekdays[dayName];
+  const now = new Date();
+  const currentDay = now.getDay();
+  
+  let daysToAdd = targetDay - currentDay;
+  if (daysToAdd < 0) daysToAdd += 7;
+  
+  const targetDate = new Date();
+  targetDate.setDate(now.getDate() + daysToAdd);
+  
+  const [hours, minutes] = timeStr.split(":").map(Number);
+  targetDate.setHours(hours || 9, minutes || 0, 0, 0);
+  
+  return targetDate;
+};
+
+// Use floating time format for local timezone support
+const formatDateToICSFloating = (date) => {
+  const yyyy = date.getFullYear();
+  const mm = String(date.getMonth() + 1).padStart(2, "0");
+  const dd = String(date.getDate()).padStart(2, "0");
+  const hh = String(date.getHours()).padStart(2, "0");
+  const min = String(date.getMinutes()).padStart(2, "0");
+  const ss = String(date.getSeconds()).padStart(2, "0");
+  return `${yyyy}${mm}${dd}T${hh}${min}${ss}`;
+};
+
+const formatDateToICSUTC = (date) => {
+  const yyyy = date.getUTCFullYear();
+  const mm = String(date.getUTCMonth() + 1).padStart(2, "0");
+  const dd = String(date.getUTCDate()).padStart(2, "0");
+  const hh = String(date.getUTCHours()).padStart(2, "0");
+  const min = String(date.getUTCMinutes()).padStart(2, "0");
+  const ss = String(date.getUTCSeconds()).padStart(2, "0");
+  return `${yyyy}${mm}${dd}T${hh}${min}${ss}Z`;
+};
+
+export async function GET(request, { params }) {
+  const { token } = params;
+
+  if (!token) {
+    return new NextResponse("Not Found", { status: 404 });
+  }
+
+  initFirebaseAdmin();
+  const db = getFirestore();
+
+  const timetablesRef = db.collection("timetables");
+  const q = timetablesRef.where("calendarToken", "==", token).limit(1);
+  const snapshot = await q.get();
+
+  if (snapshot.empty) {
+    return new NextResponse("Calendar Feed Not Found", { status: 404 });
+  }
+
+  const data = snapshot.docs[0].data();
+  const timetableData = data.timetableData || {};
+
+  let icsString = [
+    "BEGIN:VCALENDAR",
+    "VERSION:2.0",
+    "PRODID:-//Learnova//Timetable//EN",
+    "CALSCALE:GREGORIAN",
+    "METHOD:PUBLISH",
+    "X-WR-CALNAME:Learnova Timetable",
+  ].join("\r\n") + "\r\n";
+
+  const nowICS = formatDateToICSUTC(new Date());
+
+  Object.keys(timetableData).forEach((day) => {
+    const dayClasses = timetableData[day] || [];
+    dayClasses.forEach((cls, idx) => {
+      const [startStr, endStr] = cls.time.split("-");
+      if (!startStr || !endStr) return;
+
+      const startDate = getNextWeekdayDate(day, startStr.trim());
+      const endDate = getNextWeekdayDate(day, endStr.trim());
+
+      const startICS = formatDateToICSFloating(startDate);
+      const endICS = formatDateToICSFloating(endDate);
+      const byDay = byDayMap[day];
+
+      icsString += [
+        "BEGIN:VEVENT",
+        `UID:class-${day}-${idx}-${token}@learnova.app`,
+        `DTSTAMP:${nowICS}`,
+        `SUMMARY:${cls.subject || "Class"}`,
+        `DESCRIPTION:Instructor: ${cls.teacher || "N/A"}\\nRoom: ${cls.room || "N/A"}`,
+        `LOCATION:${cls.room || "N/A"}`,
+        `DTSTART:${startICS}`,
+        `DTEND:${endICS}`,
+        `RRULE:FREQ=WEEKLY;BYDAY=${byDay}`,
+        "STATUS:CONFIRMED",
+        "END:VEVENT",
+      ].join("\r\n") + "\r\n";
+    });
+  });
+
+  icsString += "END:VCALENDAR";
+
+  return new NextResponse(icsString, {
+    status: 200,
+    headers: {
+      "Content-Type": "text/calendar; charset=utf-8",
+      "Content-Disposition": 'attachment; filename="timetable_feed.ics"',
+      "Cache-Control": "no-cache, no-store, must-revalidate",
+    },
+  });
+}

--- a/app/api/timetable/sync/route.js
+++ b/app/api/timetable/sync/route.js
@@ -1,0 +1,64 @@
+import { jsonError, jsonSuccess } from "@/lib/api-response";
+import { withErrorHandler, parseJSON } from "@/lib/error-handler";
+import { requireAuth } from "@/lib/rbac";
+import { initFirebaseAdmin } from "@/lib/firebase-admin";
+import { getFirestore, FieldValue } from "firebase-admin/firestore";
+import crypto from "crypto";
+
+export const POST = withErrorHandler(async (request) => {
+  const decodedToken = await requireAuth(request);
+  const body = await parseJSON(request, 1024 * 50); // allow 50kb for timetable data
+  const { timetableData } = body;
+
+  if (!timetableData) {
+    return jsonError("timetableData is required", 400);
+  }
+
+  initFirebaseAdmin();
+  const db = getFirestore();
+  const userId = decodedToken.uid;
+  
+  const timetableRef = db.collection("timetables").doc(userId);
+  const timetableDoc = await timetableRef.get();
+  
+  let calendarToken;
+  
+  if (timetableDoc.exists) {
+    calendarToken = timetableDoc.data().calendarToken || crypto.randomUUID();
+    await timetableRef.update({
+      timetableData,
+      calendarToken,
+      updatedAt: FieldValue.serverTimestamp(),
+    });
+  } else {
+    calendarToken = crypto.randomUUID();
+    await timetableRef.set({
+      userId,
+      calendarToken,
+      timetableData,
+      updatedAt: FieldValue.serverTimestamp(),
+    });
+  }
+
+  return jsonSuccess({ success: true, calendarToken }, 200);
+});
+
+export const GET = withErrorHandler(async (request) => {
+  const decodedToken = await requireAuth(request);
+  initFirebaseAdmin();
+  const db = getFirestore();
+  const userId = decodedToken.uid;
+  
+  const timetableRef = db.collection("timetables").doc(userId);
+  const timetableDoc = await timetableRef.get();
+  
+  if (!timetableDoc.exists) {
+    return jsonSuccess({ timetableData: null, calendarToken: null }, 200);
+  }
+  
+  const data = timetableDoc.data();
+  return jsonSuccess({ 
+    timetableData: data.timetableData, 
+    calendarToken: data.calendarToken 
+  }, 200);
+});

--- a/components/Timetable.js
+++ b/components/Timetable.js
@@ -20,10 +20,8 @@ import {
   Sparkles,
   Copy,
   CalendarPlus,
-  Link as LinkIcon
 } from "lucide-react";
 import { useAuth } from "@/hooks/useAuth";
-import { apiFetch } from "@/lib/apiClient";
 
 
 const days = ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"];
@@ -118,7 +116,7 @@ export default function Timetable({ role = "student" }) {
       if (!user) return;
       try {
         const token = await user.getIdToken();
-        const res = await apiFetch("/api/timetable/sync", {
+        const res = await fetch("/api/timetable/sync", {
           headers: { Authorization: `Bearer ${token}` }
         });
         if (res.ok) {
@@ -171,7 +169,7 @@ export default function Timetable({ role = "student" }) {
       setIsSyncing(true);
       try {
         const token = await user.getIdToken();
-        const res = await apiFetch("/api/timetable/sync", {
+        const res = await fetch("/api/timetable/sync", {
           method: "POST",
           headers: {
             "Content-Type": "application/json",

--- a/components/Timetable.js
+++ b/components/Timetable.js
@@ -18,7 +18,13 @@ import {
   Check,
   Download,
   Sparkles,
+  Copy,
+  CalendarPlus,
+  Link as LinkIcon
 } from "lucide-react";
+import { useAuth } from "@/hooks/useAuth";
+import { apiFetch } from "@/lib/apiClient";
+
 
 const days = ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"];
 
@@ -77,6 +83,7 @@ const byDayMap = {
 };
 
 export default function Timetable({ role = "student" }) {
+  const { user } = useAuth();
   const today = new Date().toLocaleDateString("en-US", { weekday: "long" });
   const [selectedDay, setSelectedDay] = useState(
     days.includes(today) ? today : "Monday"
@@ -88,6 +95,9 @@ export default function Timetable({ role = "student" }) {
   const [mounted, setMounted] = useState(false);
   const [timetableData, setTimetableData] = useState(mockTimetable);
   const [isModalOpen, setIsModalOpen] = useState(false);
+  const [isSyncModalOpen, setIsSyncModalOpen] = useState(false);
+  const [calendarToken, setCalendarToken] = useState(null);
+  const [isSyncing, setIsSyncing] = useState(false);
   const [modalMode, setModalMode] = useState("add"); // "add" | "edit"
   const [editingIndex, setEditingIndex] = useState(null);
   const [originalDay, setOriginalDay] = useState("");
@@ -101,6 +111,35 @@ export default function Timetable({ role = "student" }) {
     startTime: "09:00",
     endTime: "10:30",
   });
+
+  // Fetch timetable from backend if authenticated
+  useEffect(() => {
+    const fetchBackendTimetable = async () => {
+      if (!user) return;
+      try {
+        const token = await user.getIdToken();
+        const res = await apiFetch("/api/timetable/sync", {
+          headers: { Authorization: `Bearer ${token}` }
+        });
+        if (res.ok) {
+          const data = await res.json();
+          if (data.data?.timetableData) {
+            setTimetableData(data.data.timetableData);
+            localStorage.setItem("learnova_custom_timetable", JSON.stringify(data.data.timetableData));
+          }
+          if (data.data?.calendarToken) {
+            setCalendarToken(data.data.calendarToken);
+          }
+        }
+      } catch (err) {
+        console.error("Failed to fetch timetable from backend:", err);
+      }
+    };
+    
+    if (user && mounted) {
+      fetchBackendTimetable();
+    }
+  }, [user, mounted]);
 
   // Client-side Hydration Safe loading of timetableData
   useEffect(() => {
@@ -123,9 +162,35 @@ export default function Timetable({ role = "student" }) {
     }
   }, []);
 
-  const saveTimetable = (newData) => {
+  const saveTimetable = async (newData) => {
     setTimetableData(newData);
     localStorage.setItem("learnova_custom_timetable", JSON.stringify(newData));
+    
+    // Sync to backend if authenticated
+    if (user) {
+      setIsSyncing(true);
+      try {
+        const token = await user.getIdToken();
+        const res = await apiFetch("/api/timetable/sync", {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${token}`
+          },
+          body: JSON.stringify({ timetableData: newData })
+        });
+        if (res.ok) {
+          const data = await res.json();
+          if (data.data?.calendarToken) {
+            setCalendarToken(data.data.calendarToken);
+          }
+        }
+      } catch (err) {
+        console.error("Failed to sync timetable:", err);
+      } finally {
+        setIsSyncing(false);
+      }
+    }
   };
 
   // Timetable push reminder scheduler
@@ -469,6 +534,17 @@ export default function Timetable({ role = "student" }) {
           </div>
         </div>
         <div className="flex items-center flex-wrap gap-2">
+          {user && (
+            <button
+              onClick={() => setIsSyncModalOpen(true)}
+              className="flex items-center gap-1.5 px-3 py-2 rounded-xl bg-purple-500/10 border border-purple-500/20 text-xs font-semibold text-purple-300 hover:bg-purple-500/20 hover:text-white hover:border-purple-500/40 transition-all duration-200 cursor-pointer shadow-sm"
+              title="Sync with Google Calendar / Apple Calendar"
+            >
+              <CalendarPlus className="w-3.5 h-3.5" />
+              <span>Sync Calendar</span>
+            </button>
+          )}
+
           {/* Export to ICS button */}
           <button
             onClick={handleExportCalendar}
@@ -776,6 +852,96 @@ export default function Timetable({ role = "student" }) {
                   </button>
                 </div>
               </form>
+            </motion.div>
+          </div>
+        )}
+      </AnimatePresence>
+      {/* Calendar Sync Modal */}
+      <AnimatePresence>
+        {isSyncModalOpen && (
+          <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
+            <motion.div
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              exit={{ opacity: 0 }}
+              onClick={() => setIsSyncModalOpen(false)}
+              className="absolute inset-0 bg-black/75 backdrop-blur-sm"
+            />
+            <motion.div
+              initial={{ opacity: 0, scale: 0.95, y: 15 }}
+              animate={{ opacity: 1, scale: 1, y: 0 }}
+              exit={{ opacity: 0, scale: 0.95, y: 15 }}
+              transition={{ type: "spring", duration: 0.4 }}
+              className="relative w-full max-w-lg overflow-hidden rounded-2xl border border-white/10 bg-slate-950 p-6 shadow-2xl backdrop-blur-2xl"
+            >
+              <div className="flex items-center justify-between border-b border-white/10 pb-4 mb-4">
+                <h3 className="text-lg font-semibold text-white flex items-center gap-2">
+                  <CalendarPlus className="w-5 h-5 text-purple-400" />
+                  Sync with External Calendar
+                </h3>
+                <button
+                  onClick={() => setIsSyncModalOpen(false)}
+                  className="rounded-lg p-1.5 hover:bg-white/10 text-white/60 hover:text-white transition-colors cursor-pointer"
+                >
+                  <X className="w-5 h-5" />
+                </button>
+              </div>
+
+              <div className="space-y-4">
+                <p className="text-sm text-white/70">
+                  Subscribe to your Learnova timetable in your favorite calendar app (Google Calendar, Apple Calendar, Outlook). Your calendar will automatically update when you make changes here.
+                </p>
+
+                {calendarToken ? (
+                  <div className="space-y-4">
+                    <div className="space-y-2">
+                      <label className="text-xs font-semibold text-white/50 uppercase tracking-wider">
+                        Calendar Feed URL
+                      </label>
+                      <div className="flex items-center gap-2">
+                        <input
+                          readOnly
+                          value={`${window.location.origin}/api/timetable/ical/${calendarToken}/feed.ics`}
+                          className="w-full rounded-xl border border-white/10 bg-white/5 px-4 py-2.5 text-sm text-white focus:outline-none"
+                        />
+                        <button
+                          onClick={() => {
+                            navigator.clipboard.writeText(`${window.location.origin}/api/timetable/ical/${calendarToken}/feed.ics`);
+                            toast.success("Feed URL copied to clipboard!");
+                          }}
+                          className="px-4 py-2.5 rounded-xl bg-purple-500/20 border border-purple-500/30 text-purple-300 hover:bg-purple-500/30 hover:text-white transition cursor-pointer flex items-center gap-1.5 whitespace-nowrap"
+                        >
+                          <Copy className="w-4 h-4" />
+                          Copy
+                        </button>
+                      </div>
+                    </div>
+
+                    <div className="grid grid-cols-1 md:grid-cols-2 gap-3 pt-2">
+                      <a
+                        href={`https://calendar.google.com/calendar/r?cid=${encodeURIComponent(`${window.location.origin}/api/timetable/ical/${calendarToken}/feed.ics`)}`}
+                        target="_blank"
+                        rel="noreferrer"
+                        className="flex items-center justify-center gap-2 px-4 py-3 rounded-xl bg-white/5 border border-white/10 hover:bg-white/10 text-sm text-white transition-colors cursor-pointer"
+                      >
+                        <CalendarPlus className="w-4 h-4" />
+                        Google Calendar
+                      </a>
+                      <a
+                        href={`webcal://${window.location.host}/api/timetable/ical/${calendarToken}/feed.ics`}
+                        className="flex items-center justify-center gap-2 px-4 py-3 rounded-xl bg-white/5 border border-white/10 hover:bg-white/10 text-sm text-white transition-colors cursor-pointer"
+                      >
+                        <CalendarPlus className="w-4 h-4" />
+                        Apple Calendar
+                      </a>
+                    </div>
+                  </div>
+                ) : (
+                  <div className="text-center py-6">
+                    <p className="text-sm text-white/50 mb-4">Please add a class to your timetable first to generate a sync link.</p>
+                  </div>
+                )}
+              </div>
             </motion.div>
           </div>
         )}

--- a/tests/api/timetable.test.js
+++ b/tests/api/timetable.test.js
@@ -1,46 +1,94 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { GET as getICalFeed } from "@/app/api/timetable/ical/[token]/feed.ics/route";
+
+// Use vi.hoisted so the shared state is available inside vi.mock factories
+const { getMock, setMockData } = vi.hoisted(() => {
+  let _mockData = null;
+
+  const getMock = vi.fn(() => {
+    if (!_mockData) {
+      return Promise.resolve({ empty: true, docs: [] });
+    }
+    return Promise.resolve({
+      empty: false,
+      docs: [{ data: () => _mockData }],
+    });
+  });
+
+  const setMockData = (data) => {
+    _mockData = data;
+    // Re-configure getMock with current data
+    getMock.mockImplementation(() => {
+      if (!data) {
+        return Promise.resolve({ empty: true, docs: [] });
+      }
+      return Promise.resolve({
+        empty: false,
+        docs: [{ data: () => data }],
+      });
+    });
+  };
+
+  return { getMock, setMockData };
+});
 
 vi.mock("@/lib/firebase-admin", () => ({
   initFirebaseAdmin: vi.fn(),
 }));
 
-let mockData = null;
+vi.mock("firebase-admin/firestore", () => ({
+  getFirestore: vi.fn(() => ({
+    collection: vi.fn(() => ({
+      where: vi.fn(() => ({
+        limit: vi.fn(() => ({
+          get: getMock,
+        })),
+      })),
+    })),
+  })),
+}));
 
-vi.mock("firebase-admin/firestore", () => {
-  const getMock = vi.fn(() => {
-    if (!mockData) {
-      return Promise.resolve({ empty: true, docs: [] });
-    } else {
-      return Promise.resolve({ 
-        empty: false, 
-        docs: [{ data: () => mockData }] 
-      });
+// next/server is not available in jsdom - mock NextResponse
+vi.mock("next/server", () => {
+  class MockHeaders {
+    constructor(init = {}) {
+      this._map = new Map();
+      Object.entries(init).forEach(([k, v]) => this._map.set(k.toLowerCase(), v));
     }
-  });
-  
+    get(name) {
+      return this._map.get(name.toLowerCase()) ?? null;
+    }
+    set(name, value) {
+      this._map.set(name.toLowerCase(), value);
+    }
+  }
+
   return {
-    getFirestore: vi.fn(() => ({
-      collection: vi.fn(() => ({
-        where: vi.fn(() => ({
-          limit: vi.fn(() => ({
-            get: getMock
-          }))
-        }))
-      }))
-    }))
+    NextResponse: class NextResponse {
+      constructor(body, init = {}) {
+        this._body = body;
+        this.status = init.status || 200;
+        this.headers = new MockHeaders(init.headers || {});
+      }
+      async text() {
+        return this._body;
+      }
+      async json() {
+        return JSON.parse(this._body);
+      }
+    },
   };
 });
+
+
+const { GET: getICalFeed } = await import(
+  "@/app/api/timetable/ical/[token]/feed.ics/route"
+);
 
 describe("Timetable iCal Feed API", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockData = null;
+    setMockData(null);
   });
-
-  const setMockData = (data) => {
-    mockData = data;
-  };
 
   it("should return 404 for missing token", async () => {
     const response = await getICalFeed({}, { params: {} });
@@ -58,16 +106,16 @@ describe("Timetable iCal Feed API", () => {
       calendarToken: "valid-token",
       timetableData: {
         Monday: [
-          { time: "09:00-10:30", subject: "Math", teacher: "Mr. Smith", room: "101" }
-        ]
-      }
+          { time: "09:00-10:30", subject: "Math", teacher: "Mr. Smith", room: "101" },
+        ],
+      },
     });
 
     const response = await getICalFeed({}, { params: { token: "valid-token" } });
-    
+
     expect(response.status).toBe(200);
     expect(response.headers.get("content-type")).toContain("text/calendar");
-    
+
     const text = await response.text();
     expect(text).toContain("BEGIN:VCALENDAR");
     expect(text).toContain("VERSION:2.0");

--- a/tests/api/timetable.test.js
+++ b/tests/api/timetable.test.js
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { GET as getICalFeed } from "@/app/api/timetable/ical/[token]/feed.ics/route";
+
+vi.mock("@/lib/firebase-admin", () => ({
+  initFirebaseAdmin: vi.fn(),
+}));
+
+let mockData = null;
+
+vi.mock("firebase-admin/firestore", () => {
+  const getMock = vi.fn(() => {
+    if (!mockData) {
+      return Promise.resolve({ empty: true, docs: [] });
+    } else {
+      return Promise.resolve({ 
+        empty: false, 
+        docs: [{ data: () => mockData }] 
+      });
+    }
+  });
+  
+  return {
+    getFirestore: vi.fn(() => ({
+      collection: vi.fn(() => ({
+        where: vi.fn(() => ({
+          limit: vi.fn(() => ({
+            get: getMock
+          }))
+        }))
+      }))
+    }))
+  };
+});
+
+describe("Timetable iCal Feed API", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockData = null;
+  });
+
+  const setMockData = (data) => {
+    mockData = data;
+  };
+
+  it("should return 404 for missing token", async () => {
+    const response = await getICalFeed({}, { params: {} });
+    expect(response.status).toBe(404);
+  });
+
+  it("should return 404 for invalid token", async () => {
+    setMockData(null);
+    const response = await getICalFeed({}, { params: { token: "invalid" } });
+    expect(response.status).toBe(404);
+  });
+
+  it("should return valid ics feed when token is valid", async () => {
+    setMockData({
+      calendarToken: "valid-token",
+      timetableData: {
+        Monday: [
+          { time: "09:00-10:30", subject: "Math", teacher: "Mr. Smith", room: "101" }
+        ]
+      }
+    });
+
+    const response = await getICalFeed({}, { params: { token: "valid-token" } });
+    
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toContain("text/calendar");
+    
+    const text = await response.text();
+    expect(text).toContain("BEGIN:VCALENDAR");
+    expect(text).toContain("VERSION:2.0");
+    expect(text).toContain("BEGIN:VEVENT");
+    expect(text).toContain("SUMMARY:Math");
+    expect(text).toContain("LOCATION:101");
+    expect(text).toContain("RRULE:FREQ=WEEKLY;BYDAY=MO");
+    expect(text).toContain("END:VCALENDAR");
+  });
+});


### PR DESCRIPTION
## Description
Adds calendar subscription support for timetable events, enabling students and educators to synchronize academic schedules with external calendar applications (Google Calendar, Apple Calendar, etc.).

Features added:
- Dynamic iCalendar (`.ics`) feed generation using a secure random token.
- New Firestore `timetables` collection and API route to persist custom timetables.
- Updated Timetable UI with a responsive "Sync Calendar" modal, feed URL generator, and one-click subscription buttons.

Fixes #2353

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] My changes generate no new warnings
- [x] I have performed a self-review of my own code