### PR TITLE
fix: prevent device resource leaks in StrictMode (#2352)

### DIFF
--- a/components/AttendanceValidation.js
+++ b/components/AttendanceValidation.js
@@ -45,6 +45,14 @@ const AttendanceValidation = ({ onValidationSuccess }) => {
 
   const modalContainerRef = useRef(null);
   const triggerElementRef = useRef(null);
+  const componentMounted = useRef(true);
+
+  useEffect(() => {
+    componentMounted.current = true;
+    return () => {
+      componentMounted.current = false;
+    };
+  }, []);
 
   // Close exception modal on Escape key press
   useEffect(() => {
@@ -302,6 +310,8 @@ const AttendanceValidation = ({ onValidationSuccess }) => {
         });
       });
 
+      if (!componentMounted.current) return;
+
       const userLat = position.coords.latitude;
       const userLng = position.coords.longitude;
       const distance = calculateDistance(
@@ -333,6 +343,7 @@ const AttendanceValidation = ({ onValidationSuccess }) => {
         );
       }
     } catch (error) {
+      if (!componentMounted.current) return;
       setRetryCount((prev) => prev + 1);
 
       if (error.code === 1) {
@@ -352,7 +363,9 @@ const AttendanceValidation = ({ onValidationSuccess }) => {
         );
       }
     } finally {
-      setIsLoading(false);
+      if (componentMounted.current) {
+        setIsLoading(false);
+      }
     }
   };
 
@@ -436,6 +449,8 @@ const AttendanceValidation = ({ onValidationSuccess }) => {
         });
       });
 
+      if (!componentMounted.current) return;
+
       const userLat = position.coords.latitude;
       const userLng = position.coords.longitude;
       const distance = calculateDistance(
@@ -460,6 +475,7 @@ const AttendanceValidation = ({ onValidationSuccess }) => {
 
       toast.success("Current location captured successfully");
     } catch (error) {
+      if (!componentMounted.current) return;
       // In getCurrentLocationForException, add error handling for denied permissions
       if (error.code === 1) {
         toast.error(
@@ -467,7 +483,9 @@ const AttendanceValidation = ({ onValidationSuccess }) => {
         );
       }
     } finally {
-      setModalLocationLoading(false);
+      if (componentMounted.current) {
+        setModalLocationLoading(false);
+      }
     }
   };
 

--- a/components/FaceRecognizer.js
+++ b/components/FaceRecognizer.js
@@ -105,13 +105,19 @@ export default function FaceRecognizer({ authUser }) {
         cancelAnimationFrame(animationFrameId.current);
       }
 
+      if (abortControllerRef.current) {
+        abortControllerRef.current.abort();
+      }
+      abortControllerRef.current = new AbortController();
+      const signal = abortControllerRef.current.signal;
+
       setMessage("Requesting camera permission...");
 
       const stream = await navigator.mediaDevices.getUserMedia({
         video: { facingMode },
       });
 
-      if (!isMounted.current || abortControllerRef.current?.signal.aborted) {
+      if (!isMounted.current || signal.aborted) {
         stream.getTracks().forEach((t) => t.stop());
         return;
       }
@@ -121,7 +127,7 @@ export default function FaceRecognizer({ authUser }) {
       if (videoRef.current) {
         videoRef.current.srcObject = stream;
         videoRef.current.onloadedmetadata = () => {
-          if (!isMounted.current || abortControllerRef.current?.signal.aborted) return;
+          if (!isMounted.current || signal.aborted) return;
           videoRef.current
             .play()
             .catch((e) => console.warn("Play interrupted", e));
@@ -136,7 +142,7 @@ export default function FaceRecognizer({ authUser }) {
           };
           setBlinkPrompt("");
 
-          processVideo();
+          processVideo(signal);
         };
       }
 
@@ -144,7 +150,8 @@ export default function FaceRecognizer({ authUser }) {
       setFinished(false);
       setAttendanceState("idle");
     } catch (err) {
-      if (!isMounted.current || abortControllerRef.current?.signal.aborted) return;
+      const signal = abortControllerRef.current?.signal;
+      if (!isMounted.current || signal?.aborted) return;
       setIsLoading(false);
       if (err.name === "NotAllowedError") {
         setMessage(
@@ -163,11 +170,14 @@ export default function FaceRecognizer({ authUser }) {
 
   useEffect(() => {
     isMounted.current = true;
-    abortControllerRef.current = new AbortController();
+    let isEffectMounted = true;
+    const localAbortController = new AbortController();
+    abortControllerRef.current = localAbortController;
+    const signal = localAbortController.signal;
 
     const loadModels = async () => {
       try {
-        if (!isMounted.current || abortControllerRef.current.signal.aborted) return;
+        if (!isEffectMounted || signal.aborted) return;
         setMessage("Loading AI models...");
         const faceapi = await import("face-api.js");
         faceapiRef.current = faceapi;
@@ -178,11 +188,11 @@ export default function FaceRecognizer({ authUser }) {
           faceapi.nets.faceRecognitionNet.loadFromUri(MODEL_URL),
         ]);
 
-        if (!isMounted.current || abortControllerRef.current.signal.aborted) return;
+        if (!isEffectMounted || signal.aborted) return;
         setMessage("Models loaded ✅ Starting webcam...");
         startVideo();
       } catch (err) {
-        if (!isMounted.current || abortControllerRef.current.signal.aborted) return;
+        if (!isEffectMounted || signal.aborted) return;
         setMessage("Failed to load models.");
         setIsLoading(false);
         setFinished(true);
@@ -191,13 +201,13 @@ export default function FaceRecognizer({ authUser }) {
 
     const startVideo = async () => {
       try {
-        if (!isMounted.current || abortControllerRef.current.signal.aborted) return;
+        if (!isEffectMounted || signal.aborted) return;
         setMessage("Requesting camera permission...");
         const stream = await navigator.mediaDevices.getUserMedia({
           video: { facingMode },
         });
 
-        if (!isMounted.current || abortControllerRef.current.signal.aborted) {
+        if (!isEffectMounted || signal.aborted) {
           stream.getTracks().forEach((t) => t.stop());
           return;
         }
@@ -207,26 +217,26 @@ export default function FaceRecognizer({ authUser }) {
         if (videoRef.current) {
           videoRef.current.srcObject = stream;
           videoRef.current.onloadedmetadata = () => {
-            if (!isMounted.current || abortControllerRef.current.signal.aborted) return;
+            if (!isEffectMounted || signal.aborted) return;
             videoRef.current
               .play()
               .catch((e) => console.warn("Play interrupted", e));
             setIsLoading(false);
             setMessage("Building face models...");
 
-            buildFaceMatcher().then(() => {
-              if (!isMounted.current || abortControllerRef.current.signal.aborted) return;
+            buildFaceMatcher(signal).then(() => {
+              if (!isEffectMounted || signal.aborted) return;
               setMessage("Looking for faces...");
               setLivenessState("DETECTING_FACE");
 
               blinkStateRef.current.requiredBlinks =
                 Math.floor(Math.random() * 2) + 1;
-              processVideo();
+              processVideo(signal);
             });
           };
         }
       } catch (err) {
-        if (!isMounted.current || abortControllerRef.current.signal.aborted) return;
+        if (!isEffectMounted || signal.aborted) return;
         setIsLoading(false);
         if (err.name === "NotAllowedError" || err.message?.includes("Permission denied")) {
           setMessage("Camera access denied. Please enable camera permissions in browser settings.");
@@ -242,12 +252,9 @@ export default function FaceRecognizer({ authUser }) {
     }
 
     return () => {
+      isEffectMounted = false;
       isMounted.current = false;
-
-      // Cancel all async operations
-      if (abortControllerRef.current) {
-        abortControllerRef.current.abort();
-      }
+      localAbortController.abort();
 
       if (animationFrameId.current) {
         cancelAnimationFrame(animationFrameId.current);
@@ -275,9 +282,9 @@ export default function FaceRecognizer({ authUser }) {
     };
   }, []);
 
-  const buildFaceMatcher = async () => {
+  const buildFaceMatcher = async (signal) => {
     if (!labels || labels.length === 0) return;
-    if (!isMounted.current || abortControllerRef.current?.signal.aborted) return;
+    if (!isMounted.current || signal?.aborted) return;
 
     const faceapi = await import("face-api.js");
     faceapiRef.current = faceapi;
@@ -286,7 +293,7 @@ export default function FaceRecognizer({ authUser }) {
       await Promise.all(
         labels.map(async (student) => {
           try {
-            if (!isMounted.current || abortControllerRef.current?.signal.aborted) return null;
+            if (!isMounted.current || signal?.aborted) return null;
             // Check if pre-calculated face descriptor exists in the database
             if (
               student.faceDescriptor &&
@@ -301,13 +308,13 @@ export default function FaceRecognizer({ authUser }) {
             if (!student.hasImage) return null;
             const imgUrl = `/api/images?id=${student._id}`;
             const img = await faceapi.fetchImage(imgUrl);
-            if (!isMounted.current || abortControllerRef.current?.signal.aborted) return null;
+            if (!isMounted.current || signal?.aborted) return null;
             const detection = await faceapi
               .detectSingleFace(img, new faceapi.TinyFaceDetectorOptions())
               .withFaceLandmarks()
               .withFaceDescriptor();
 
-            if (detection && isMounted.current) {
+            if (detection && isMounted.current && !signal?.aborted) {
               return new faceapi.LabeledFaceDescriptors(student.name, [
                 detection.descriptor,
               ]);
@@ -324,7 +331,7 @@ export default function FaceRecognizer({ authUser }) {
       )
     ).filter(Boolean);
 
-    if (!isMounted.current || abortControllerRef.current?.signal.aborted) return;
+    if (!isMounted.current || signal?.aborted) return;
     cachedDescriptorsRef.current = labeledFaceDescriptors;
 
     if (!labeledFaceDescriptors.length) {
@@ -339,33 +346,33 @@ export default function FaceRecognizer({ authUser }) {
     );
   };
 
-  const processVideo = async () => {
+  const processVideo = async (signal) => {
     if (
       !videoRef.current ||
       !canvasRef.current ||
       !faceMatcherRef.current ||
       !isMounted.current ||
-      abortControllerRef.current?.signal.aborted
+      signal?.aborted
     ) {
       return;
     }
 
     const faceapi = await import("face-api.js");
     faceapiRef.current = faceapi;
-    if (!isMounted.current || abortControllerRef.current?.signal.aborted) return;
+    if (!isMounted.current || signal?.aborted) return;
     const video = videoRef.current;
 
     if (video.paused || video.ended || !video.videoWidth) {
-      if (isMounted.current && !finished) {
-        animationFrameId.current = requestAnimationFrame(processVideo);
+      if (isMounted.current && !finished && !signal?.aborted) {
+        animationFrameId.current = requestAnimationFrame(() => processVideo(signal));
       }
       return;
     }
 
     const now = Date.now();
     if (now - lastDetectionTime.current < PROCESSING_INTERVAL_MS) {
-      if (isMounted.current && !finished) {
-        animationFrameId.current = requestAnimationFrame(processVideo);
+      if (isMounted.current && !finished && !signal?.aborted) {
+        animationFrameId.current = requestAnimationFrame(() => processVideo(signal));
       }
       return;
     }
@@ -389,7 +396,7 @@ export default function FaceRecognizer({ authUser }) {
       .withFaceLandmarks()
       .withFaceDescriptors();
 
-    if (!isMounted.current || abortControllerRef.current?.signal.aborted) return;
+    if (!isMounted.current || signal?.aborted) return;
 
     const resizedDetections = faceapi.resizeResults(detections, displaySize);
     const ctx = canvas.getContext("2d");
@@ -487,7 +494,7 @@ export default function FaceRecognizer({ authUser }) {
         }
       }
     } else {
-      if (isMounted.current && !abortControllerRef.current?.signal.aborted) {
+      if (isMounted.current && !signal?.aborted) {
         if (livenessState !== "AUTHENTICATED") {
           setMessage("No face detected");
           setLivenessState("DETECTING_FACE");
@@ -498,12 +505,12 @@ export default function FaceRecognizer({ authUser }) {
       }
     }
 
-    if (isMounted.current && !finished && !abortControllerRef.current?.signal.aborted) {
+    if (isMounted.current && !finished && !signal?.aborted) {
       // Loop execution only if not finished
       // To prevent race conditions, check if we just transitioned to AUTHENTICATED
       setLivenessState((currentLiveness) => {
-        if (currentLiveness !== "AUTHENTICATED" && isMounted.current) {
-          animationFrameId.current = requestAnimationFrame(processVideo);
+        if (currentLiveness !== "AUTHENTICATED" && isMounted.current && !signal?.aborted) {
+          animationFrameId.current = requestAnimationFrame(() => processVideo(signal));
         }
         return currentLiveness;
       });


### PR DESCRIPTION
## Description
Fixes resource leaks caused by React StrictMode double-mount behavior in components using browser device APIs and external subscriptions.

Several effects initialized hardware resources, listeners, or asynchronous operations without guaranteeing proper cleanup during component unmounts and StrictMode remount cycles. Specifically, `FaceRecognizer.js` leaked camera stream objects because the original mount's `abortControllerRef` was overwritten before it was able to clean up the `navigator.mediaDevices.getUserMedia` callback. `AttendanceValidation.js` called `navigator.geolocation.getCurrentPosition` which executed without verifying if the component was unmounted, causing memory and state leaks.

Changes made:
* Added media stream cleanup checks explicitly bound to local effect closure scope in `FaceRecognizer.js`
* Added asynchronous operation safeguards to block unmounted updates in `AttendanceValidation.js`
* Added async operation abort signals to recursive detection loops (`processVideo`)
* Improved StrictMode compatibility by decoupling cleanup logic from global component refs

Fixes #2352

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] My changes generate no new warnings
- [x] I have performed a self-review of my own code