### PR TITLE
fix(ai-productivity): add authentication and rate limiting to POST endpoint

### DIFF
--- a/app/api/ai-productivity/route.js
+++ b/app/api/ai-productivity/route.js
@@ -1,12 +1,22 @@
 import { jsonSuccess, jsonError } from "@/lib/api-response";
-import { parseJSON, withErrorHandler } from "@/lib/error-handler";
+import { authenticateRequest, parseJSON, withErrorHandler } from "@/lib/error-handler";
 import { callGroq } from "@/lib/ai/groq";
+import { checkRateLimit } from "@/lib/rateLimit";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
 
+const MAX_BODY_BYTES = 1024 * 10;
+
 export const POST = withErrorHandler(async (request) => {
-  const analytics = await parseJSON(request);
+  const decodedToken = await authenticateRequest(request);
+
+  const rateLimitResult = await checkRateLimit(decodedToken.uid);
+  if (!rateLimitResult.allowed) {
+    return jsonError("Too many requests. Please try again later.", 429);
+  }
+
+  const analytics = await parseJSON(request, MAX_BODY_BYTES);
 
   const {
     totalFocusMinutes = 0,
@@ -17,19 +27,16 @@ export const POST = withErrorHandler(async (request) => {
     peakFocusHours = "Unknown",
   } = analytics;
 
-  if (
-  totalFocusMinutes === 0 &&
-  completedFocusSessions === 0
-) {
-  return jsonSuccess({
-    strength:
-      "You have successfully started using the productivity dashboard.",
-    improvement:
-      "Complete your first focus session to unlock deeper insights.",
-    recommendation:
-      "Try a 25-minute focus session today to begin building consistency.",
-  });
-}
+  if (totalFocusMinutes === 0 && completedFocusSessions === 0) {
+    return jsonSuccess({
+      strength:
+        "You have successfully started using the productivity dashboard.",
+      improvement:
+        "Complete your first focus session to unlock deeper insights.",
+      recommendation:
+        "Try a 25-minute focus session today to begin building consistency.",
+    });
+  }
 
   const prompt = `
 You are an expert productivity coach.
@@ -65,10 +72,7 @@ Do not wrap JSON in code blocks.
   try {
     insights = JSON.parse(aiResponse);
   } catch {
-    return jsonError(
-      "AI returned an invalid response format.",
-      500
-    );
+    return jsonError("AI returned an invalid response format.", 500);
   }
 
   return jsonSuccess(insights);


### PR DESCRIPTION
## Problem Statement

`POST /api/ai-productivity` forwarded every request directly to the Groq LLM without checking whether the caller was authenticated or had exceeded their request budget. Any anonymous HTTP client could call this endpoint in a loop and exhaust the server's Groq API quota, causing billing impact and degraded service for real users. The same risks were already addressed on `/api/groq` with `authenticateRequest`, `checkRateLimit`, and a bounded `parseJSON` call, but the productivity insights endpoint was left unprotected.

## Root Cause Analysis

The handler imported `parseJSON` and `withErrorHandler` from `@/lib/error-handler` but did not call `authenticateRequest`, so no Firebase token was ever verified. The `checkRateLimit` import from `@/lib/rateLimit` was also absent, meaning per-user request budgets were never consulted. The `parseJSON` call used the default 100 KB size cap instead of the tighter 10 KB cap used on comparable endpoints, allowing oversized payloads to reach the LLM.

## Solution Overview

This PR applies the same three-layer guard already present on `/api/groq`:

1. `authenticateRequest(request)` - verifies the Firebase token and returns 401 for unauthenticated callers.
2. `checkRateLimit(decodedToken.uid)` - enforces per-user request budgets and returns 429 when the limit is exceeded.
3. `parseJSON(request, 1024 * 10)` - caps the request body at 10 KB before it reaches the prompt builder.

No application logic is changed; only the security envelope is brought in line with the rest of the API.

## Changes Made

### app/api/ai-productivity/route.js
- Added `authenticateRequest` to the import from `@/lib/error-handler`
- Added import for `checkRateLimit` from `@/lib/rateLimit`
- Added `authenticateRequest(request)` call as the first operation in the handler
- Added `checkRateLimit(decodedToken.uid)` with a 429 response when the user is over limit
- Added a `MAX_BODY_BYTES` constant (10 KB) and passed it to `parseJSON`
- Corrected inconsistent indentation in the early-return block for zero-session users

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing Done

### Manual Testing Steps

**Test Case 1: Unauthenticated request returns 401**
1. Send `POST /api/ai-productivity` with no Authorization header and valid JSON body.
Expected: `401 Unauthorized`
Actual: `401 Unauthorized`

**Test Case 2: Authenticated request returns insights**
1. Obtain a valid Firebase ID token.
2. Send `POST /api/ai-productivity` with `Authorization: Bearer <token>` and a body containing `totalFocusMinutes: 100`.
Expected: `200` with `strength`, `improvement`, `recommendation` fields.
Actual: `200` with correct fields.

**Test Case 3: Rate limit returns 429**
1. Exceed the rate limit for a user account.
2. Send an additional authenticated request.
Expected: `429 Too Many Requests`
Actual: `429 Too Many Requests`

## Related Issue

Closes #2672

## Checklist

- [x] My code follows the style guidelines of this project
- [x] My changes generate no new warnings
- [x] I have performed a self-review of my own code
- [x] I have read CONTRIBUTING.md and CODE_OF_CONDUCT.md
- [x] I have tested my changes locally
- [x] No em dashes or double hyphens in this PR

---

Maintainer, could you please add the appropriate GSSoC label to this PR? This helps with contribution tracking and scoring under GSSoC '26. Thank you.