### PR TITLE
Security: Remove spoofable x-forwarded-for from password reset rate limit key

### DIFF
--- a/app/api/auth/reset-password/route.js
+++ b/app/api/auth/reset-password/route.js
@@ -25,9 +25,8 @@ export async function POST(request) {
       );
     }
     
-    // Rate limit both by IP and by email to prevent spamming
-    const ip = request.headers.get("x-forwarded-for") || "unknown";
-    const rateLimitKey = `reset_pwd_${sanitizedEmail}_${ip}`;
+    // Rate limit by email to prevent spamming (IP is not used as x-forwarded-for is trivially spoofed)
+    const rateLimitKey = `reset_pwd_${sanitizedEmail}`;
     const rateLimitResult = await checkRateLimit(rateLimitKey);
 
     if (!rateLimitResult.allowed) {


### PR DESCRIPTION
Fixes #2688

- Removed x-forwarded-for from rate limit key (trivially spoofable)
- Rate limit now keys solely on sanitized email address