### PR TITLE
Performance: Remove silent instituteId fallback to profile.uid in analytics/attendance-risk

### DIFF
--- a/app/api/analytics/attendance-risk/route.js
+++ b/app/api/analytics/attendance-risk/route.js
@@ -28,7 +28,10 @@ export const GET = withErrorHandler(async (request) => {
     return jsonError("User not found", 404);
   }
 
-  const instituteId = profile.instituteId || profile.uid;
+  if (!profile.instituteId) {
+    return jsonError("User profile missing instituteId. Please contact your institute admin.", 400);
+  }
+  const instituteId = profile.instituteId;
 
   // Two-week window dates
   const now = new Date();


### PR DESCRIPTION
Fixes #2689

- Returns 400 error when profile.instituteId is missing instead of silently falling back to profile.uid
- Prevents cross-institute data leakage when teacher lacks instituteId configuration