### PR TITLE
Performance: Replace updateOne+findOne with findOneAndUpdate in flashcardModel

### DIFF
--- a/lib/models/flashcardModel.js
+++ b/lib/models/flashcardModel.js
@@ -65,8 +65,12 @@ export async function updateFlashcard(id, update) {
   const db = await connectDb();
   const _id = typeof id === "string" ? new ObjectId(id) : id;
   update.updatedAt = new Date().toISOString();
-  await db.collection(COLLECTION).updateOne({ _id }, { $set: update });
-  return await db.collection(COLLECTION).findOne({ _id });
+  const result = await db.collection(COLLECTION).findOneAndUpdate(
+    { _id },
+    { $set: update },
+    { returnDocument: "after" }
+  );
+  return result;
 }
 
 export default {


### PR DESCRIPTION
Fixes #2694

- Replaced two round trips (updateOne + findOne) with a single findOneAndUpdate with returnDocument: 'after'
- Halves network latency for each flashcard update operation