### PR TITLE
DevOps: Add concurrency groups, timeout-minutes, and npm ci to workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,16 +6,21 @@ on:
   push:
     branches: [main, master]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     strategy:
       matrix:
-        node-version: [18.x, 20.x]
+        node-version: [20.x]
 
     steps:
       - name: 📥 Checkout code

--- a/.github/workflows/contributor-guidelines.yml
+++ b/.github/workflows/contributor-guidelines.yml
@@ -14,6 +14,7 @@ permissions:
 jobs:
   check-contributor-limits:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
 
     steps:
       - name: Post Contribution Guidelines

--- a/.github/workflows/issue-auto-assign.yml
+++ b/.github/workflows/issue-auto-assign.yml
@@ -10,6 +10,7 @@ permissions:
 jobs:
   auto-assign-comment:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - name: Auto-assign and comment
         uses: actions/github-script@v7

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -4,9 +4,14 @@ on:
   pull_request:
     branches: [main, master]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   checks:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     # Updated: refined secret scanning
 
     steps:
@@ -16,7 +21,7 @@ jobs:
       - name: 📦 Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20.x'
+          node-version-file: '.nvmrc'
           cache: 'npm'
 
       - name: 📚 Install dependencies

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   stale:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
     - uses: actions/stale@v9
       with:

--- a/.github/workflows/update-contributors.yml
+++ b/.github/workflows/update-contributors.yml
@@ -10,6 +10,7 @@ on:
 jobs:
   update:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: write
 

--- a/.github/workflows/verify-pr.yml
+++ b/.github/workflows/verify-pr.yml
@@ -4,9 +4,14 @@ on:
   pull_request:
     branches: [ master ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   verify:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     steps:
       - name: Checkout Code
@@ -15,11 +20,11 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version-file: '.nvmrc'
           cache: 'npm'
 
       - name: Install Dependencies
-        run: npm install --legacy-peer-deps
+        run: npm ci
 
       - name: Verify Linter and Formatters
         run: npm run lint --if-present


### PR DESCRIPTION
Fixes #2696
Fixes #2697
Fixes #2698

- verify-pr.yml: replaced npm install with npm ci, added concurrency group + cancel-in-progress, added timeout-minutes: 10, switched to node-version-file
- ci.yml: added concurrency group + cancel-in-progress, added timeout-minutes: 15, reduced matrix to Node 20 only
- pr-checks.yml: added concurrency group + cancel-in-progress, added timeout-minutes: 10, switched to node-version-file
- stale.yml: added timeout-minutes: 5
- issue-auto-assign.yml: added timeout-minutes: 5
- contributor-guidelines.yml: added timeout-minutes: 5
- update-contributors.yml: added timeout-minutes: 10