### PR TITLE
Security: Remove hardcoded dummy private key from ci.yml workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,23 +50,23 @@ jobs:
       - name: 🔨 Build project
         run: npm run build
         env:
-          NEXT_PUBLIC_FIREBASE_API_KEY: dummy
-          NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN: dummy.firebaseapp.com
-          NEXT_PUBLIC_FIREBASE_PROJECT_ID: dummy
-          NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET: dummy.appspot.com
-          NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID: 123456789
-          NEXT_PUBLIC_FIREBASE_APP_ID: 1:123456789:web:abcdefghijklmnop
-          NEXT_PUBLIC_FIREBASE_MEASUREMENT_ID: G-DUMMY
-          MONGODB_URI: mongodb://localhost/dummy
-          MONGODB_DB: dummy
-          FIREBASE_PROJECT_ID: dummy
-          FIREBASE_PRIVATE_KEY: "-----BEGIN PRIVATE KEY-----\nMIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQC1\n-----END PRIVATE KEY-----"
-          FIREBASE_CLIENT_EMAIL: dummy@dummy.iam.gserviceaccount.com
-          BLOB_READ_WRITE_TOKEN: dummy_token
-          NEXT_PUBLIC_EMAILJS_SERVICE_ID: dummy
-          NEXT_PUBLIC_EMAILJS_TEMPLATE_ID: dummy
-          NEXT_PUBLIC_EMAILJS_USER_ID: dummy
-          GROQ_API_KEY: dummy
+          NEXT_PUBLIC_FIREBASE_API_KEY: ${{ vars.NEXT_PUBLIC_FIREBASE_API_KEY || 'dummy' }}
+          NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN: ${{ vars.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN || 'dummy.firebaseapp.com' }}
+          NEXT_PUBLIC_FIREBASE_PROJECT_ID: ${{ vars.NEXT_PUBLIC_FIREBASE_PROJECT_ID || 'dummy' }}
+          NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET: ${{ vars.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET || 'dummy.appspot.com' }}
+          NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID: ${{ vars.NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID || '000000000000' }}
+          NEXT_PUBLIC_FIREBASE_APP_ID: ${{ vars.NEXT_PUBLIC_FIREBASE_APP_ID || '1:000000000000:web:0000000000000000' }}
+          NEXT_PUBLIC_FIREBASE_MEASUREMENT_ID: ${{ vars.NEXT_PUBLIC_FIREBASE_MEASUREMENT_ID || 'G-DUMMY' }}
+          MONGODB_URI: ${{ secrets.MONGODB_URI || 'mongodb://localhost/dummy' }}
+          MONGODB_DB: ${{ vars.MONGODB_DB || 'dummy' }}
+          FIREBASE_PROJECT_ID: ${{ vars.FIREBASE_PROJECT_ID || 'dummy' }}
+          FIREBASE_PRIVATE_KEY: ${{ secrets.FIREBASE_PRIVATE_KEY || 'placeholder' }}
+          FIREBASE_CLIENT_EMAIL: ${{ secrets.FIREBASE_CLIENT_EMAIL || 'dummy@dummy.iam.gserviceaccount.com' }}
+          BLOB_READ_WRITE_TOKEN: ${{ secrets.BLOB_READ_WRITE_TOKEN || 'dummy_token' }}
+          NEXT_PUBLIC_EMAILJS_SERVICE_ID: ${{ vars.NEXT_PUBLIC_EMAILJS_SERVICE_ID || 'dummy' }}
+          NEXT_PUBLIC_EMAILJS_TEMPLATE_ID: ${{ vars.NEXT_PUBLIC_EMAILJS_TEMPLATE_ID || 'dummy' }}
+          NEXT_PUBLIC_EMAILJS_USER_ID: ${{ vars.NEXT_PUBLIC_EMAILJS_USER_ID || 'dummy' }}
+          GROQ_API_KEY: ${{ secrets.GROQ_API_KEY || 'dummy' }}
 
       - name: ✅ Build successful
         run: echo "✨ Build completed successfully!"


### PR DESCRIPTION
Fixes #2700

- Replaced hardcoded 18 env vars (including a private-key-format string) with GitHub Actions secrets/vars references
- All values fall back to safe placeholders when secrets/vars are not configured
- Prevents normalization of secrets-in-YAML anti-pattern