### PR TITLE
fix: standardize navbar mobile padding spacing

### DIFF
--- a/components/Navbar.js
+++ b/components/Navbar.js
@@ -709,7 +709,7 @@ export function Navbar() {
               initial="hidden"
               animate="visible"
               exit="exit"
-              className="fixed top-4 right-4 max-w-[85vw] w-64 rounded-2xl shadow-2xl p-4 space-y-4 z-[90] flex flex-col"
+              className="fixed top-[max(1rem,env(safe-area-inset-top))] right-[max(1rem,env(safe-area-inset-right))] max-w-[calc(100vw-2rem)] w-64 rounded-2xl shadow-2xl p-4 sm:p-5 space-y-4 z-[90] flex flex-col"
               style={{
                 backdropFilter: "blur(24px)",
                 WebkitBackdropFilter: "blur(24px)",


### PR DESCRIPTION
# Problem
The mobile navbar drawer uses fixed offsets and width constraints that do not account for very small screens or safe-area insets.

# Current Behavior
On compact mobile devices, drawer spacing can feel tight and may sit too close to screen edges or device safe areas.

# Why This Improvement Is Needed
Consistent mobile spacing improves usability and gives the navigation a more polished experience across phones.

# Proposed Solution
Update the mobile drawer positioning and padding classes to use safe-area-aware offsets and responsive padding.

# Expected Outcome
The navbar drawer keeps consistent spacing on compact devices while preserving the existing desktop layout.

# Additional Notes
This is an isolated styling-only update in components/Navbar.js.

Closes #2808