### PR TITLE
fix: add inline validation messages in login form

### DIFF
--- a/components/AuthForm.js
+++ b/components/AuthForm.js
@@ -104,6 +104,28 @@ const handleFieldChange = (field) => (value) => {
   const handleSubmit = (event) => {
     event.preventDefault();
 
+    const fieldsToValidate = isLogin
+      ? ["email", "password"]
+      : ["fullName", "email", "password", "confirmPassword"];
+    const nextErrors = {};
+
+    fieldsToValidate.forEach((field) => {
+      const result = validateAuthField(field, formData[field], {
+        isLogin,
+        password,
+        confirmPassword,
+      });
+
+      if (result !== true) {
+        nextErrors[field] = result;
+      }
+    });
+
+    if (Object.keys(nextErrors).length > 0) {
+      setErrors((prev) => ({ ...prev, ...nextErrors }));
+      return;
+    }
+
     if (!isLogin && password !== confirmPassword) {
       setErrors((prev) => ({
         ...prev,


### PR DESCRIPTION
# Problem
The login form can submit incomplete or invalid field values before showing field-level validation feedback.

# Current Behavior
Users may only see a submit-level authentication failure instead of immediate inline guidance for email or password fields.

# Why This Improvement Is Needed
Inline validation helps users correct issues faster and avoids unnecessary authentication requests.

# Proposed Solution
Validate login fields on submit inside the form component and set field-specific errors before calling the parent submit handler.

# Expected Outcome
Users receive clear inline messages for missing or invalid login fields before the auth request is sent.

# Additional Notes
This update is isolated to components/AuthForm.js.

Closes #2810