### PR TITLE
fix: trim password input before validation

### DIFF
--- a/components/AuthForm.js
+++ b/components/AuthForm.js
@@ -104,7 +104,17 @@ const handleFieldChange = (field) => (value) => {
   const handleSubmit = (event) => {
     event.preventDefault();
 
-    if (!isLogin && password !== confirmPassword) {
+    const submitData = isLogin
+      ? formData
+      : {
+          ...formData,
+          password: password.trim(),
+          confirmPassword: confirmPassword.trim(),
+        };
+    const submitPassword = submitData.password;
+    const submitConfirmPassword = submitData.confirmPassword;
+
+    if (!isLogin && submitPassword !== submitConfirmPassword) {
       setErrors((prev) => ({
         ...prev,
         confirmPassword: "Passwords do not match",
@@ -113,7 +123,7 @@ const handleFieldChange = (field) => (value) => {
     }
 
     // Pass the local state object cleanly to the parent's submit function
-    onSubmit(formData); 
+    onSubmit(submitData); 
   };
 
   const selectedRoleConfig = selectedRole ? ROLE_CONFIG[selectedRole] : null;


### PR DESCRIPTION
# Problem
Signup password and confirm-password values are validated exactly as typed, including accidental leading or trailing spaces.

# Current Behavior
Users can fail password matching or validation because of whitespace accidentally entered around signup passwords.

# Why This Improvement Is Needed
Normalizing signup password values before validation reduces avoidable form friction.

# Proposed Solution
Trim signup password and confirm-password values before validation and submission while preserving login password behavior.

# Expected Outcome
Signup password validation becomes more forgiving of accidental edge whitespace without changing login semantics.

# Additional Notes
This change is scoped to signup submit handling in components/AuthForm.js.

Closes #2811