### PR TITLE
fix: add defensive auth null safety checks

### DIFF
--- a/hooks/useAuth.js
+++ b/hooks/useAuth.js
@@ -171,6 +171,7 @@ export const useAuth = () => {
 
   useEffect(() => {
     if (!auth) {
+      setError("Authentication is not configured.");
       setLoading(false);
       return;
     }
@@ -197,6 +198,14 @@ export const useAuth = () => {
           // Create a new token refresh manager with exponential backoff retry
           refreshManagerRef.current = createTokenRefreshManager(firebaseUser, handleSessionExpired);
           refreshManagerRef.current.start();
+
+          if (!db || !firebaseUser?.uid) {
+            if (isMounted()) {
+              setUserProfile(null);
+              setLoading(false);
+            }
+            return;
+          }
 
           // Listen to the user profile document in real-time for profile data
           const userDocRef = doc(db, "users", firebaseUser.uid);
@@ -287,7 +296,9 @@ export const useAuth = () => {
         refreshManagerRef.current = null;
       }
       await clearAuthSessionCookie();
-      await firebaseSignOut(auth);
+      if (auth) {
+        await firebaseSignOut(auth);
+      }
       if (isMounted()) {
         setUser(null);
         setUserProfile(null);


### PR DESCRIPTION
# Problem
The auth hook assumes Firebase auth and Firestore services are available once the hook starts running.

# Current Behavior
If auth or db is not initialized, profile subscriptions or sign-out operations can fail with unclear errors.

# Why This Improvement Is Needed
Defensive checks make auth flows safer in misconfigured, test, or fallback environments.

# Proposed Solution
Add explicit auth/db null checks, avoid profile subscriptions without Firestore, and guard firebaseSignOut calls.

# Expected Outcome
The auth hook fails more gracefully and surfaces a clearer configuration error.

# Additional Notes
This change is scoped to hooks/useAuth.js.

Closes #2814