### PR TITLE
fix: improve sidebar keyboard accessibility

### DIFF
--- a/components/universal-settings.js
+++ b/components/universal-settings.js
@@ -648,12 +648,12 @@ export default function UniversalSettings() {
           {/* Sidebar Navigation */}
           <div className="lg:col-span-1">
             <div className="bg-black/20 backdrop-blur-2xl rounded-2xl border border-white/10 p-4 sticky top-24">
-              <nav className="space-y-2">
+              <nav className="space-y-2" aria-label="Settings sections">
                 {sections.map((section) => (
                   <button
                     key={section.id}
                     onClick={() => setActiveSection(section.id)}
-                    className={`w-full flex items-center space-x-3 px-4 py-3 rounded-lg font-medium transition-all duration-200 ${activeSection === section.id
+                    className={`w-full flex items-center space-x-3 px-4 py-3 rounded-lg font-medium transition-all duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950 ${activeSection === section.id
                         ? "bg-gradient-to-r from-blue-500 to-purple-600 text-white shadow-lg"
                         : "text-white/70 hover:text-white hover:bg-white/10"
                       }`}


### PR DESCRIPTION
# Problem
The settings sidebar navigation lacks an explicit navigation label and strong focus-visible styling.

# Current Behavior
Click navigation works, but keyboard users have less context and weaker focus indication.

# Why This Improvement Is Needed
Accessible navigation helps keyboard and assistive technology users move through settings sections confidently.

# Proposed Solution
Add an aria-label to the sidebar nav and focus-visible ring styles to sidebar buttons.

# Expected Outcome
The settings sidebar is clearer for assistive technology and keyboard navigation.

# Additional Notes
This change is scoped to components/universal-settings.js.

Closes #2815