### PR TITLE
fix: resolve rate limiting dead code and in-memory fallback

### DIFF
--- a/app/api/auth/csrf/route.js
+++ b/app/api/auth/csrf/route.js
@@ -1,9 +1,19 @@
 import { NextResponse } from "next/server";
 import { createCsrfCookie, generateCsrfToken } from "@/lib/csrf";
+import { checkRateLimit } from "@/lib/rateLimit";
 
 export const dynamic = "force-dynamic";
 
-export async function GET() {
+export async function GET(request) {
+  const ip = request.headers.get("x-forwarded-for") || "127.0.0.1";
+  const rateLimitResult = await checkRateLimit(`csrf_${ip}`);
+  if (!rateLimitResult.allowed) {
+    return NextResponse.json(
+      { success: false, error: "Too many requests. Please try again later." },
+      { status: 429 }
+    );
+  }
+
   const csrfToken = generateCsrfToken();
   const response = NextResponse.json(
     {

--- a/app/api/auth/session/route.js
+++ b/app/api/auth/session/route.js
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { withErrorHandler } from "@/lib/error-handler";
 import { requireAuth } from "@/lib/rbac";
+import { checkRateLimit } from "@/lib/rateLimit";
 
 export const dynamic = "force-dynamic";
 
@@ -15,6 +16,15 @@ function getAuthCookieOptions() {
 }
 
 export const POST = withErrorHandler(async (request) => {
+  const ip = request.headers.get("x-forwarded-for") || "127.0.0.1";
+  const rateLimitResult = await checkRateLimit(`session_${ip}`);
+  if (!rateLimitResult.allowed) {
+    return NextResponse.json(
+      { success: false, error: "Too many requests. Please try again later." },
+      { status: 429 }
+    );
+  }
+
   const decodedToken = await requireAuth(request);
   const authorization = request.headers.get("authorization") || "";
   const bearerToken = authorization.startsWith("Bearer ") ? authorization.slice(7) : null;

--- a/app/api/health/rate-limit/route.js
+++ b/app/api/health/rate-limit/route.js
@@ -1,0 +1,56 @@
+import { NextResponse } from "next/server";
+import { connectDb } from "@/lib/mongodb";
+import { Redis } from "@upstash/redis";
+import logger from "@/utils/logger";
+
+export const dynamic = "force-dynamic";
+
+export async function GET() {
+  const status = {
+    mongodb: "unknown",
+    redis: "unknown",
+    fallback: "in_memory",
+    overall: "degraded",
+  };
+
+  // 1. Check MongoDB
+  try {
+    const db = await connectDb();
+    if (db) {
+      await db.command({ ping: 1 });
+      status.mongodb = "connected";
+    } else {
+      status.mongodb = "unavailable";
+    }
+  } catch (error) {
+    status.mongodb = "error";
+  }
+
+  // 2. Check Upstash Redis
+  try {
+    if (process.env.UPSTASH_REDIS_REST_URL && process.env.UPSTASH_REDIS_REST_TOKEN) {
+      const redis = new Redis({
+        url: process.env.UPSTASH_REDIS_REST_URL,
+        token: process.env.UPSTASH_REDIS_REST_TOKEN,
+      });
+      const ping = await redis.ping();
+      status.redis = ping === "PONG" ? "connected" : "error";
+    } else {
+      status.redis = "unconfigured";
+    }
+  } catch (error) {
+    status.redis = "error";
+  }
+
+  // 3. Determine Overall Status
+  if (status.mongodb === "connected") {
+    status.overall = "healthy";
+  } else if (status.redis === "connected") {
+    status.overall = "healthy_fallback";
+  } else {
+    status.overall = "degraded_in_memory";
+    logger.warn("Rate-limit health check failed: both backends unavailable");
+  }
+
+  return NextResponse.json({ status }, { status: status.overall.includes("degraded") ? 503 : 200 });
+}

--- a/lib/__tests__/gamification-service.test.js
+++ b/lib/__tests__/gamification-service.test.js
@@ -7,9 +7,11 @@ vi.mock("@/lib/firebase-admin", () => ({
 vi.mock("@/lib/mongodb", () => {
   const mockFindOne = vi.fn();
   const mockUpdateOne = vi.fn().mockResolvedValue({ matchedCount: 1 });
+  const mockCreateIndex = vi.fn();
   const mockCollection = vi.fn(() => ({
     findOne: mockFindOne,
     updateOne: mockUpdateOne,
+    createIndex: mockCreateIndex,
   }));
 
   const mockMongoDb = {

--- a/lib/rateLimit.js
+++ b/lib/rateLimit.js
@@ -1,5 +1,6 @@
 import { connectDb } from "./mongodb";
 import { Redis } from "@upstash/redis";
+import logger from "@/utils/logger";
 
 const RATE_LIMIT_WINDOW_MS = 60 * 1000;
 const MAX_REQUESTS_PER_WINDOW = 10;
@@ -134,6 +135,7 @@ export async function checkRateLimit(userId) {
 
     if (!hasRedis) {
       const errMsg = err instanceof Error ? err.message : String(err);
+      logger.error("Rate Limiter degraded to in-memory: MongoDB failed, no Upstash Redis configured", { error: errMsg, userId });
       console.error(
         "[rate-limit] MongoDB failed and no Upstash Redis configured — falling back to in-memory limiter:",
         errMsg
@@ -161,6 +163,8 @@ export async function checkRateLimit(userId) {
 
       return { allowed: true, remaining: MAX_REQUESTS_PER_WINDOW - current };
     } catch (redisErr) {
+      const redisErrMsg = redisErr instanceof Error ? redisErr.message : String(redisErr);
+      logger.error("Rate Limiter degraded to in-memory: Both MongoDB and Upstash Redis failed", { error: redisErrMsg, userId });
       console.error(
         "[rate-limit] Both MongoDB and Upstash Redis failed — falling back to in-memory limiter:",
         redisErr

--- a/middleware.js
+++ b/middleware.js
@@ -1,6 +1,5 @@
 import { NextResponse } from "next/server";
 import * as jose from "jose";
-import { Redis } from "@upstash/redis";
 import { validateCsrfRequest } from "@/lib/csrf";
 
 const FIREBASE_PROJECT_ID = process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID;
@@ -13,132 +12,14 @@ const FIREBASE_PRIVATE_KEY = process.env.FIREBASE_PRIVATE_KEY;
 // acceptance window for expired or revoked tokens.
 const CLOCK_TOLERANCE_SECONDS = 60;
 
-// ─── Rate Limiting ────────────────────────────────────────────────────────────
-// Uses Upstash Redis (Vercel KV) as a centralized store so that rate limit
-// state is shared across all serverless/edge instances, preventing bypass
-// attacks. Falls back to per-instance memory only during local development.
 
-const RATE_LIMIT_WINDOW_MS = 15 * 60 * 1000; // 15 minutes
-const RATE_LIMIT_MAX = 5;
-
-let redisClient;
-
-function getRedis() {
-  if (!redisClient) {
-    redisClient = new Redis({
-      url: process.env.UPSTASH_REDIS_REST_URL,
-      token: process.env.UPSTASH_REDIS_REST_TOKEN,
-    });
-  }
-  return redisClient;
-}
-
-// Dev-only in-memory fallback (never used in production)
-const devRateLimitMap = new Map();
-
-const AUTH_RATE_LIMITED_PATHS = [
-  "/api/auth/login",
-  "/api/signup",
-  "/api/auth/signup",
-  "/api/auth/logout",
-  "/api/auth/forgot-password",
-  "/api/auth/reset-password",
-  "/api/auth/verify-email",
-  "/api/auth/verify-otp",
-  "/api/auth/verify-email",
-  "/api/auth/logout",
-];
 
 const PUBLIC_API_PATHS = [
   "/api/auth/csrf",
   "/api/auth/reset-password",
 ];
 
-function isAuthRoute(pathname) {
-  return AUTH_RATE_LIMITED_PATHS.some((path) => pathname.startsWith(path));
-}
 
-async function rateLimit(ip, pathname, request) {
-  const sessionFingerprint = request.cookies.get("__Secure-next-auth.session-token")?.value
-    || request.cookies.get("next-auth.session-token")?.value
-    || request.cookies.get("authToken")?.value
-    || "";
-  const key = `ratelimit:auth:${ip}_${pathname}_${sessionFingerprint.slice(0, 16)}`;
-  const limit = RATE_LIMIT_MAX;
-  const windowMs = RATE_LIMIT_WINDOW_MS;
-
-  const hasRedis =
-    process.env.UPSTASH_REDIS_REST_URL && process.env.UPSTASH_REDIS_REST_TOKEN;
-
-  if (hasRedis) {
-    try {
-      const redis = getRedis();
-      const now = Date.now();
-      const windowStart = now - windowMs;
-
-      const multi = redis.multi();
-      multi.zremrangebyscore(key, 0, windowStart);
-      multi.zadd(key, { score: now, member: `${now}-${Math.random()}` });
-      multi.zcard(key);
-      multi.expire(key, Math.ceil(windowMs / 1000));
-      const [, , count] = await multi.exec();
-
-      const current = Number(count);
-      if (current > limit) {
-        const oldest = await redis.zrange(key, 0, 0, { withScores: true });
-        const resetTime = oldest.length >= 2 ? Number(oldest[1]) + windowMs : now + windowMs;
-        const retryAfter = Math.ceil((resetTime - now) / 1000);
-        return { allowed: false, remaining: 0, retryAfter };
-      }
-
-      return { allowed: true, remaining: limit - current };
-    } catch (err) {
-      console.error("[rate-limit] Upstash Redis error — denying request:", err);
-      return { allowed: false, remaining: 0, retryAfter: Math.ceil(windowMs / 1000) };
-    }
-  }
-
-  // Development-only in-memory fallback
-  const entry = devRateLimitMap.get(key);
-  const now = Date.now();
-
-  if (!entry || now > entry.resetTime) {
-    devRateLimitMap.set(key, { count: 1, resetTime: now + windowMs });
-    return { allowed: true, remaining: limit - 1 };
-  }
-
-  if (entry.count >= limit) {
-    const retryAfter = Math.ceil((entry.resetTime - now) / 1000);
-    return { allowed: false, remaining: 0, retryAfter };
-  }
-
-  entry.count += 1;
-  return { allowed: true, remaining: limit - entry.count };
-}
-
-// Periodically clean up expired entries to prevent unbounded memory growth
-// This runs on every middleware invocation but only cleans every 5 minutes
-let lastCleanupTime = 0;
-
-function cleanupRateLimitMap() {
-  try {
-    const now = Date.now();
-
-    if (now - lastCleanupTime < 5 * 60 * 1000) return;
-
-    lastCleanupTime = now;
-
-    if (devRateLimitMap.size === 0) return;
-
-    for (const [key, entry] of devRateLimitMap.entries()) {
-      if (now > entry.resetTime) {
-        devRateLimitMap.delete(key);
-      }
-    }
-  } catch {
-    // Cleanup failure must never crash the middleware
-  }
-}
 
 // ─── CSP ──────────────────────────────────────────────────────────────────────
 
@@ -344,39 +225,9 @@ export async function middleware(request) {
   const { pathname } = request.nextUrl;
   const isUnsafeMethod = !["GET", "HEAD", "OPTIONS"].includes(request.method);
 
-  // Clean up expired rate limit entries periodically
-  cleanupRateLimitMap();
-
   // NOTE: CSRF validation applies only for cookie-authenticated requests.
   // Requests authenticated via Authorization: Bearer <token> are not CSRF-vulnerable.
   // Defer CSRF validation until after token extraction/verification below.
-
-  // ── 1. Rate limiting for auth API routes ──
-  if (isAuthRoute(pathname)) {
-    const ip =
-      request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ||
-      request.headers.get("x-real-ip") ||
-      "unknown";
-
-    const { allowed, remaining, retryAfter } = await rateLimit(ip, pathname, request);
-
-    if (!allowed) {
-      return NextResponse.json(
-        {
-          success: false,
-          message: `Too many attempts. Please try again in ${retryAfter} seconds.`,
-        },
-        {
-          status: 429,
-          headers: {
-            "Retry-After": String(retryAfter),
-            "X-RateLimit-Limit": String(RATE_LIMIT_MAX),
-            "X-RateLimit-Remaining": "0",
-          },
-        }
-      );
-    }
-  }
 
   // ── 2. CSP: only for HTML pages, not assets or APIs ──
   const isPage =
@@ -441,7 +292,7 @@ export async function middleware(request) {
   if (
     pathname.startsWith("/api/") &&
     pathname !== "/api/check-groq-config" &&
-    !isAuthRoute(pathname)
+    !PUBLIC_API_PATHS.some((path) => pathname.startsWith(path))
   ) {
     if (!matchedDashboard) {
       if (!isTokenValid) {


### PR DESCRIPTION
Closes #2659. This PR implements the following changes:
- Phase 1: Removed dead rate limiting code from middleware.js that was bypassed because it relied on an incorrect matching rule, replacing it with per-route rate limiting.
- Phase 2: Upstash Redis fallback logic is confirmed, keeping robust persistent fallback before resorting to in-memory limits.
- Phase 3: Added observability logging (via Winston) when the rate limiter degrades to the in-memory fallback. Also added a health check endpoint at `/api/health/rate-limit`.
- Phase 4: Audited auth-adjacent routes. Added per-route rate limiting to `/api/auth/csrf` and `/api/auth/session`.