### PR TITLE
fix: resolve IDOR in images and labels API (#2658)

### DIFF
--- a/app/api/images/route.js
+++ b/app/api/images/route.js
@@ -6,6 +6,7 @@ import { del } from "@vercel/blob";
 import { connectDb } from "@/lib/mongodb";
 import { getUserProfile } from "@/lib/firebase-admin";
 import { AppError, ForbiddenError, NotFoundError } from "@/lib/errors";
+import logger from "@/utils/logger";
 import {
   extractImageFileFromFormData,
   fetchAndValidateImage,
@@ -19,30 +20,31 @@ import {
 export const dynamic = "force-dynamic";
 
 export const GET = withErrorHandler(async (request) => {
+  const ip = request.headers.get("x-forwarded-for") || "127.0.0.1";
   const { searchParams } = new URL(request.url);
   const id = searchParams.get("id");
 
+  const rateLimitResult = await checkRateLimit(`images_get_${ip}`);
+  if (!rateLimitResult.allowed) {
+    throw new AppError("Too many attempts. Please try again later.", 429);
+  }
+
   const decodedToken = await requireAuth(request);
+  const profile = await getUserProfile(decodedToken.uid) || { role: "student" };
 
-  const db = await connectDb();
-  const users = db.collection("users");
-  const requestingUser = await users.findOne(
-    { firebaseUid: decodedToken.uid },
-    { projection: { _id: 1 } }
-  );
+  const imageUrl = await getUserImageFromDb({ 
+    id, 
+    callerUid: decodedToken.uid,
+    callerRole: profile.role,
+    callerInstituteId: profile.instituteId
+  });
 
-  if (!requestingUser) {
-    throw new NotFoundError("User not found");
-  }
+  logger.info("Image accessed", {
+    userId: decodedToken.uid,
+    targetId: id,
+    timestamp: new Date().toISOString()
+  });
 
-  if (requestingUser._id.toString() !== id) {
-    const profile = await getUserProfile(decodedToken.uid);
-    if (!profile || !["admin", "teacher"].includes(profile.role)) {
-      throw new ForbiddenError("You can only view your own profile image");
-    }
-  }
-
-  const imageUrl = await getUserImageFromDb({ id });
   const { imageBuffer, contentType } = await fetchAndValidateImage(imageUrl);
 
   return new NextResponse(imageBuffer, {

--- a/app/api/labels/route.js
+++ b/app/api/labels/route.js
@@ -37,6 +37,16 @@ export const GET = withErrorHandler(async (request) => {
       }
     : {};
 
+  if (profile.role !== "admin") {
+    if (profile.instituteId) {
+      query.instituteId = profile.instituteId;
+    } else {
+      // If a non-admin (like a student) doesn't have an instituteId,
+      // they shouldn't be able to search other users globally.
+      query.instituteId = "unassigned_no_match";
+    }
+  }
+
   // Database — faceDescriptor is excluded from the projection.
   // Biometric embeddings are sensitive personal data and must not be
   // returned to arbitrary authenticated callers.

--- a/components/__tests__/imagesRoute.test.js
+++ b/components/__tests__/imagesRoute.test.js
@@ -3,7 +3,8 @@ import { GET, POST } from "@/app/api/images/route";
 import { requireAuth } from "@/lib/rbac";
 import { connectDb } from "@/lib/mongodb";
 import { getUserProfile } from "@/lib/firebase-admin";
-import { NotFoundError } from "@/lib/errors";
+import { ForbiddenError, NotFoundError } from "@/lib/errors";
+import { checkRateLimit } from "@/lib/rateLimit";
 import {
   extractImageFileFromFormData,
   fetchAndValidateImage,
@@ -41,6 +42,10 @@ vi.mock("@/lib/rbac", () => ({
   requireAuth: vi.fn(),
 }));
 
+vi.mock("@/lib/rateLimit", () => ({
+  checkRateLimit: vi.fn(),
+}));
+
 vi.mock("@/lib/mongodb", () => ({
   connectDb: vi.fn(),
 }));
@@ -71,6 +76,8 @@ describe("/api/images route orchestration", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     validateFaceDescriptor.mockReturnValue(null);
+    checkRateLimit.mockResolvedValue({ allowed: true, remaining: 10 });
+    getUserProfile.mockResolvedValue(null);
   });
 
   test("GET returns own image when requested id matches authenticated user", async () => {
@@ -100,6 +107,9 @@ describe("/api/images route orchestration", () => {
     expect(requireAuth).toHaveBeenCalledWith(req);
     expect(getUserImageFromDb).toHaveBeenCalledWith({
       id: userId.toString(),
+      callerUid: uid,
+      callerRole: "student",
+      callerInstituteId: undefined,
     });
     expect(fetchAndValidateImage).toHaveBeenCalledWith(
       "https://public.blob.vercel-storage.com/a.jpg"
@@ -108,16 +118,11 @@ describe("/api/images route orchestration", () => {
 
   test("GET rejects when user requests another user's image and is not admin or teacher", async () => {
     const uid = "firebase-uid-1";
-    const ownId = new ObjectId();
     const otherId = new ObjectId();
 
     requireAuth.mockResolvedValue({ uid });
-    connectDb.mockResolvedValue({
-      collection: vi.fn().mockReturnValue({
-        findOne: vi.fn().mockResolvedValue({ _id: ownId }),
-      }),
-    });
     getUserProfile.mockResolvedValue({ role: "student" });
+    getUserImageFromDb.mockRejectedValue(new ForbiddenError("You do not have permission to view this image"));
 
     const req = {
       url: `https://learnova.test/api/images?id=${otherId.toString()}`,
@@ -128,20 +133,14 @@ describe("/api/images route orchestration", () => {
     const body = await response.json();
 
     expect(response.status).toBe(403);
-    expect(body.error).toBe("You can only view your own profile image");
+    expect(body.error).toBe("You do not have permission to view this image");
   });
 
   test("GET allows admin to view any user's image", async () => {
     const uid = "admin-uid-1";
-    const ownId = new ObjectId();
     const otherId = new ObjectId();
 
     requireAuth.mockResolvedValue({ uid });
-    connectDb.mockResolvedValue({
-      collection: vi.fn().mockReturnValue({
-        findOne: vi.fn().mockResolvedValue({ _id: ownId }),
-      }),
-    });
     getUserProfile.mockResolvedValue({ role: "admin" });
     getUserImageFromDb.mockResolvedValue("https://public.blob.vercel-storage.com/admin-view.jpg");
     fetchAndValidateImage.mockResolvedValue({
@@ -159,27 +158,18 @@ describe("/api/images route orchestration", () => {
     expect(response.status).toBe(200);
     expect(getUserImageFromDb).toHaveBeenCalledWith({
       id: otherId.toString(),
+      callerUid: uid,
+      callerRole: "admin",
+      callerInstituteId: undefined,
     });
   });
 
   test("GET allows teacher to view any user's image", async () => {
     const uid = "teacher-uid-1";
-    const ownId = new ObjectId();
     const otherId = new ObjectId();
-    const instituteId = new ObjectId();
 
     requireAuth.mockResolvedValue({ uid });
-    
-    const findOneMock = vi.fn()
-      .mockResolvedValueOnce({ _id: ownId, instituteId })
-      .mockResolvedValueOnce({ _id: otherId, instituteId });
-
-    connectDb.mockResolvedValue({
-      collection: vi.fn().mockReturnValue({
-        findOne: findOneMock,
-      }),
-    });
-    getUserProfile.mockResolvedValue({ role: "teacher" });
+    getUserProfile.mockResolvedValue({ role: "teacher", instituteId: "inst1" });
     getUserImageFromDb.mockResolvedValue("https://public.blob.vercel-storage.com/teacher-view.jpg");
     fetchAndValidateImage.mockResolvedValue({
       imageBuffer: new ArrayBuffer(3),
@@ -194,28 +184,6 @@ describe("/api/images route orchestration", () => {
     const response = await GET(req);
 
     expect(response.status).toBe(200);
-  });
-
-  test("GET returns 404 if authenticated user has no MongoDB record", async () => {
-    const uid = "orphan-uid";
-
-    requireAuth.mockResolvedValue({ uid });
-    connectDb.mockResolvedValue({
-      collection: vi.fn().mockReturnValue({
-        findOne: vi.fn().mockResolvedValue(null),
-      }),
-    });
-
-    const req = {
-      url: "https://learnova.test/api/images?id=507f1f77bcf86cd799439011",
-      headers: { get: vi.fn() },
-    };
-
-    const response = await GET(req);
-    const body = await response.json();
-
-    expect(response.status).toBe(404);
-    expect(body.error).toBe("User not found");
   });
 
   test("POST orchestrates auth, file extraction, upload and DB update", async () => {

--- a/components/__tests__/labelsRoute.test.js
+++ b/components/__tests__/labelsRoute.test.js
@@ -118,7 +118,7 @@ describe("GET /api/labels - Security & Authentication Tests", () => {
       { name: "Bob", email: "bob@domain.com", sensitiveField: "secret", hasImage: true },
     ]);
     expect(connectDb).toHaveBeenCalled();
-    expect(mockFind).toHaveBeenCalledWith({}, { projection: { _id: 1, name: 1, email: 1, image: 1 } });
+    expect(mockFind).toHaveBeenCalledWith({ instituteId: "unassigned_no_match" }, { projection: { _id: 1, name: 1, email: 1, image: 1 } });
     expect(mockLimit).toHaveBeenCalledWith(50);
   });
 
@@ -137,6 +137,7 @@ describe("GET /api/labels - Security & Authentication Tests", () => {
           { name: { $regex: "alice", $options: "i" } },
           { email: { $regex: "alice", $options: "i" } },
         ],
+        instituteId: "unassigned_no_match",
       },
       { projection: { _id: 1, name: 1, email: 1, image: 1 } }
     );
@@ -159,6 +160,7 @@ describe("GET /api/labels - Security & Authentication Tests", () => {
           { name: { $regex: "test\\.\\*\\+\\?", $options: "i" } },
           { email: { $regex: "test\\.\\*\\+\\?", $options: "i" } },
         ],
+        instituteId: "unassigned_no_match",
       },
       { projection: { _id: 1, name: 1, email: 1, image: 1 } }
     );

--- a/lib/__tests__/gamification-service.test.js
+++ b/lib/__tests__/gamification-service.test.js
@@ -7,9 +7,11 @@ vi.mock("@/lib/firebase-admin", () => ({
 vi.mock("@/lib/mongodb", () => {
   const mockFindOne = vi.fn();
   const mockUpdateOne = vi.fn().mockResolvedValue({ matchedCount: 1 });
+  const mockCreateIndex = vi.fn();
   const mockCollection = vi.fn(() => ({
     findOne: mockFindOne,
     updateOne: mockUpdateOne,
+    createIndex: mockCreateIndex,
   }));
 
   const mockMongoDb = {

--- a/lib/images/imagesService.js
+++ b/lib/images/imagesService.js
@@ -6,6 +6,7 @@ import { z } from "zod";
 import { connectDb } from "@/lib/mongodb";
 import {
   AppError,
+  ForbiddenError,
   NotFoundError,
   ValidationError,
 } from "@/lib/errors";
@@ -78,22 +79,37 @@ export function validateRemoteImageUrl(url) {
   return parsedUrl;
 }
 
-export async function getUserImageFromDb({ id }) {
+export async function getUserImageFromDb({ id, callerUid, callerRole, callerInstituteId }) {
   const objectId = validateImageRequestId(id);
 
   const db = await connectDb();
   const users = db.collection("users");
 
-  const user = await users.findOne(
+  const targetUser = await users.findOne(
     { _id: objectId },
-    { projection: { image: 1 } }
+    { projection: { image: 1, firebaseUid: 1, instituteId: 1 } }
   );
 
-  if (!user?.image) {
+  if (!targetUser?.image) {
     throw new NotFoundError("Image not found");
   }
 
-  return user.image;
+  // Admins can view any image
+  if (callerRole === "admin") {
+    return targetUser.image;
+  }
+
+  // Users can view their own image
+  if (targetUser.firebaseUid === callerUid) {
+    return targetUser.image;
+  }
+
+  // Teachers and Institute Admins can view images of users within their institution
+  if (["teacher", "institute"].includes(callerRole) && callerInstituteId && targetUser.instituteId === callerInstituteId) {
+    return targetUser.image;
+  }
+
+  throw new ForbiddenError("You do not have permission to view this image");
 }
 
 export async function fetchAndValidateImage(url) {


### PR DESCRIPTION
Closes #2658.

This PR addresses the critical IDOR and enumeration vulnerabilities identified in Issue #2658:
- **Phase 1 & 4**: Modified `getUserImageFromDb` in `imagesService.js` to accept the caller's context (UID, Role, Institute ID) and perform strict ownership and RBAC checks securely at the service layer.
- **Phase 1 & 3**: Updated `app/api/images/route.js` to enforce rate limiting, pass caller context down to the service layer, and emit an audit log via Winston whenever an image is accessed.
- **Phase 2**: Scoped the `app/api/labels/route.js` search query by `instituteId` for non-admin users to prevent global enumeration of all users. If a student is somehow lacking an `instituteId`, they are isolated into a safe fallback constraint.
- Fixed associated unit tests (and the unrelated `createIndex` error in `gamification-service.test.js`).

All tests pass successfully.