### PR TITLE
[SECURITY] CSRF cookie is not Secure in non-production

### DIFF
--- a/lib/csrf.js
+++ b/lib/csrf.js
@@ -22,14 +22,24 @@ export function generateCsrfToken() {
 }
 
 export function getCsrfCookieOptions() {
+  // Prefer an explicit override. This helps in staging/test and reverse-proxy setups.
+  // If CSRF_COOKIE_SECURE is set to "true"/"false", it wins.
+  const explicitSecure = process.env.CSRF_COOKIE_SECURE;
+  const secure =
+    explicitSecure === "true" ? true : explicitSecure === "false" ? false : true;
+
+  // Default behavior is secure-by-default.
+  // If you truly need HTTP-only cookies for local development, set:
+  //   CSRF_COOKIE_SECURE=false
   return {
     httpOnly: false,
     sameSite: "lax",
-    secure: process.env.NODE_ENV === "production",
+    secure,
     path: "/",
     maxAge: 60 * 60 * 24 * 7,
   };
 }
+
 
 export function getClientCsrfToken() {
   if (typeof document === "undefined") {


### PR DESCRIPTION
Fixed CSRF cookie Secure flag to be secure-by-default with explicit environment override.

Updated lib/csrf.js getCsrfCookieOptions():
Replaced secure: process.env.NODE_ENV === "production" with:
CSRF_COOKIE_SECURE="true" -> secure: true
CSRF_COOKIE_SECURE="false" -> secure: false
unset -> secure: true
This prevents weakening CSRF protection in staging/test/non-production when the site is actually served over HTTPS.


closes #2760