### PR TITLE
fix: resolve AI chatbot API contract mismatch (#2657)

### DIFF
--- a/components/ChatBot.js
+++ b/components/ChatBot.js
@@ -293,7 +293,7 @@ async function generateBotResponse(userMessage, currentCategory, idToken, update
     const headers = { "Content-Type": "application/json" };
     if (idToken) headers["Authorization"] = `Bearer ${idToken}`;
     
-    const response = await apiFetch("/api/groq", {
+    const payload = await apiFetch("/api/groq", {
       method: "POST",
       headers,
       body: JSON.stringify({ 
@@ -305,8 +305,7 @@ async function generateBotResponse(userMessage, currentCategory, idToken, update
       }),
     });
 
-    if (response.ok) {
-      const payload = await response.json();
+    if (payload) {
       return payload?.data?.message || payload?.message;
     }
   } catch {
@@ -458,8 +457,8 @@ export default function LearnovaChatbot() {
 
         if (!isMounted) return;
 
-        if (response.ok) {
-          const payload = await response.json();
+        if (response && response.success !== false) {
+          const payload = response;
           const history = payload?.data || [];
           if (history.length > 0) {
             const historyMessages = [];


### PR DESCRIPTION
Closes #2657.

This PR fixes the final critical bugs keeping the Nova AI chatbot from functioning properly.

**Root Cause:**
While the backend ( and ) was recently updated to properly accept and manage the full conversation history array and manage the token limits, the frontend client was still trying to consume  as if it were the native  object. Since  in  automatically parses and returns the JSON payload upon success (or throws  upon failure), checking  resulted in  evaluating to . This caused the client to silently bypass the AI response and permanently drop into the local fallback responses.

**Changes:**
- Modified  to correctly handle the returned JSON payload from  for both  and  endpoints.
- Removed invalid  checks and  invocations.
- Re-verified that the backend accurately passes conversation context into the Llama model within token boundaries.

The AI chatbot now correctly reaches Groq, handles conversation history, and displays AI-generated responses.