### PR TITLE
fix: resolve attendance schema mismatch (#2767)

### DIFF
--- a/app/api/attendance/record/route.js
+++ b/app/api/attendance/record/route.js
@@ -37,14 +37,14 @@ export const POST = withErrorHandler(async (request) => {
     return jsonError("Forbidden: Cannot submit attendance for another user", 403);
   }
 
-  // 3. Ensure they actually matched the face threshold (60 is the minimum configured in the frontend)
+  // 3. Ensure they actually matched the face threshold (0.60 is the minimum configured in the frontend)
   const parsedConfidence = Number(confidenceScore);
-  if (parsedConfidence < 60) {
+  if (parsedConfidence < 0.6) {
     return jsonError("Bad Request: Confidence score too low", 400);
   }
 
-  // Normalize confidence score to 0-1 range for consistency across the DB and dashboards
-  const normalizedConfidence = parsedConfidence / 100;
+  // Confidence score is already normalized to 0-1 range by the validation schema
+  const normalizedConfidence = parsedConfidence;
 
   // 4. Write attendance to Firestore (single source of truth).
   // Use a deterministic doc id and a transaction to prevent duplicates and match client duplicate checks.


### PR DESCRIPTION
Closes #2767.

### What does this PR do?
Fixes a critical validation mismatch that prevented users from marking attendance. The validation schema enforcing a `confidenceScore` between 0 and 1 was fundamentally conflicting with the route handler's expectation of a raw score out of 100, causing a universal `400 Bad Request` failure.

### Changes Made:
- Updated `app/api/attendance/record/route.js` to evaluate `parsedConfidence < 0.6` (reflecting the 0-1 bounds already enforced by Zod) instead of `< 60`.
- Removed redundant division by 100 since the score is pre-normalized by the frontend/schema.

### Testing
- Submitting an attendance request with `confidenceScore: 0.85` successfully records the attendance.
- Submitting an attendance request with `confidenceScore: 0.40` correctly yields a 400 error.
