### PR TITLE
fix: use Next.js fetch cache for Firebase public keys in edge middleware

### DIFF
--- a/middleware.js
+++ b/middleware.js
@@ -68,32 +68,17 @@ function buildPageCsp() {
 // This eliminates 100-300ms latency per request and removes the dependency
 // on Google's API availability.
 
-let cachedPublicKey = null;
-let publicKeyFetchTime = 0;
-const PUBLIC_KEY_CACHE_TTL_MS = 60 * 60 * 1000; // 1 hour
-
-/**
- * Fetches the Firebase public keys for JWT verification.
- * Caches the keys for 1 hour to avoid repeated HTTP calls.
- * Falls back to the identitytoolkit endpoint if key fetching fails.
- */
 async function getFirebasePublicKeys() {
-  const now = Date.now();
-  if (cachedPublicKey && now - publicKeyFetchTime < PUBLIC_KEY_CACHE_TTL_MS) {
-    return cachedPublicKey;
-  }
-
   try {
     const response = await fetch(
-      "https://www.googleapis.com/robot/v1/metadata/x509/securetoken@system.gserviceaccount.com"
+      "https://www.googleapis.com/robot/v1/metadata/x509/securetoken@system.gserviceaccount.com",
+      { next: { revalidate: 3600 } } // Cache for 1 hour using Next.js Data Cache
     );
     if (!response.ok) throw new Error("Failed to fetch public keys");
-    const data = await response.json();
-    cachedPublicKey = data;
-    publicKeyFetchTime = now;
-    return data;
-  } catch {
-    return cachedPublicKey;
+    return await response.json();
+  } catch (error) {
+    console.error("Failed to fetch Firebase public keys:", error);
+    return null;
   }
 }
 


### PR DESCRIPTION
This pull request updates the way Firebase public keys are fetched and cached in `middleware.js`. The change removes the manual in-memory caching logic and instead leverages Next.js's built-in Data Cache for a more robust and scalable solution.

**Improvements to public key fetching and caching:**

* Removed custom in-memory caching (`cachedPublicKey`, `publicKeyFetchTime`, and manual TTL logic) from the `getFirebasePublicKeys` function, and now use the Next.js Data Cache by passing a `revalidate` option to the fetch call for 1-hour caching.
* Improved error handling by logging failures and returning `null` instead of potentially stale cached data.

Closes #2781 