### PR TITLE
Critical: fix Google login ReferenceError by adding missing isMockAuthMode and MOCK_USER imports

### DIFF
--- a/services/authService.js
+++ b/services/authService.js
@@ -1,4 +1,4 @@
-import { auth, db } from "@/lib/firebaseConfig";
+import { auth, db, isMockAuthMode, MOCK_USER } from "@/lib/firebaseConfig";
 import {
   GoogleAuthProvider,
   signInWithPopup,


### PR DESCRIPTION
## What the issue was
The loginWithGoogle function in services/authService.js referenced isMockAuthMode and MOCK_USER but these exports were never imported from @/lib/firebaseConfig. This caused a ReferenceError: isMockAuthMode is not defined every time Google login was attempted in development mode (or if the code path was evaluated in production).

## What I fixed
Added isMockAuthMode and MOCK_USER to the existing destructured import from @/lib/firebaseConfig on line 1:
`js
import { auth, db, isMockAuthMode, MOCK_USER } from "@/lib/firebaseConfig";
`

## Closes
Closes #2798

## Additional context
- This blocks ALL Google OAuth sign-in/sign-up in development mode without Firebase credentials
- The variables are defined and exported from @/lib/firebaseConfig but simply weren't imported
- Minimal one-line change with no side effects