### PR TITLE
Critical: fix streak sync crash by adding missing normalizeStreakCount import and fixing const reassignment

### DIFF
--- a/components/ClientLayout.js
+++ b/components/ClientLayout.js
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useReducer, useState } from "react";
 import dynamic from "next/dynamic";
 import { useKeyboardShortcuts } from "@/hooks/useKeyboardShortcuts";
 import { useIdleTimeout } from "@/hooks/useIdleTimeout";
+import { normalizeStreakCount } from "@/lib/streakUtils";
 import ErrorBoundary from "@/components/ErrorBoundary";
 import ShortcutsModal from "@/components/ShortcutsModal";
 import SearchModal from "@/components/SearchModal";
@@ -196,9 +197,7 @@ export default function ClientLayout({ children }) {
         }
         if (!Array.isArray(clientHistory)) clientHistory = [];
 
-        const firestoreStreak = userProfile?.siteStreak || 0;
-        // 2. Fetch Firestore profile variables
-        firestoreStreak = normalizeStreakCount(userProfile?.siteStreak);
+        const firestoreStreak = normalizeStreakCount(userProfile?.siteStreak) ?? 0;
         const firestoreLastVisit = userProfile?.siteLastVisit || "";
         const firestoreHistory = userProfile?.siteVisitHistory || [];
 


### PR DESCRIPTION
## What the issue was
The streak-sync useEffect in components/ClientLayout.js had two bugs:
1. 
ormalizeStreakCount() was called but never imported ? ReferenceError
2. irestoreStreak was declared as const then immediately reassigned ? TypeError: Assignment to constant variable

## What I fixed
1. Added import { normalizeStreakCount } from "@/lib/streakUtils";
2. Consolidated the duplicate assignment to a single const: const firestoreStreak = normalizeStreakCount(userProfile?.siteStreak) ?? 0;

## Closes
Closes #2799

## Additional context
- The streak feature (consecutive-day visitor tracking) was completely broken - the effect threw on every execution
- The toast notification for visit streaks never fired and streak data was never synced to Firestore
- Minimal change: 2 insertions, 3 deletions