### PR TITLE
Critical: add missing .catch() handlers to service worker event.waitUntil() calls to prevent SW termination

### DIFF
--- a/worker/index.js
+++ b/worker/index.js
@@ -96,13 +96,13 @@ self.addEventListener("sync", (event) => {
 
 self.addEventListener("message", (event) => {
   if (event.data && event.data.type === "TRIGGER_SYNC_PENDING_ACTIONS") {
-    event.waitUntil(handleSync());
+    event.waitUntil(handleSync().catch(err => console.error("[SW] Message sync failed:", err)));
   } else if (event.data && event.data.type === "CLEAR_USER_CACHE") {
     const userHash = event.data.userHash;
     if (userHash) {
-      event.waitUntil(clearCacheForUser(userHash));
+      event.waitUntil(clearCacheForUser(userHash).catch(err => console.error("[SW] Clear user cache failed:", err)));
     } else {
-      event.waitUntil(clearUserCaches());
+      event.waitUntil(clearUserCaches().catch(err => console.error("[SW] Clear all caches failed:", err)));
     }
   }
 });
@@ -165,7 +165,7 @@ self.addEventListener("fetch", (event) => {
           if (networkResponse.ok) {
             const cloned = networkResponse.clone();
             const cachePutPromise = cache.put(cacheKey, cloned).then(() => trimCache(cache));
-            event.waitUntil(cachePutPromise);
+            event.waitUntil(cachePutPromise.catch(err => console.error("[SW] Cache put failed:", err)));
           }
           return networkResponse;
         } catch {


### PR DESCRIPTION
## What the issue was
Four event.waitUntil() calls in worker/index.js (message handler lines 99, 103, 105 and fetch handler line 168) were missing .catch() handlers. Unhandled promise rejections in Service Workers cause the browser to terminate the worker, breaking offline sync, API response caching, and all PWA features.

The sync event handler on line 93 already had the correct pattern with .catch() - but the message and etch handlers were overlooked.

## What I fixed
Added .catch() handlers to all four unprotected event.waitUntil() calls:
- handleSync() in the TRIGGER_SYNC_PENDING_ACTIONS handler
- clearCacheForUser() in the CLEAR_USER_CACHE handler
- clearUserCaches() in the CLEAR_USER_CACHE handler
- cachePutPromise in the fetch handler

## Closes
Closes #2801

## Additional context
- If the SW terminates, attendance records queued while offline are never synced
- API response cache is never cleared, causing stale data
- This is a well-known Service Worker pitfall per MDN documentation
- 4 insertions, 4 deletions - minimal change