### PR TITLE
Critical: fix race condition in useAttendance that leaks Firestore onSnapshot listeners

### DIFF
--- a/hooks/useAttendance.js
+++ b/hooks/useAttendance.js
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useRef } from "react";
 import { db } from "@/lib/firebaseConfig";
 import {
   collection,
@@ -189,13 +189,15 @@ export const useAttendance = ({ role, user }) => {
   // teacher real-time roster via onSnapshot
   useEffect(() => {
     if (role !== "teacher" || !user) return;
-    let unsubscribe = () => {};
+    let cancelled = false;
+    const unsubRef = { current: () => {} };
 
     const fetchStudentsAndAttendance = async () => {
       try {
         const usersRef = collection(db, "users");
         const qStudents = query(usersRef, where("role", "==", "student"));
         const studentDocs = await getDocs(qStudents);
+        if (cancelled) return;
 
         const studentsList = studentDocs.docs.map((doc) => ({
           id: doc.id,
@@ -213,8 +215,10 @@ export const useAttendance = ({ role, user }) => {
           collection(db, "attendance_records"),
           where("date", "==", today)
         );
+        if (cancelled) return;
 
-        unsubscribe = onSnapshot(attendanceQuery, (snapshot) => {
+        unsubRef.current = onSnapshot(attendanceQuery, (snapshot) => {
+          if (cancelled) return;
           const attendanceMap = new Map();
           snapshot.docs.forEach((doc) => {
             const data = doc.data();
@@ -270,7 +274,10 @@ export const useAttendance = ({ role, user }) => {
     };
 
     fetchStudentsAndAttendance();
-    return () => unsubscribe();
+    return () => {
+      cancelled = true;
+      unsubRef.current();
+    };
   }, [role, user]);
 
   useEffect(() => {


### PR DESCRIPTION
## What the issue was
The teacher real-time roster effect in hooks/useAttendance.js had a race condition: onSnapshot was assigned inside an async callback after an wait, but the cleanup function closed over a no-op initial value. If the component unmounted during the await, the real listener was leaked forever.

**Race timeline:**
1. Effect runs; etchStudentsAndAttendance() starts
2. wait getDocs(qStudents) yields
3. Component unmounts / deps change
4. Cleanup runs: unsubscribe() is still the no-op
5. getDocs resolves; unsubscribe = onSnapshot(...) creates a real listener
6. Listener is now orphaned - no reference to unsubscribe it

## What I fixed
- Added a cancelled flag to short-circuit after each wait
- Changed from let unsubscribe to a mutable ref object (unsubRef) so cleanup always unsubscribes the correct function
- Added if (cancelled) guards inside the onSnapshot callback to prevent state updates on unmounted components

## Closes
Closes #2802

## Additional context
- Firestore enforces a hard limit on concurrent active listeners (typically 100-1,000)
- Once exhausted, ALL real-time features across the app break
- This is a well-known React async effect pattern issue
- 11 insertions, 4 deletions