### PR TITLE
fix: standardize navbar mobile padding spacing

### DIFF
--- a/components/Navbar.js
+++ b/components/Navbar.js
@@ -709,7 +709,7 @@ export function Navbar() {
               initial="hidden"
               animate="visible"
               exit="exit"
-              className="fixed top-[max(1rem,env(safe-area-inset-top))] right-[max(1rem,env(safe-area-inset-right))] max-w-[calc(100vw-2rem)] w-64 rounded-2xl shadow-2xl p-4 sm:p-5 space-y-4 z-[90] flex flex-col"
+              className="fixed top-[max(1rem,env(safe-area-inset-top))] right-[max(1rem,env(safe-area-inset-right))] max-w-[calc(100vw-2rem)] w-64 rounded-2xl shadow-2xl p-4 sm:p-5 space-y-4 z-[90] flex max-h-[calc(100dvh-2rem)] flex-col overflow-y-auto"
               style={{
                 backdropFilter: "blur(24px)",
                 WebkitBackdropFilter: "blur(24px)",


### PR DESCRIPTION
## Description
Please include a summary of the change and which issue it fixes.

Improves the mobile navbar drawer spacing by adding a viewport-aware height boundary and internal scrolling for compact screens.

Fixes #2808

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:
- [x] My code follows the style guidelines of this project
- [ ] My changes generate no new warnings
- [x] I have performed a self-review of my own code