### PR TITLE
fix: add inline validation messages in login form

### DIFF
--- a/components/AuthForm.js
+++ b/components/AuthForm.js
@@ -220,6 +220,8 @@ const handleFieldChange = (field) => (value) => {
             onChange={handleFieldChange("password")}
             onBlur={handleFieldBlur("password")}
             error={errors.password}
+            aria-invalid={errors.password ? "true" : "false"}
+            aria-describedby={errors.password ? "password-error" : undefined}
             placeholder="Enter your password"
             icon={Lock}
             isVisible={showPassword}


### PR DESCRIPTION
## Description
Please include a summary of the change and which issue it fixes.

Improves login validation accessibility by connecting password error state to the password input metadata.

Fixes #2810

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:
- [x] My code follows the style guidelines of this project
- [ ] My changes generate no new warnings
- [x] I have performed a self-review of my own code