### PR TITLE
fix: trim password input before validation

### DIFF
--- a/components/AuthForm.js
+++ b/components/AuthForm.js
@@ -104,16 +104,23 @@ const handleFieldChange = (field) => (value) => {
   const handleSubmit = (event) => {
     event.preventDefault();
 
+    const submitData = isLogin
+      ? formData
+      : {
+          ...formData,
+          password: password.trim(),
+          confirmPassword: confirmPassword.trim(),
+        };
     const fieldsToValidate = isLogin
       ? ["email", "password"]
       : ["fullName", "email", "password", "confirmPassword"];
     const nextErrors = {};
 
     fieldsToValidate.forEach((field) => {
-      const result = validateAuthField(field, formData[field], {
+      const result = validateAuthField(field, submitData[field], {
         isLogin,
-        password,
-        confirmPassword,
+        password: submitData.password,
+        confirmPassword: submitData.confirmPassword,
       });
 
       if (result !== true) {
@@ -126,7 +133,7 @@ const handleFieldChange = (field) => (value) => {
       return;
     }
 
-    if (!isLogin && password !== confirmPassword) {
+    if (!isLogin && submitData.password !== submitData.confirmPassword) {
       setErrors((prev) => ({
         ...prev,
         confirmPassword: "Passwords do not match",
@@ -135,7 +142,7 @@ const handleFieldChange = (field) => (value) => {
     }
 
     // Pass the local state object cleanly to the parent's submit function
-    onSubmit(formData); 
+    onSubmit(submitData); 
   };
 
   const selectedRoleConfig = selectedRole ? ROLE_CONFIG[selectedRole] : null;


### PR DESCRIPTION
## Description
Please include a summary of the change and which issue it fixes.

Normalizes signup password and confirm-password values before validation and submission while preserving login behavior.

Fixes #2811

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:
- [x] My code follows the style guidelines of this project
- [ ] My changes generate no new warnings
- [x] I have performed a self-review of my own code