### PR TITLE
fix: improve dashboard async loading fallback

### DIFF
--- a/app/dashboard/loading.jsx
+++ b/app/dashboard/loading.jsx
@@ -10,7 +10,8 @@ import SkeletonCard from "@/components/SkeletonCard";
  */
 export default function DashboardLoading() {
   return (
-    <div className="min-h-screen bg-slate-950 text-white p-6 space-y-8 pt-24 relative overflow-hidden">
+    <div className="min-h-screen bg-slate-950 text-white p-6 space-y-8 pt-24 relative overflow-hidden" role="status" aria-live="polite" aria-busy="true">
+      <span className="sr-only">Loading dashboard content...</span>
       {/* Background glow orbs */}
       <div className="fixed inset-0 bg-[radial-gradient(ellipse_at_top,_var(--tw-gradient-stops))] from-purple-900/10 via-slate-950 to-slate-950 -z-10 pointer-events-none" />
 


### PR DESCRIPTION
## Description
Please include a summary of the change and which issue it fixes.

Marks the dashboard loading skeleton as a polite busy status region and adds screen-reader loading text.

Fixes #2816

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:
- [x] My code follows the style guidelines of this project
- [ ] My changes generate no new warnings
- [x] I have performed a self-review of my own code