### PR TITLE
fix: enforce payload and rate limits on flashcards api (#2770)

### DIFF
--- a/app/api/flashcards/route.js
+++ b/app/api/flashcards/route.js
@@ -1,8 +1,9 @@
 import { NextResponse } from "next/server";
 import { z } from "zod";
-import { withErrorHandler } from "@/lib/error-handler";
+import { withErrorHandler, parseJSON } from "@/lib/error-handler";
 import { requireRole } from "@/lib/rbac";
 import * as FlashcardModel from "@/lib/models/flashcardModel";
+import { checkRateLimit } from "@/lib/rateLimit";
 
 const createSchema = z.object({
   front: z.string().min(1),
@@ -31,7 +32,14 @@ export const GET = withErrorHandler(async (request) => {
 
 export const POST = withErrorHandler(async (request) => {
   const { payload } = await requireRole(request, ["student", "teacher", "admin"]);
-  const body = await request.json();
+  
+  const ip = request.headers.get("x-forwarded-for") || "127.0.0.1";
+  const limited = await checkRateLimit(`flashcards_post_${ip}_${payload.uid}`);
+  if (!limited.allowed) {
+    return NextResponse.json({ success: false, error: "Too many requests. Please slow down." }, { status: 429 });
+  }
+
+  const body = await parseJSON(request, 1024 * 10);
 
   const parsed = createSchema.safeParse(body);
   if (!parsed.success) {


### PR DESCRIPTION
Closes #2770.

### What does this PR do?
Resolves a critical Denial of Service (DoS) vector on the `POST /api/flashcards` endpoint caused by unbounded payload consumption and a lack of rate limiting. 

### Changes Made:
- Integrated `checkRateLimit` to prevent malicious mass-creation of flashcards (storage exhaustion).
- Swapped the native `request.json()` call with the standardized `parseJSON(request, MAX_BYTES)` utility, strictly capping incoming payload sizes at 10KB.

### Impact:
- Completely eliminates the Out-Of-Memory (OOM) attack vector from oversized JSON payloads.
- Restricts API abuse and safeguards database capacity.
