### PR TITLE
fix: handle leading and trailing whitespace in command palette search

### DIFF
--- a/components/SearchModal.js
+++ b/components/SearchModal.js
@@ -99,18 +99,19 @@ export default function SearchModal({ isOpen, onClose }) {
     return list;
   }, [isAuthenticated, userProfile]);
 
-  
+  const normalizedQuery = debouncedQuery.trim().toLowerCase();
   const filteredItems = useMemo(() => {
     return items.filter(item => {
       const matchesCategory = selectedCategory === "All" || item.category === selectedCategory;
 
-      const matchesSearch = !debouncedQuery.trim() || 
-        item.label.toLowerCase().includes(debouncedQuery.toLowerCase()) ||
-        item.category.toLowerCase().includes(debouncedQuery.toLowerCase());
+      const matchesSearch =
+        !normalizedQuery ||
+        item.label.toLowerCase().includes(normalizedQuery) ||
+        item.category.toLowerCase().includes(normalizedQuery);
 
       return matchesCategory && matchesSearch;
     });
-  }, [debouncedQuery, selectedCategory, items]);
+  }, [normalizedQuery, selectedCategory, items]);
 
   // Reset selected index when query changes
   useEffect(() => {


### PR DESCRIPTION
## Description
This PR fixes command palette search behavior when users enter leading or trailing whitespace.

Fixes #2795 

Before: 
<img width="692" height="521" alt="image" src="https://github.com/user-attachments/assets/4b1efe1f-dc5c-4841-adc9-8172cee61b11" />

After:
<img width="721" height="320" alt="image" src="https://github.com/user-attachments/assets/dda97573-1096-4d71-8fb1-777043575026" />


## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] My changes generate no new warnings
- [x] I have performed a self-review of my own code
