### PR TITLE
test: add saga context passing tests to resolve #2266

### DIFF
--- a/lib/__tests__/transactionCoordinator.test.js
+++ b/lib/__tests__/transactionCoordinator.test.js
@@ -105,6 +105,40 @@ describe("TransactionCoordinator", () => {
       expect(compensate1).toHaveBeenCalled();
     });
 
+    it("passes a shared mutable context to all step and compensate callbacks", async () => {
+      const step1Execute = vi.fn().mockImplementation(async (ctx) => {
+        ctx.sharedValue = "from-step1";
+      });
+      const step2Execute = vi.fn().mockImplementation(async (ctx) => {
+        expect(ctx.sharedValue).toBe("from-step1");
+        ctx.step2Value = "from-step2";
+        throw new Error("fail in step2");
+      });
+      const step1Compensate = vi.fn().mockImplementation(async (ctx) => {
+        expect(ctx.sharedValue).toBe("from-step1");
+        expect(ctx.step2Value).toBe("from-step2");
+      });
+
+      const result = await executeSaga({
+        operationType: "test_context",
+        uid: "user-1",
+        steps: [
+          { name: "step1", execute: step1Execute, compensate: step1Compensate },
+          { name: "step2", execute: step2Execute, compensate: vi.fn() },
+        ],
+      });
+
+      expect(result.success).toBe(false);
+      expect(step1Execute).toHaveBeenCalled();
+      expect(step2Execute).toHaveBeenCalled();
+      expect(step1Compensate).toHaveBeenCalled();
+      
+      expect(result.context).toEqual({
+        sharedValue: "from-step1",
+        step2Value: "from-step2",
+      });
+    });
+
     it("returns fullyCompensated: true when all compensations succeed", async () => {
       const result = await executeSaga({
         operationType: "test_op",


### PR DESCRIPTION
This PR adds the missing unit tests for the saga context passing, which was refactored earlier but lacked tests. Fixes #2266