### PR TITLE
Fix/command palette focus management

### DIFF
--- a/components/CommandPalette.js
+++ b/components/CommandPalette.js
@@ -68,11 +68,14 @@ const CommandPalette = ({ isOpen, onClose }) => {
   const flat = filtered;
 
   useEffect(() => {
-    if (isOpen) {
-      setTimeout(() => inputRef.current?.focus(), 50);
-      setQuery('');
-      setActiveIndex(0);
-    }
+    if (!isOpen) return;
+
+    requestAnimationFrame(() => {
+      inputRef.current?.focus();
+    });
+
+    setQuery('');
+    setActiveIndex(0);
   }, [isOpen]);
 
   useEffect(() => {
@@ -101,7 +104,7 @@ const CommandPalette = ({ isOpen, onClose }) => {
     const el = listRef.current?.querySelector('[data-active="true"]');
     el?.scrollIntoView({ block: 'nearest' });
   }, [activeIndex]);
-  
+
   useEffect(() => {
     const handleEscape = (e) => {
       if (e.key === 'Escape') {

--- a/components/CommandPalette.js
+++ b/components/CommandPalette.js
@@ -101,6 +101,22 @@ const CommandPalette = ({ isOpen, onClose }) => {
     const el = listRef.current?.querySelector('[data-active="true"]');
     el?.scrollIntoView({ block: 'nearest' });
   }, [activeIndex]);
+  
+  useEffect(() => {
+    const handleEscape = (e) => {
+      if (e.key === 'Escape') {
+        onClose();
+      }
+    };
+
+    if (isOpen) {
+      window.addEventListener('keydown', handleEscape);
+    }
+
+    return () => {
+      window.removeEventListener('keydown', handleEscape);
+    };
+  }, [isOpen, onClose]);
 
   if (!isOpen) return null;
 

--- a/components/RoleSelection.js
+++ b/components/RoleSelection.js
@@ -86,6 +86,7 @@ export default function RoleSelection({ onRoleSelect }) {
 
               {/* CTA pill — appears on hover */}
               <div
+                aria-hidden="true"
                 className={`mt-5 w-full rounded-xl bg-gradient-to-r ${config.color} py-2 text-sm font-semibold text-white opacity-0 transition-all duration-300 group-hover:opacity-100 group-focus-visible:opacity-100`}
               >
                 Select Role

--- a/components/RoleSelection.js
+++ b/components/RoleSelection.js
@@ -92,7 +92,7 @@ export default function RoleSelection({ onRoleSelect }) {
 
               {/* CTA pill — appears on hover */}
               <div
-                className={`mt-5 w-full rounded-xl bg-gradient-to-r ${config.color} py-2 text-sm font-semibold text-white opacity-0 transition-all duration-300 group-hover:opacity-100`}
+                className={`mt-5 w-full rounded-xl bg-gradient-to-r ${config.color} py-2 text-sm font-semibold text-white opacity-0 transition-all duration-300 group-hover:opacity-100 group-focus-visible:opacity-100`}
               >
                 Select Role
               </div>

--- a/components/RoleSelection.js
+++ b/components/RoleSelection.js
@@ -33,12 +33,7 @@ const FEATURES = [
 ];
 
 export default function RoleSelection({ onRoleSelect }) {
-  const handleKeyDown = (e, role) => {
-    if (e.key === "Enter" || e.key === " ") {
-      e.preventDefault();
-      onRoleSelect(role);
-    }
-  };
+
 
   return (
     <div className="relative mx-auto max-w-5xl px-4 py-10 text-center">
@@ -71,7 +66,6 @@ export default function RoleSelection({ onRoleSelect }) {
               key={role}
               type="button"
               onClick={() => onRoleSelect(role)}
-              onKeyDown={(e) => handleKeyDown(e, role)}
               aria-label={`Select ${config.title} role`}
               className={`group relative flex flex-col items-center rounded-2xl border border-border bg-card p-6 text-center shadow-sm transition-all duration-300 hover:-translate-y-1 hover:shadow-lg active:scale-[0.98] focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 focus-visible:ring-offset-background ${glow}`}
             >


### PR DESCRIPTION
## Description

Replaced the timeout-based focus management in the Command Palette with a more reliable `requestAnimationFrame` approach. Previously, the search input relied on a hardcoded delay before receiving focus, which could lead to inconsistent behavior across devices and rendering conditions.

Fixes #2877 

## Type of change

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] This change requires a documentation update

## Checklist:

* [x] My code follows the style guidelines of this project
* [x] My changes generate no new warnings
* [x] I have performed a self-review of my own code
