### PR TITLE
Fix: Use centralized logger in ActivityError (Issue #2906)

### DIFF
--- a/app/activity/error.js
+++ b/app/activity/error.js
@@ -3,6 +3,8 @@
 import React, { useEffect } from "react";
 import { AlertCircle, RefreshCw } from "lucide-react";
 
+import { logger } from "@/lib/logger";
+
 /**
  * Localized Error Boundary for Activity segment
  * Prevents errors inside app/activity routes from crashing the root layout.
@@ -10,7 +12,7 @@ import { AlertCircle, RefreshCw } from "lucide-react";
  */
 export default function ActivityError({ error, reset }) {
   useEffect(() => {
-    console.error("Captured Activity Segment Error:", error);
+    logger.error("Captured Activity Segment Error:", { error: error?.message || error });
   }, [error]);
 
   return (


### PR DESCRIPTION
## Description
This PR replaces the native `console.error` call with the application's centralized `logger.error` utility within the `ActivityError` boundary component. This ensures that when the activity segment fails to load, the error is correctly passed to our standardized logging service, improving error aggregation and observability in production.

Fixes #2906

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] My changes generate no new warnings
- [x] I have performed a self-review of my own code