### PR TITLE
docs: remove misleading pnpm suggestion from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,15 +209,6 @@ cd Learnova
 npm install
 ```
 
-<details>
-<summary>▶️ <b>Windows(or any OS) with pnpm</b></summary>
-
-```bash
-pnpm install
-```
-
-</details>
-
 ### 3. Configure environment variables
 
 A `.env.example` file is included in the repo with all required keys. Copy it first:


### PR DESCRIPTION
 ## Description
README.md contain a collapsible section under 
Getting Started → Step 2 (Install dependencies) suggesting 
pnpm install for Windows or any OS. Since the repository only 
contains package-lock.json and no pnpm-lock.yaml, npm is the 
sole official package manager. This section was misleading for 
new contributors and has been removed.

## Fixes
Fixes #2911

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [x] Documentation update
- [ ] Performance improvement

## Changes Made
- Removed collapsible Windows(or any OS) with pnpm 
  section from README.md.
- Getting Started → Step 2: Install dependencies.
- npm install retained as primary install command.

## Testing
- [x] No sensitive data committed.
- [x] No merge conflicts.
- [x] Single file changed: README.md.
- [x] Branch rebased against upstream/master.

## Screenshots
Before:
<img width="1413" height="307" alt="Screenshot 2026-06-03 114020" src="https://github.com/user-attachments/assets/e103579a-5fdd-43c9-9232-0ea45e856b0d" />


After:
<img width="1377" height="210" alt="Screenshot 2026-06-03 113842" src="https://github.com/user-attachments/assets/c5697c14-666a-4596-864f-d778557ac2a8" />


## Checklist
- [x] My changes follow the style guidelines of this project.
- [x] I have performed a self-review of my own changes.
- [x] My changes generate no new warnings.
- [x] Documentation updated.
