### PR TITLE
Test notice skeleton

### DIFF
--- a/components/__tests__/AttendanceBadge.test.jsx
+++ b/components/__tests__/AttendanceBadge.test.jsx
@@ -1,0 +1,113 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { vi } from "vitest";
+import AttendanceBadge from "../AttendanceBadge";
+
+vi.mock("framer-motion", async () => {
+  const React = await vi.importActual("react");
+
+  return {
+    motion: {
+      article: React.forwardRef(({ children, ...props }, ref) =>
+        React.createElement("article", { ref, ...props }, children)
+      ),
+      div: React.forwardRef(({ children, ...props }, ref) =>
+        React.createElement("div", { ref, ...props }, children)
+      ),
+    },
+  };
+});
+
+const defaultProps = {
+  icon: "🏆",
+  title: "Attendance Champion",
+  description: "Maintain excellent attendance throughout the semester.",
+  condition: "95% Attendance",
+  progress: 87.8,
+  unlocked: false,
+};
+
+describe("AttendanceBadge Achievement Display", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test("renders badge content correctly", () => {
+    render(<AttendanceBadge {...defaultProps} />);
+
+    expect(screen.getByText("🏆")).toBeInTheDocument();
+
+    expect(
+      screen.getByText("Attendance Champion")
+    ).toBeInTheDocument();
+
+    expect(
+      screen.getByText(
+        "Maintain excellent attendance throughout the semester."
+      )
+    ).toBeInTheDocument();
+
+    expect(screen.getByText("95% Attendance")).toBeInTheDocument();
+  });
+
+  test("shows locked status when unlocked is false", () => {
+    render(
+      <AttendanceBadge
+        {...defaultProps}
+        unlocked={false}
+      />
+    );
+
+    expect(screen.getByText("Locked")).toBeInTheDocument();
+    expect(
+      screen.queryByText("Unlocked")
+    ).not.toBeInTheDocument();
+  });
+
+  test("shows unlocked status when unlocked is true", () => {
+    render(
+      <AttendanceBadge
+        {...defaultProps}
+        unlocked={true}
+      />
+    );
+
+    expect(screen.getByText("Unlocked")).toBeInTheDocument();
+    expect(
+      screen.queryByText("Locked")
+    ).not.toBeInTheDocument();
+  });
+
+  test("floors and displays progress percentage correctly", () => {
+    render(
+      <AttendanceBadge
+        {...defaultProps}
+        progress={87.8}
+      />
+    );
+
+    expect(screen.getByText("87%")).toBeInTheDocument();
+  });
+
+  test("renders 100 percent progress correctly", () => {
+    render(
+      <AttendanceBadge
+        {...defaultProps}
+        progress={100}
+      />
+    );
+
+    expect(screen.getByText("100%")).toBeInTheDocument();
+  });
+
+  test("renders 0 percent progress correctly", () => {
+    render(
+      <AttendanceBadge
+        {...defaultProps}
+        progress={0}
+      />
+    );
+
+    expect(screen.getByText("0%")).toBeInTheDocument();
+  });
+});

--- a/components/__tests__/AttendanceValidation.test.jsx
+++ b/components/__tests__/AttendanceValidation.test.jsx
@@ -1,0 +1,225 @@
+import React from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { vi } from "vitest";
+import AttendanceValidation from "../AttendanceValidation";
+
+const mockPush = vi.fn();
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({
+    push: mockPush,
+  }),
+}));
+
+vi.mock("@/hooks/useAuth", () => ({
+  useAuth: () => ({
+    user: {
+      email: "student@test.com",
+      displayName: "Test Student",
+      getIdToken: vi.fn().mockResolvedValue("mock-token"),
+    },
+  }),
+}));
+
+vi.mock("react-hot-toast", () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+const mockApiFetch = vi.fn();
+
+vi.mock("@/lib/apiClient", () => ({
+  apiFetch: (...args) => mockApiFetch(...args),
+}));
+
+describe("AttendanceValidation Core States", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test("renders loading state while attendance settings are loading", () => {
+    mockApiFetch.mockImplementation(() => new Promise(() => {}));
+
+    render(
+      <AttendanceValidation
+        onValidationSuccess={vi.fn()}
+      />
+    );
+
+    expect(
+      screen.getByText(/loading system/i)
+    ).toBeInTheDocument();
+
+    expect(
+      screen.getByText(/preparing attendance validation/i)
+    ).toBeInTheDocument();
+  });
+
+  test("renders error state when settings request fails", async () => {
+    mockApiFetch.mockRejectedValueOnce(
+      new Error("Settings fetch failed")
+    );
+
+    render(
+      <AttendanceValidation
+        onValidationSuccess={vi.fn()}
+      />
+    );
+
+    expect(
+      await screen.findByText(/system error/i)
+    ).toBeInTheDocument();
+
+    expect(
+      screen.getByRole("button", {
+        name: /retry/i,
+      })
+    ).toBeInTheDocument();
+
+    expect(
+      screen.getByRole("button", {
+        name: /hard refresh/i,
+      })
+    ).toBeInTheDocument();
+  });
+
+  test("opens exception request modal", async () => {
+    const user = userEvent.setup();
+
+    mockApiFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        timeWindow: {
+          start: "00:00",
+          end: "23:59",
+        },
+        gpsLocation: {
+          lat: 0,
+          lng: 0,
+          radius: 100,
+        },
+      }),
+    });
+
+    render(
+      <AttendanceValidation
+        onValidationSuccess={vi.fn()}
+      />
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/secure attendance/i)
+      ).toBeInTheDocument();
+    });
+
+    await user.click(
+      screen.getByRole("button", {
+        name: /request exception/i,
+      })
+    );
+
+    expect(
+      screen.getByText(/exception request/i)
+    ).toBeInTheDocument();
+
+    expect(
+      screen.getByText(
+        /request attendance validation exception/i
+      )
+    ).toBeInTheDocument();
+  });
+
+  test("closes exception modal when cancel is clicked", async () => {
+    const user = userEvent.setup();
+
+    mockApiFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        timeWindow: {
+          start: "00:00",
+          end: "23:59",
+        },
+        gpsLocation: {
+          lat: 0,
+          lng: 0,
+          radius: 100,
+        },
+      }),
+    });
+
+    render(
+      <AttendanceValidation
+        onValidationSuccess={vi.fn()}
+      />
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/secure attendance/i)
+      ).toBeInTheDocument();
+    });
+
+    await user.click(
+      screen.getByRole("button", {
+        name: /request exception/i,
+      })
+    );
+
+    await user.click(
+      screen.getByRole("button", {
+        name: /cancel/i,
+      })
+    );
+
+    expect(
+      screen.queryByText(/exception request/i)
+    ).not.toBeInTheDocument();
+  });
+
+  test("disables submit button when required fields are empty", async () => {
+    const user = userEvent.setup();
+
+    mockApiFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        timeWindow: {
+          start: "00:00",
+          end: "23:59",
+        },
+        gpsLocation: {
+          lat: 0,
+          lng: 0,
+          radius: 100,
+        },
+      }),
+    });
+
+    render(
+      <AttendanceValidation
+        onValidationSuccess={vi.fn()}
+      />
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/secure attendance/i)
+      ).toBeInTheDocument();
+    });
+
+    await user.click(
+      screen.getByRole("button", {
+        name: /request exception/i,
+      })
+    );
+
+    const submitButton = screen.getByRole("button", {
+      name: /submit/i,
+    });
+
+    expect(submitButton).toBeDisabled();
+  });
+});

--- a/components/__tests__/NoticeSkeleton.test.jsx
+++ b/components/__tests__/NoticeSkeleton.test.jsx
@@ -1,0 +1,56 @@
+import React from "react";
+import { render } from "@testing-library/react";
+import { vi } from "vitest";
+import NoticeSkeleton from "../NoticeSkeleton";
+
+vi.mock("framer-motion", async () => {
+  const React = await vi.importActual("react");
+
+  return {
+    motion: {
+      div: React.forwardRef(({ children, ...props }, ref) =>
+        React.createElement("div", { ref, ...props }, children)
+      ),
+    },
+  };
+});
+
+describe("NoticeSkeleton Loading States", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test("renders four skeleton cards by default", () => {
+    const { container } = render(<NoticeSkeleton />);
+
+    const cards = container.querySelectorAll(
+      ".rounded-\\[2rem\\]"
+    );
+
+    expect(cards).toHaveLength(4);
+  });
+
+  test("renders custom skeleton count", () => {
+    const { container } = render(
+      <NoticeSkeleton count={6} />
+    );
+
+    const cards = container.querySelectorAll(
+      ".rounded-\\[2rem\\]"
+    );
+
+    expect(cards).toHaveLength(6);
+  });
+
+  test("renders no skeleton cards when count is zero", () => {
+    const { container } = render(
+      <NoticeSkeleton count={0} />
+    );
+
+    const cards = container.querySelectorAll(
+      ".rounded-\\[2rem\\]"
+    );
+
+    expect(cards).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Description

Adds automated test coverage for the `NoticeSkeleton` component using Vitest and React Testing Library.

The test suite verifies:

* Default rendering of four skeleton cards.
* Correct rendering when a custom `count` prop is provided.
* Proper handling of edge cases such as `count={0}`.

These tests improve confidence in loading-state UI behavior and help prevent regressions during future refactoring.

Fixes #2930 

## Type of change

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] This change requires a documentation update

## Checklist:

* [x] My code follows the style guidelines of this project
* [x] My changes generate no new warnings
* [x] I have performed a self-review of my own code
