### PR TITLE
fix: add Firebase Auth rollback on bulk import MongoDB failure

### DIFF
--- a/app/api/institute/bulk-import/route.js
+++ b/app/api/institute/bulk-import/route.js
@@ -177,7 +177,20 @@ export async function POST(req) {
     }
 
     if (mongoBulkOps.length > 0) {
-      await mongoUsers.bulkWrite(mongoBulkOps, { ordered: false });
+      try {
+        await mongoUsers.bulkWrite(mongoBulkOps, { ordered: false });
+      } catch (mongoError) {
+        // Rollback: delete Firebase Auth users created in this request
+        if (createdAuthUids.length > 0) {
+          try {
+            await admin.auth().deleteUsers(createdAuthUids);
+            console.warn(`Rolled back ${createdAuthUids.length} Firebase Auth users after MongoDB write failure`);
+          } catch (rollbackError) {
+            console.error(`Failed to rollback Firebase Auth users:`, rollbackError);
+          }
+        }
+        throw mongoError;
+      }
     }
 
     successfulImports = validStudents.length - failedImports.filter((f) =>


### PR DESCRIPTION
## Summary

Wraps the MongoDB ulkWrite in a try/catch that rolls back the Firebase Auth users created during this import request. This prevents orphaned Auth accounts (ghost users) when the MongoDB write fails.

## Changes

- pp/api/institute/bulk-import/route.js: Added try/catch around mongoUsers.bulkWrite() with dmin.auth().deleteUsers(createdAuthUids) rollback on failure.

Closes #2938