### PR TITLE
fix(FaceRecognizer): dispose face-api tensors on unmount and stop web…

### DIFF
--- a/components/FaceRecognizer.js
+++ b/components/FaceRecognizer.js
@@ -241,8 +241,23 @@ export default function FaceRecognizer({ authUser }) {
         videoRef.current.load();
       }
 
-      if (faceapi.tf?.disposeVariables) {
-        faceapi.tf.disposeVariables();
+      // Attempt to dispose face-api / TensorFlow variables if library is available.
+      // Use dynamic import to avoid referencing `faceapi` from outer scope which
+      // can throw a ReferenceError during cleanup.
+      if (typeof window !== "undefined") {
+        import("face-api.js")
+          .then((faceapi) => {
+            try {
+              if (faceapi?.tf?.disposeVariables) {
+                faceapi.tf.disposeVariables();
+              }
+            } catch (e) {
+              console.warn("Failed to dispose face-api tensors:", e);
+            }
+          })
+          .catch(() => {
+            // library not loaded or not available — nothing to dispose
+          });
       }
     };
   }, [labelsLoading, error, labels, facingMode]);

--- a/components/FaceRecognizer_BUG.md
+++ b/components/FaceRecognizer_BUG.md
@@ -1,0 +1,48 @@
+# Medium: Webcam memory leak & ReferenceError on unmount
+
+**Summary**
+- A medium-severity bug in the `FaceRecognizer` component causes a runtime error on unmount and can lead to retained TensorFlow variables / webcam resources (memory leak / persistent camera activation).
+
+**Affected file**: components/FaceRecognizer.js
+
+**Symptoms / Reproduction**
+- Navigate to the attendance/face-recognition page that mounts `FaceRecognizer`.
+- Navigate away or unmount the component.
+- Observe console errors (ReferenceError) and/or camera remaining active after leaving the page.
+
+**Root cause**
+- In the cleanup function of the main `useEffect`, the code attempts to call `faceapi.tf?.disposeVariables()` but `faceapi` is not defined in that scope. Referencing `faceapi` directly causes a `ReferenceError`, preventing proper disposal and leaving WebRTC tracks or TF variables alive.
+
+**Proposed fix**
+1. Guard the cleanup against `faceapi` being undefined by dynamically importing `face-api.js` inside the cleanup and then disposing TensorFlow variables if available. Since the cleanup cannot be `async`, use a promise-based import.
+
+Suggested snippet to replace the existing cleanup disposal block:
+
+```js
+// inside the useEffect cleanup
+if (typeof window !== 'undefined') {
+  import('face-api.js')
+    .then((faceapi) => {
+      try {
+        if (faceapi?.tf?.disposeVariables) {
+          faceapi.tf.disposeVariables();
+        }
+      } catch (e) {
+        console.warn('Failed to dispose face-api tensors:', e);
+      }
+    })
+    .catch(() => {
+      // ignore: face-api may not have been loaded or available
+    });
+}
+```
+
+2. Ensure other cleanup steps already present are kept: `cancelAnimationFrame`, stop media tracks (`getTracks().forEach(t=>t.stop())`), pause video and clear `srcObject`.
+
+**Why this fixes it**
+- Dynamically importing `face-api.js` within cleanup avoids referencing an out-of-scope `faceapi` variable. If the library was loaded earlier, the import will resolve quickly and allow calling `disposeVariables`. If it wasn't loaded, the catch path avoids throwing. This allows TensorFlow resources to be released and avoids leaving the camera or TF memory allocated.
+
+**Severity**: Medium — can crash user UI or cause degraded performance and privacy issues (camera left active).
+
+**Next steps / PR**
+- Patch `components/FaceRecognizer.js` cleanup to use promise import as shown above and add a small unit / manual test that mounts/unmounts the component and confirms no active camera tracks remain.


### PR DESCRIPTION
# Fix FaceRecognizer cleanup ReferenceError and resource leak (#2964)

## Summary

This PR fixes a medium-severity issue in `components/FaceRecognizer.js` where the component cleanup logic could throw a `ReferenceError` during unmount and prevent proper disposal of TensorFlow variables and webcam resources.

Fixes #2964.

## Problem

When the `FaceRecognizer` component unmounts, the cleanup function attempts to call:

```js
faceapi.tf?.disposeVariables();
```

However, `faceapi` is not defined within the cleanup scope, resulting in a `ReferenceError`.

Because the error interrupts the cleanup process, TensorFlow variables and WebRTC media tracks may not be released correctly, potentially causing:

* Runtime errors in the browser console
* Retained TensorFlow memory
* Webcam remaining active after navigation
* Degraded application performance and privacy concerns

## Solution

Updated the cleanup logic to safely load `face-api.js` via dynamic import and dispose TensorFlow variables only when available.

### Changes made

* Replaced direct `faceapi` reference with a promise-based dynamic import.
* Added defensive error handling around tensor disposal.
* Preserved existing cleanup operations:

  * `cancelAnimationFrame`
  * Stopping all media tracks
  * Pausing the video element
  * Clearing `srcObject`

### Updated cleanup snippet

```js
if (typeof window !== 'undefined') {
  import('face-api.js')
    .then((faceapi) => {
      try {
        if (faceapi?.tf?.disposeVariables) {
          faceapi.tf.disposeVariables();
        }
      } catch (e) {
        console.warn('Failed to dispose face-api tensors:', e);
      }
    })
    .catch(() => {
      // ignore: face-api may not have been loaded or available
    });
}
```

## Why this works

The cleanup function no longer references an out-of-scope `faceapi` variable. By dynamically importing `face-api.js`, the module is safely accessed when available, allowing TensorFlow resources to be disposed without causing runtime exceptions.

If the module is unavailable, the cleanup continues gracefully without affecting the remaining resource-release steps.

## Testing

### Manual Testing

1. Open the attendance/face-recognition page.
2. Allow webcam access.
3. Navigate away from the page.
4. Verify:

   * No `ReferenceError` appears in the console.
   * Webcam indicator turns off.
   * No active media tracks remain.
   * Component unmount completes successfully.

## Result

* Eliminates cleanup-time `ReferenceError`
* Prevents TensorFlow resource leaks
* Ensures webcam tracks are properly released
* Improves application stability and user privacy

Fixes #2964.
