### PR TITLE
fix: revoke Blob object URL after CSV download to prevent memory leak

### DIFF
--- a/utils/exportUtils.js
+++ b/utils/exportUtils.js
@@ -2,6 +2,7 @@ import Papa from 'papaparse';
 import jsPDF from 'jspdf';
 import 'jspdf-autotable';
 
+// AFTER (fixed)
 export const exportToCSV = (data, filename) => {
   const csv = Papa.unparse(data);
   const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
@@ -14,6 +15,7 @@ export const exportToCSV = (data, filename) => {
     document.body.appendChild(link);
     link.click();
     document.body.removeChild(link);
+    URL.revokeObjectURL(url); // Release the Blob URL from memory immediately
   }
 };
 


### PR DESCRIPTION
URL.createObjectURL() creates a reference that keeps the Blob alive in memory until it is explicitly revoked or the tab is closed. The previous code never called URL.revokeObjectURL(), so every CSV export permanently leaked a Blob for the entire tab session.
This fix adds URL.revokeObjectURL(url) immediately after the download is triggered (after link.click() and the link is removed from the DOM), freeing the memory at the earliest safe point.

Fixes #2966 

## Type of change
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:
- [ x] My code follows the style guidelines of this project
- [ x] My changes generate no new warnings
- [ x] I have performed a self-review of my own code
