### PR TITLE
fix: remove leftover debug log 

### DIFF
--- a/components/productivity/AIProductivityInsights.jsx
+++ b/components/productivity/AIProductivityInsights.jsx
@@ -38,8 +38,6 @@ export default function AIProductivityInsights({
 
     const data = await response.json();
 
-    console.log(data);
-
     if (data.success) {
       setInsights(data.data);
     }


### PR DESCRIPTION
## Description
This PR addresses Issue #2902. A leftover `console.log(data);` on line 41 of `components/productivity/AIProductivityInsights.jsx` was logging fetched insights directly to the browser console. This has been removed to keep the production console clean.

## Changes Made
- Removed `console.log(data);` in `components/productivity/AIProductivityInsights.jsx`.

## Verification
- Verified that the log is no longer outputting the parsed JSON data.
- Ensure component continues to successfully update state with `data.data`.
