### PR TITLE
fix: replace native alert with toast in AIProductivityInsights 

### DIFF
--- a/components/productivity/AIProductivityInsights.jsx
+++ b/components/productivity/AIProductivityInsights.jsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { motion } from "framer-motion";
 import { Brain, Sparkles, TrendingUp, Target } from "lucide-react";
 import { useAuthContext } from "@/contexts/AuthContext";
+import toast from "react-hot-toast";
 
 export default function AIProductivityInsights({
   analytics,
@@ -21,7 +22,7 @@ export default function AIProductivityInsights({
     setLoading(true);
 
     if (!user) {
-      alert("Please login to generate AI insights.");
+      toast.error("Please login to generate AI insights.");
       return;
     }
 


### PR DESCRIPTION
## Description
This PR addresses Issue #2903. The `AIProductivityInsights` component was using a native browser `alert("Please login to generate AI insights.");` for error handling, which disrupts the modern UI experience.

## Changes Made
- Imported `toast` from `react-hot-toast` in `components/productivity/AIProductivityInsights.jsx`.
- Replaced the native `alert` with `toast.error("Please login to generate AI insights.");`.

## Verification
- Verified that the error message is now displayed as a non-blocking toast notification.
- Ensured no compilation errors exist.
