### PR TITLE
fix: replace native alert with toast in timetable page 

### DIFF
--- a/app/timetable/page.js
+++ b/app/timetable/page.js
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-
+import toast from "react-hot-toast";
 export default function TimetablePage() {
   const [goal, setGoal] = useState("");
   const [hours, setHours] = useState("");
@@ -22,7 +22,7 @@ export default function TimetablePage() {
     
   const generatePlan = () => {
   if (!goal || !hours || !topics) {
-    alert("Please fill all fields");
+    toast.error("Please fill all fields");
     return;
   }
 


### PR DESCRIPTION
## Description
This PR addresses Issue #2904. The `TimetablePage` component was using a native browser `alert("Please fill all fields");` for form validation when a user submitted an incomplete form. This native alert disrupts the user experience and is inconsistent with the rest of the application.

## Changes Made
- Imported `toast` from `react-hot-toast` in `app/timetable/page.js`.
- Replaced the native `alert` with `toast.error("Please fill all fields");`.

## Verification
- Verified that form validation triggers a non-blocking toast notification instead of a native alert.
- Ensured no compilation errors exist.
