### PR TITLE
fix(curriculum): validate module and lesson schema before persisting sync payload

### DIFF
--- a/app/api/courses/curriculum/sync/route.js
+++ b/app/api/courses/curriculum/sync/route.js
@@ -24,6 +24,51 @@ export async function POST(request) {
       );
     }
 
+    // Validate each module entry. Accepting arbitrary objects without schema
+    // validation allows malformed data (null IDs, non-string titles, lesson
+    // arrays that are actually objects) to be persisted, causing downstream
+    // errors when the curriculum is rendered or processed.
+    const invalidModules = modules.filter(
+      (mod, idx) =>
+        mod === null ||
+        typeof mod !== "object" ||
+        typeof mod.title !== "string" ||
+        mod.title.trim() === "" ||
+        (mod.lessons !== undefined && !Array.isArray(mod.lessons))
+    );
+
+    if (invalidModules.length > 0) {
+      return NextResponse.json(
+        {
+          success: false,
+          error:
+            "Each module must be an object with a non-empty title string and an optional lessons array",
+        },
+        { status: 400 }
+      );
+    }
+
+    // Validate each lesson within every module.
+    for (let modIdx = 0; modIdx < modules.length; modIdx++) {
+      const lessons = modules[modIdx].lessons || [];
+      const invalidLessons = lessons.filter(
+        (les) =>
+          les === null ||
+          typeof les !== "object" ||
+          typeof les.title !== "string" ||
+          les.title.trim() === ""
+      );
+      if (invalidLessons.length > 0) {
+        return NextResponse.json(
+          {
+            success: false,
+            error: `Module at index ${modIdx} contains lessons with missing or invalid title fields`,
+          },
+          { status: 400 }
+        );
+      }
+    }
+
     let isDbPersisted = false;
 
     if (process.env.MONGODB_URI) {
@@ -46,11 +91,11 @@ export async function POST(request) {
       // Structure the modules list to enforce position sequences
       const structuredModules = modules.map((mod, modIdx) => ({
         id: mod.id,
-        title: mod.title,
+        title: mod.title.trim(),
         order: modIdx,
         lessons: (mod.lessons || []).map((les, lesIdx) => ({
           id: les.id,
-          title: les.title,
+          title: les.title.trim(),
           duration: les.duration || "15 mins",
           type: les.type || "video",
           completed: les.completed || false,


### PR DESCRIPTION
## Description

POST /api/courses/curriculum/sync accepted a modules array but did not validate the structure of individual module or lesson entries. A payload containing null IDs, empty string titles, or a lessons field that was an object rather than an array was persisted to MongoDB without error, causing silent data corruption and downstream errors when the curriculum was displayed.

## Root Cause

The existing check only verified that modules was an Array. No per-element validation existed for the module or lesson shapes.

## Related Issue

Closes #2972

## Type of Change

- [x] Bug fix

## Changes Made

- app/api/courses/curriculum/sync/route.js: Added per-module validation (non-null object, non-empty title, lessons must be an array if present) and per-lesson validation (non-null object, non-empty title) before the database write. Valid titles are trimmed before storage. Invalid payloads return 400 with a descriptive message.

## Testing Done

1. Valid modules array: sync proceeds and returns 200.
2. Module with null value: 400 returned.
3. Module with empty title string: 400 returned.
4. Module with lessons as an object instead of array: 400 returned.
5. Lesson with missing title: 400 with module index in message.

## Checklist

- [x] My code follows the style and formatting of this project
- [x] I have tested my changes locally and they work as expected
- [x] There are no merge conflicts with the base branch
- [x] This PR is linked to the correct issue