### PR TITLE
fix(grades): return sample data without persisting to production database

### DIFF
--- a/app/api/parent/student/[studentId]/grades/route.js
+++ b/app/api/parent/student/[studentId]/grades/route.js
@@ -40,32 +40,17 @@ export const GET = withErrorHandler(async (request, context) => {
   let grades = [];
 
   if (gradesQuery.empty) {
-    // Self-seed sample grades for high-fidelity presentation
-    try {
-      const mongoDb = await connectDb();
-      for (const sample of SAMPLE_GRADES) {
-        const gradeDoc = {
-          studentId,
-          ...sample,
-          createdAt: new Date().toISOString(),
-        };
-
-        const result = await db.collection("grades").add(gradeDoc);
-        const docWithId = { id: result.id, ...gradeDoc };
-        grades.push(docWithId);
-
-        // Sync to MongoDB
-        await mongoDb.collection("grades").updateOne(
-          { _id: result.id },
-          { $set: { ...gradeDoc, _id: result.id } },
-          { upsert: true }
-        );
-      }
-    } catch (seedErr) {
-      console.error("Failed to seed sample grades:", seedErr);
-      // Fallback: return mock grades without database save to prevent crash
-      grades = SAMPLE_GRADES.map((g, i) => ({ id: `mock_${i}`, studentId, ...g }));
-    }
+    // No real grades exist yet. Return sample data for display purposes only.
+    // Do NOT persist sample records to Firestore or MongoDB. Writing demo data
+    // to the production database on first access creates permanent stub records
+    // that mix with real grades on subsequent queries, producing duplicate or
+    // misleading academic data that cannot be easily cleaned up.
+    grades = SAMPLE_GRADES.map((g, i) => ({
+      id: `sample_${i}`,
+      studentId,
+      ...g,
+      isSample: true,
+    }));
   } else {
     grades = gradesQuery.docs.map((doc) => ({
       id: doc.id,


### PR DESCRIPTION
## Description

When a parent viewed a student's grades for the first time and no records existed, the endpoint wrote SAMPLE_GRADES directly to Firestore and MongoDB. Every subsequent visit showed these demo records alongside real grades, and concurrent first-access requests could insert duplicate sample documents. There was no way to distinguish demo data from real academic records once persisted.

## Root Cause

The empty-result path called db.collection("grades").add(gradeDoc) and a MongoDB upsert for each sample entry, permanently mixing demo data with the production dataset.

## Related Issue

Closes #2970

## Type of Change

- [x] Bug fix

## Changes Made

- app/api/parent/student/[studentId]/grades/route.js: Removed the database writes from the empty-result path. Sample grades are now returned as in-memory objects tagged with isSample=true without touching Firestore or MongoDB. Real grades continue to be stored and retrieved through the POST handler.

## Testing Done

1. First access with no real grades: sample data returned, no records created in Firestore or MongoDB.
2. First access with real grades: real records returned as before.
3. Concurrent first-access requests: no duplicate records inserted.

## Checklist

- [x] My code follows the style and formatting of this project
- [x] I have tested my changes locally and they work as expected
- [x] There are no merge conflicts with the base branch
- [x] This PR is linked to the correct issue