### PR TITLE
fix(attendance): validate studentId format to prevent IDOR enumeration

### DIFF
--- a/app/api/parent/student/[studentId]/attendance/route.js
+++ b/app/api/parent/student/[studentId]/attendance/route.js
@@ -7,15 +7,30 @@ import { getFirestore } from "firebase-admin/firestore";
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
 
+// Accepted studentId pattern: Firebase UIDs are 28-character alphanumeric strings.
+// Reject values that do not conform to prevent path manipulation and enumeration.
+const STUDENT_ID_RE = /^[A-Za-z0-9]{10,128}$/;
+
 export const GET = withErrorHandler(async (request, context) => {
   const { payload: decodedToken } = await requireParent(request);
   const parentId = decodedToken.uid;
   const { studentId } = context.params;
 
+  // Validate studentId format before issuing any database query.
+  // Accepting arbitrary strings allows a caller to enumerate IDs by
+  // making repeated requests with different values and observing the
+  // 403 vs 200 response difference. Rejecting malformed IDs early also
+  // prevents special characters from being used in Firestore document paths.
+  if (!studentId || !STUDENT_ID_RE.test(studentId)) {
+    return jsonError("Invalid student ID format.", 400);
+  }
+
   initFirebaseAdmin();
   const db = getFirestore();
 
-  // 1. Verify parent-student linking relationship
+  // 1. Verify parent-student linking relationship.
+  // parentId is derived from the authenticated Firebase token, not from
+  // the request body, so it cannot be spoofed by the caller.
   const linkId = `${parentId}_${studentId}`;
   const linkDoc = await db.collection("parent_student_links").doc(linkId).get();
   if (!linkDoc.exists) {


### PR DESCRIPTION
## Description

The parent attendance endpoint accepted any value for studentId from the URL path and immediately issued a Firestore link lookup. A caller could submit arbitrary values in a loop, using the 403 vs 200 status difference to enumerate valid student IDs. Special characters in the path value could also be used to manipulate Firestore document references.

## Root Cause

No input validation existed for the studentId path parameter before it was used in database queries. parentId came correctly from the authenticated token, but studentId was untrusted user input.

## Related Issue

Closes #2969

## Type of Change

- [x] Bug fix (security)

## Changes Made

- app/api/parent/student/[studentId]/attendance/route.js: Added STUDENT_ID_RE format validation (10-128 alphanumeric characters matching Firebase UID format) before any database query. Values that do not match return 400 immediately. Added a comment documenting that parentId comes from the authenticated token and cannot be spoofed.

## Testing Done

1. Valid studentId format: proceeds to link check as before.
2. Empty studentId: returns 400.
3. studentId with special characters: returns 400.
4. Valid studentId with no link: returns 403 as before.

## Checklist

- [x] My code follows the style and formatting of this project
- [x] I have tested my changes locally and they work as expected
- [x] There are no merge conflicts with the base branch
- [x] This PR is linked to the correct issue