### PR TITLE
fix(cron): enforce strict instituteId validation to prevent cross-institute warning dispatch

### DIFF
--- a/app/api/cron/attendance-warnings/route.js
+++ b/app/api/cron/attendance-warnings/route.js
@@ -221,14 +221,29 @@ export async function GET(request) {
 
     for (const settings of allSettings) {
       const threshold = settings.institute.lowAttendanceThreshold || 75;
-      const instituteId = settings.instituteId || settings._id?.toString() || settings.userId;
-      if (!instituteId) continue;
+
+      // Derive the institute ID from the settings document. instituteId is the
+      // canonical field; fall back to _id only when instituteId is absent.
+      // Reject any document whose instituteId cannot be determined as a
+      // non-empty string: processing it with an undefined or empty key would
+      // cause studentsByInstitute.get() to return undefined, silently matching
+      // no students or incorrectly matching students from another institute if
+      // two settings documents resolve to the same fallback key.
+      const rawInstituteId = settings.instituteId;
+      if (!rawInstituteId || typeof rawInstituteId !== "string" || rawInstituteId.trim() === "") {
+        console.warn(
+          "[attendance-warnings] Skipping settings document with missing or invalid instituteId",
+          { settingsId: settings._id?.toString() }
+        );
+        continue;
+      }
+      const instituteId = rawInstituteId.trim();
 
       const instituteStudents = studentsByInstitute.get(instituteId) || [];
 
       if (instituteStudents.length === 0) continue;
 
-      // Load attendance from MongoDB (scoped by institute) for all students in this institute
+      // Load attendance from MongoDB scoped to this institute only.
       const instituteStudentUids = instituteStudents.map(s => s.firebaseUid).filter(Boolean);
       const mongoAttendance = await loadMongoAttendanceByUser(db, instituteId, instituteStudentUids);
 


### PR DESCRIPTION
## Description

The attendance warnings cron used a fallback chain to derive the working instituteId. If a settings document was missing the canonical instituteId field, the cron would fall through to settings._id.toString() or settings.userId. If that fallback string coincidentally matched the instituteId stored on student documents from a different institute, the cron would dispatch low-attendance warnings to students belonging to the wrong institute.

## Root Cause

```js
const instituteId = settings.instituteId || settings._id?.toString() || settings.userId;
```

No validation ensured that the derived value actually corresponded to the institute the settings document described.

## Related Issue

Closes #2968

## Type of Change

- [x] Bug fix (security)

## Changes Made

- app/api/cron/attendance-warnings/route.js: Added strict validation that rejects settings documents where instituteId is absent, non-string, or empty. A console.warn with the settings document ID is emitted so administrators can identify and fix the data. The fallback path to _id or userId is removed.

## Testing Done

1. Settings with a valid instituteId: cron processes only students from that institute.
2. Settings with missing instituteId: document skipped with a warning log.
3. Two institutes with separate settings: each processes only its own students.

## Checklist

- [x] My code follows the style and formatting of this project
- [x] I have tested my changes locally and they work as expected
- [x] There are no merge conflicts with the base branch
- [x] This PR is linked to the correct issue