### PR TITLE
fix(maintenance): remove hardcoded bypass key fallback

### DIFF
--- a/utils/maintenance.js
+++ b/utils/maintenance.js
@@ -16,7 +16,15 @@ export function isMaintenanceModeActive(request) {
     const bypassCookie = request.cookies?.get?.("learnova_maintenance_bypass")?.value;
     const bypassHeader = request.headers?.get?.("x-learnova-maintenance-bypass");
     
-    const secretBypassKey = process.env.MAINTENANCE_BYPASS_KEY || "bypass_maintenance_2026";
+    // The bypass key must be configured via the MAINTENANCE_BYPASS_KEY environment
+    // variable. A hardcoded fallback value is visible to anyone with repository
+    // access and allows maintenance mode to be bypassed without authorization.
+    // Refuse to grant bypass access if the key is not set in the environment.
+    const secretBypassKey = process.env.MAINTENANCE_BYPASS_KEY;
+    if (!secretBypassKey) {
+      // No bypass key configured — deny bypass regardless of what the caller sends.
+      return true;
+    }
     if (bypassCookie === secretBypassKey || bypassHeader === secretBypassKey) {
       return false;
     }


### PR DESCRIPTION
## Description

isMaintenanceModeActive used a hardcoded static string as the fallback bypass key when MAINTENANCE_BYPASS_KEY was not set in the environment. Anyone with repository access could read the fallback value and use it to bypass maintenance mode by setting the cookie or header, gaining access to the application during scheduled downtime windows without authorization.

## Root Cause

```js
const secretBypassKey = process.env.MAINTENANCE_BYPASS_KEY || "bypass_maintenance_2026";
```

The fallback literal is visible in the source code.

## Related Issue

Closes #2971

## Type of Change

- [x] Bug fix (security)

## Changes Made

- utils/maintenance.js: Removed the hardcoded fallback. When MAINTENANCE_BYPASS_KEY is not set the bypass check is skipped and maintenance mode stays active. Operators must configure MAINTENANCE_BYPASS_KEY in their environment to use the bypass feature.

## Testing Done

1. MAINTENANCE_BYPASS_KEY set, correct value in cookie: bypass granted.
2. MAINTENANCE_BYPASS_KEY set, wrong value: bypass denied.
3. MAINTENANCE_BYPASS_KEY not set, any value in cookie: bypass denied.

## Checklist

- [x] My code follows the style and formatting of this project
- [x] I have tested my changes locally and they work as expected
- [x] There are no merge conflicts with the base branch
- [x] This PR is linked to the correct issue