### PR TITLE
fix: add magic byte validation on avatar upload

### DIFF
--- a/lib/images/imagesService.js
+++ b/lib/images/imagesService.js
@@ -18,6 +18,33 @@ export const ALLOWED_IMAGE_TYPES = new Set([
   "image/webp",
 ]);
 
+const MAGIC_BYTES = {
+  "image/jpeg": [0xff, 0xd8, 0xff],
+  "image/png": [0x89, 0x50, 0x4e, 0x47],
+  "image/webp": [0x52, 0x49, 0x46, 0x46],
+};
+
+const WEBP_MARKER = [0x57, 0x45, 0x42, 0x50];
+
+function validateMagicBytes(buffer, mimeType) {
+  const magic = MAGIC_BYTES[mimeType];
+  if (!magic || buffer.length < magic.length) {
+    return false;
+  }
+  for (let i = 0; i < magic.length; i++) {
+    if (buffer[i] !== magic[i]) {
+      return false;
+    }
+  }
+  if (mimeType === "image/webp") {
+    if (buffer.length < 12) return false;
+    for (let i = 0; i < WEBP_MARKER.length; i++) {
+      if (buffer[8 + i] !== WEBP_MARKER[i]) return false;
+    }
+  }
+  return true;
+}
+
 export const allowedImageHosts = [
   "public.blob.vercel-storage.com",
   "lh3.googleusercontent.com",
@@ -150,6 +177,10 @@ export async function uploadAvatarToBlob({ file, uid }) {
 
   if (buffer.byteLength > MAX_FILE_SIZE) {
     throw new ValidationError("File size exceeds 5MB limit");
+  }
+
+  if (!validateMagicBytes(buffer, mimeType)) {
+    throw new ValidationError("File content does not match declared image type");
   }
 
   const extension = mimeType.split("/")[1] || "jpg";


### PR DESCRIPTION
Added file signature (magic byte) validation to the avatar upload pipeline. Uses the same MAGIC_BYTES constants as the register route to verify JPEG/PNG/WebP headers before uploading to Vercel Blob, preventing MIME spoofing attacks.

Closes #3016