### PR TITLE
fix: add compound database indexes for 6 query patterns

### DIFF
--- a/app/api/cron/attendance-risk/route.js
+++ b/app/api/cron/attendance-risk/route.js
@@ -1,6 +1,7 @@
 import { jsonError, jsonSuccess } from "@/lib/api-response";
 import { authorizeCronRequest } from "@/lib/cronAuth";
 import { connectDb } from "@/lib/mongodb";
+import { ensureIndexes } from "@/lib/db-indexes";
 
 /**
  * GET /api/cron/attendance-risk
@@ -22,6 +23,7 @@ export const GET = async (request) => {
 
   try {
     const db = await connectDb();
+    await ensureIndexes();
 
     const now = new Date();
     const fourWeeksAgo = new Date(now);

--- a/app/api/cron/attendance-warnings/route.js
+++ b/app/api/cron/attendance-warnings/route.js
@@ -5,6 +5,7 @@ import { getUserProfile } from '@/lib/firebase-admin';
 import { initializeFirebase } from '@/lib/firebase-admin';
 import admin from 'firebase-admin';
 import { evaluateStudentAttendance } from '@/lib/attendanceUtils';
+import { ensureIndexes } from '@/lib/db-indexes';
 
 export const dynamic = 'force-dynamic';
 
@@ -16,6 +17,7 @@ export async function GET(request) {
     }
 
     const db = await connectDb();
+    await ensureIndexes();
     initializeFirebase();
     const firestore = admin.firestore();
 

--- a/lib/db-indexes.js
+++ b/lib/db-indexes.js
@@ -1,0 +1,25 @@
+import { connectDb } from "./mongodb";
+
+let indexesEnsured = false;
+
+export async function ensureIndexes() {
+  if (indexesEnsured) return;
+  indexesEnsured = true;
+
+  const db = await connectDb();
+
+  await Promise.all([
+    db.collection("attendance").createIndex({ date: 1, instituteId: 1 }),
+    db.collection("users").createIndex({ role: 1 }),
+    db.collection("warning_logs").createIndex({ userId: 1, createdAt: 1 }),
+    db.collection("notices").createIndex(
+      { targetAudience: 1, instituteId: 1, isPinned: -1, createdAt: -1 }
+    ),
+    db.collection("pomodoro_sessions").createIndex(
+      { firebaseUid: 1, completedAt: -1 }
+    ),
+    db.collection("notifications").createIndex(
+      { userId: 1, createdAt: -1 }
+    ),
+  ]);
+}


### PR DESCRIPTION
Created lib/db-indexes.js with ensureIndexes() that creates compound indexes for 6 frequently-queried collection patterns. Called in cron routes (attendance-warnings, attendance-risk) to eliminate full collection scans. Indexes: attendance(date+instituteId), users(role), warning_logs(userId+createdAt), notices(multi-field), pomodoro_sessions(firebaseUid+completedAt), notifications(userId+createdAt).

Closes #3019