### PR TITLE
feat: add unsaved changes warning for forms

### DIFF
--- a/components/dashboard/CurriculumBuilder.jsx
+++ b/components/dashboard/CurriculumBuilder.jsx
@@ -25,6 +25,7 @@ import { toast } from "react-hot-toast";
 // Fetch the master courses list
 import { COURSES } from "@/lib/courses";
 import { apiFetch } from "@/lib/apiClient";
+import useUnsavedChangesWarning from "@/hooks/useUnsavedChangesWarning";
 
 
 export default function CurriculumBuilder() {
@@ -35,6 +36,9 @@ export default function CurriculumBuilder() {
   const [loading, setLoading] = useState(true);
   const [syncing, setSyncing] = useState(false);
   const [lastSaved, setLastSaved] = useState(null);
+  const [isDirty, setIsDirty] = useState(false);
+
+  useUnsavedChangesWarning(isDirty);
 
   // Track expanded state for module accordions
   const [expandedModules, setExpandedModules] = useState({});
@@ -110,6 +114,7 @@ export default function CurriculumBuilder() {
       const data = await res.json();
       if (data.success) {
         setLastSaved(new Date().toLocaleTimeString());
+        setIsDirty(false);
         toast.success(data.message || "Changes saved!", { id: toastId });
       } else {
         throw new Error(data.error);
@@ -144,6 +149,7 @@ export default function CurriculumBuilder() {
     const updated = [...modules, newModule];
     setModules(updated);
     setExpandedModules(prev => ({ ...prev, [newModule.id]: true }));
+    setIsDirty(true);
     syncCurriculum(updated);
     toast.success("Module created! Double-click to rename.");
   };
@@ -154,6 +160,7 @@ export default function CurriculumBuilder() {
       .filter(mod => mod.id !== moduleId)
       .map((mod, idx) => ({ ...mod, order: idx }));
     setModules(updated);
+    setIsDirty(true);
     syncCurriculum(updated);
     toast.success("Module deleted successfully.");
   };
@@ -196,6 +203,7 @@ export default function CurriculumBuilder() {
     }
 
     setModules(updated);
+    setIsDirty(true);
     syncCurriculum(updated);
     setEditingEntity(null);
   };
@@ -227,6 +235,7 @@ export default function CurriculumBuilder() {
     setModules(updated);
     // Make sure module is expanded so user sees the new lesson
     setExpandedModules(prev => ({ ...prev, [moduleId]: true }));
+    setIsDirty(true);
     syncCurriculum(updated);
     toast.success(`New ${type} added!`);
   };
@@ -245,6 +254,7 @@ export default function CurriculumBuilder() {
       return mod;
     });
     setModules(updated);
+    setIsDirty(true);
     syncCurriculum(updated);
     toast.success("Lesson deleted.");
   };
@@ -263,6 +273,7 @@ export default function CurriculumBuilder() {
       return mod;
     });
     setModules(updated);
+    setIsDirty(true);
     syncCurriculum(updated);
   };
 
@@ -280,6 +291,7 @@ export default function CurriculumBuilder() {
       return mod;
     });
     setModules(updated);
+    setIsDirty(true);
     syncCurriculum(updated);
   };
 
@@ -345,6 +357,7 @@ export default function CurriculumBuilder() {
       // Update order field
       updated = updated.map((mod, idx) => ({ ...mod, order: idx }));
       setModules(updated);
+      setIsDirty(true);
       syncCurriculum(updated);
     }
 
@@ -378,6 +391,7 @@ export default function CurriculumBuilder() {
         targetModule.lessons = targetModule.lessons.map((les, idx) => ({ ...les, order: idx }));
 
         setModules(updated);
+        setIsDirty(true);
         syncCurriculum(updated);
         // Force expand target module so dropped lesson is visible
         setExpandedModules(prev => ({ ...prev, [targetModuleId]: true }));

--- a/components/register.js
+++ b/components/register.js
@@ -8,6 +8,7 @@ import toast from "react-hot-toast";
 import { Upload, User, Mail, Hash, CheckCircle } from "lucide-react";
 import { Navbar } from "@/components/Navbar";
 import { useAuth } from "@/hooks/useAuth";
+import useUnsavedChangesWarning from "@/hooks/useUnsavedChangesWarning";
 import NextImage from "next/image";
 import { validateRequired, validateName } from "@/utils/formValidation";
 import { isValidEmail, suggestEmailCorrection } from "@/utils/emailValidation";
@@ -69,6 +70,9 @@ export default function RegisterPage() {
   const [error, setError] = useState(null);
   const [emailSuggestion, setEmailSuggestion] = useState(null);
   const [isLoading, setIsLoading] = useState(false);
+  const [isDirty, setIsDirty] = useState(false);
+
+  useUnsavedChangesWarning(isDirty);
 
   // ✅ CORRECT LOCATION: Prefill email from auth user using useEffect
   useEffect(() => {
@@ -236,6 +240,7 @@ setEmailSuggestion(null);
         setRollNo("");
         setEmail(user?.email || ""); // ✅ Reset email to auth user's email
         setPhoto(null);
+        setIsDirty(false);
         toast.success("Registration successful!");
       } else {
         setError(data.error || "An unknown error occurred."); // ✅ Provide a default error message
@@ -300,7 +305,7 @@ setEmailSuggestion(null);
                     type="text"
                     placeholder="Enter your full name"
                     value={name}
-                    onChange={(e) => setName(e.target.value.trimStart())}
+                    onChange={(e) => { setName(e.target.value.trimStart()); setIsDirty(true); }}
                     required
                     className="w-full rounded-xl border border-border bg-background px-4 py-3 text-sm text-foreground placeholder:text-muted-foreground transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-indigo-500/40 focus:border-indigo-500 dark:focus:ring-indigo-400/30 dark:focus:border-indigo-400"
                   />
@@ -317,7 +322,7 @@ setEmailSuggestion(null);
                     type="text"
                     placeholder="Enter your roll number"
                     value={rollNo}
-                    onChange={(e) => setRollNo(e.target.value)}
+                    onChange={(e) => { setRollNo(e.target.value); setIsDirty(true); }}
                     required
                     className="w-full rounded-xl border border-border bg-background px-4 py-3 text-sm text-foreground placeholder:text-muted-foreground transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-indigo-500/40 focus:border-indigo-500 dark:focus:ring-indigo-400/30 dark:focus:border-indigo-400"
                   />
@@ -348,7 +353,7 @@ setEmailSuggestion(null);
                     id="profilePhoto"
                     type="file"
                     accept="image/*"
-                    onChange={(e) => setPhoto(e.target.files?.[0] || null)}
+                    onChange={(e) => { setPhoto(e.target.files?.[0] || null); setIsDirty(true); }}
                     required
                     className="w-full rounded-xl border border-border bg-background px-4 py-3 text-sm text-foreground transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-indigo-500/40 focus:border-indigo-500 file:mr-4 file:rounded-lg file:border-0 file:bg-gradient-to-r file:from-indigo-500 file:to-violet-600 file:px-4 file:py-1.5 file:text-xs file:font-semibold file:text-white hover:file:from-indigo-600 hover:file:to-violet-700"
                   />

--- a/components/universal-profile.js
+++ b/components/universal-profile.js
@@ -44,6 +44,7 @@ import {
 
 import { useAuth } from "@/hooks/useAuth";
 import { useIsMounted } from "@/hooks/useIsMounted";
+import useUnsavedChangesWarning from "@/hooks/useUnsavedChangesWarning";
 import { Navbar } from "./Navbar";
 import ActivityHeatmap from "@/components/activity/ActivityHeatmap";
 import { apiFetch } from "@/lib/apiClient";
@@ -56,8 +57,11 @@ export default function UniversalProfile() {
 
   const [isEditing, setIsEditing] = useState(false);
   const [isSaving, setIsSaving] = useState(false);
+  const [isProfileDirty, setIsProfileDirty] = useState(false);
   const [activeTab, setActiveTab] = useState("overview");
   const isMounted = useIsMounted();
+
+  useUnsavedChangesWarning(isEditing && isProfileDirty);
 
   const [avatarUrl, setAvatarUrl] = useState(null);
   const [imageError, setImageError] = useState(false);
@@ -193,6 +197,7 @@ export default function UniversalProfile() {
   }, [user]);
 
   const handleInputChange = (e) => {
+    setIsProfileDirty(true);
     setFormData((prev) => ({
       ...prev,
       [e.target.name]: e.target.value,
@@ -261,6 +266,7 @@ export default function UniversalProfile() {
         );
 
         setIsEditing(false);
+        setIsProfileDirty(false);
       }
     } catch (error) {
       toast.error(
@@ -694,9 +700,10 @@ export default function UniversalProfile() {
 
                       <Button
                         variant="outline"
-                        onClick={() =>
-                          setIsEditing(false)
-                        }
+                        onClick={() => {
+                          setIsEditing(false);
+                          setIsProfileDirty(false);
+                        }}
                       >
                         <X className="w-4 h-4 mr-2" />
                         Cancel

--- a/hooks/useUnsavedChangesWarning.js
+++ b/hooks/useUnsavedChangesWarning.js
@@ -1,0 +1,59 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+
+export default function useUnsavedChangesWarning(isDirty) {
+  const isDirtyRef = useRef(isDirty);
+
+  useEffect(() => {
+    isDirtyRef.current = isDirty;
+    if (!isDirty) return;
+
+    const MESSAGE = "You have unsaved changes. Are you sure you want to leave?";
+
+    const handleBeforeUnload = (e) => {
+      e.preventDefault();
+      e.returnValue = "";
+    };
+
+    const originalPushState = history.pushState.bind(history);
+    const originalReplaceState = history.replaceState.bind(history);
+
+    let suppressNextConfirm = false;
+
+    const handlePopState = () => {
+      if (isDirtyRef.current) {
+        if (!window.confirm(MESSAGE)) {
+          suppressNextConfirm = true;
+          history.pushState(null, "");
+        }
+      }
+    };
+
+    history.pushState = function (state, title, url) {
+      if (!suppressNextConfirm && isDirtyRef.current && !window.confirm(MESSAGE)) {
+        return;
+      }
+      suppressNextConfirm = false;
+      return originalPushState(state, title, url);
+    };
+
+    history.replaceState = function (state, title, url) {
+      if (!suppressNextConfirm && isDirtyRef.current && !window.confirm(MESSAGE)) {
+        return;
+      }
+      suppressNextConfirm = false;
+      return originalReplaceState(state, title, url);
+    };
+
+    window.addEventListener("beforeunload", handleBeforeUnload);
+    window.addEventListener("popstate", handlePopState);
+
+    return () => {
+      window.removeEventListener("beforeunload", handleBeforeUnload);
+      window.removeEventListener("popstate", handlePopState);
+      history.pushState = originalPushState;
+      history.replaceState = originalReplaceState;
+    };
+  }, [isDirty]);
+}


### PR DESCRIPTION
## Description

This PR adds an **Unsaved Changes Warning** to help prevent accidental data loss when users modify form data and attempt to leave the page before saving.

### Features Added

* Warns users when refreshing the page with unsaved changes
* Warns users when closing the browser tab/window with unsaved changes
* Detects client-side navigation attempts and prompts for confirmation
* Automatically clears warnings after successful save operations
* Automatically clears warnings when changes are discarded/cancelled
* Reusable implementation for future forms

### Forms Covered

* Student Registration
* Profile Editing
* Curriculum Builder

### Implementation Details

* Added a reusable `useUnsavedChangesWarning` hook
* Uses the browser `beforeunload` event for refresh/tab-close protection
* Handles client-side navigation scenarios
* Activates only when a form contains unsaved changes
* Includes proper cleanup of event listeners to prevent memory leaks

### Scope Compliance

This implementation intentionally remains minimal and focused on the issue requirements:

* No new dependencies added
* No backend changes
* No API modifications
* No database changes
* No UI redesigns
* No unrelated code refactoring

### Files Changed

* `hooks/useUnsavedChangesWarning.js`
* `components/register.js`
* `components/universal-profile.js`
* `components/dashboard/CurriculumBuilder.jsx`

### Testing Performed

* Verified warning appears on page refresh when unsaved changes exist
* Verified warning appears on browser/tab close when unsaved changes exist
* Verified warning does not appear when no changes are present
* Verified warning is cleared after successful save operations

Fixes #2384

