### PR TITLE
Fix incomplete rollback leaving orphaned Firestore docs in bulk import

### DIFF
--- a/app/api/institute/bulk-import/route.js
+++ b/app/api/institute/bulk-import/route.js
@@ -60,6 +60,8 @@ export async function POST(req) {
     let successfulImports = 0;
     const failedImports = [];
     const createdAuthUids = [];
+    const newlyCreatedUids = [];
+    const firestoreWrittenUids = [];
 
     // Batch phase 1: Firebase Auth – look up existing users in bulk
     const authIdentifiers = students.map((s) => ({ email: s.email }));
@@ -72,6 +74,7 @@ export async function POST(req) {
 
     // Batch phase 2: Create non-existing Firebase Auth users in bulk
     const usersToCreate = students.filter((s) => !existingAuthUsers.includes(s.email));
+    const newlyCreatedEmails = new Set(usersToCreate.map((s) => s.email));
     if (usersToCreate.length > 0) {
       const createResult = await admin.auth().createUsers(
         usersToCreate.map((s) => ({
@@ -101,6 +104,13 @@ export async function POST(req) {
       }
     }
 
+    // Track which UIDs were newly created (for scoped rollback)
+    for (const user of allAuthUsers.users) {
+      if (user.email && newlyCreatedEmails.has(user.email)) {
+        newlyCreatedUids.push(user.uid);
+      }
+    }
+
     // Batch phase 3: Gather all UIDs for students that passed Auth
     const validStudents = students.filter((s) => {
       const alreadyFailed = failedImports.some((f) => f.email === s.email);
@@ -115,10 +125,30 @@ export async function POST(req) {
       }
     }
 
-    // Set Firebase custom claims for all created auth users
-    await Promise.all(createdAuthUids.map(uid =>
-      admin.auth().setCustomUserClaims(uid, { role: 'student', instituteId })
-    ));
+    // Set Firebase custom claims — allSettled to handle partial failures
+    const claimsResults = await Promise.allSettled(
+      createdAuthUids.map((uid) =>
+        admin.auth().setCustomUserClaims(uid, { role: "student", instituteId })
+      )
+    );
+    const failedClaims = claimsResults.filter((r) => r.status === "rejected");
+    if (failedClaims.length > 0) {
+      const claimsSucceededUids = createdAuthUids.filter(
+        (_, i) => claimsResults[i].status === "fulfilled"
+      );
+      await Promise.allSettled(
+        claimsSucceededUids.map((uid) =>
+          admin.auth().setCustomUserClaims(uid, null)
+        )
+      );
+      if (newlyCreatedUids.length > 0) {
+        await admin.auth().deleteUsers(newlyCreatedUids);
+      }
+      return NextResponse.json(
+        { error: `Failed to set custom claims for ${failedClaims.length} users` },
+        { status: 500 }
+      );
+    }
 
     // Batch phase 4: Bulk Firestore writes
     const BATCH_LIMIT = 500;
@@ -141,6 +171,7 @@ export async function POST(req) {
         },
         { merge: true }
       );
+      firestoreWrittenUids.push(uid);
       batchCount++;
       if (batchCount >= BATCH_LIMIT) {
         await firestoreBatch.commit();
@@ -191,15 +222,48 @@ export async function POST(req) {
       try {
         await mongoUsers.bulkWrite(mongoBulkOps, { ordered: false });
       } catch (mongoError) {
-        // Rollback: delete Firebase Auth users created in this request
-        if (createdAuthUids.length > 0) {
+        // Rollback in reverse order of writes: Firestore → claims → Auth accounts
+
+        // 1. Delete Firestore documents that were written
+        if (firestoreWrittenUids.length > 0) {
           try {
-            await admin.auth().deleteUsers(createdAuthUids);
-            console.warn(`Rolled back ${createdAuthUids.length} Firebase Auth users after MongoDB write failure`);
-          } catch (rollbackError) {
-            console.error(`Failed to rollback Firebase Auth users:`, rollbackError);
+            for (let i = 0; i < firestoreWrittenUids.length; i += BATCH_LIMIT) {
+              const batch = firestore.batch();
+              firestoreWrittenUids.slice(i, i + BATCH_LIMIT).forEach((uid) => {
+                batch.delete(firestore.collection("users").doc(uid));
+              });
+              await batch.commit();
+            }
+            console.warn(`Rolled back ${firestoreWrittenUids.length} Firestore documents after MongoDB write failure`);
+          } catch (fsRollbackError) {
+            console.error(`Failed to rollback Firestore documents:`, fsRollbackError);
           }
         }
+
+        // 2. Clear custom claims on all users that received them
+        if (createdAuthUids.length > 0) {
+          try {
+            await Promise.allSettled(
+              createdAuthUids.map((uid) =>
+                admin.auth().setCustomUserClaims(uid, null)
+              )
+            );
+            console.warn(`Cleared custom claims for ${createdAuthUids.length} users after MongoDB write failure`);
+          } catch (claimsRollbackError) {
+            console.error(`Failed to clear custom claims:`, claimsRollbackError);
+          }
+        }
+
+        // 3. Delete only newly created Firebase Auth users, not pre-existing ones
+        if (newlyCreatedUids.length > 0) {
+          try {
+            await admin.auth().deleteUsers(newlyCreatedUids);
+            console.warn(`Rolled back ${newlyCreatedUids.length} newly created Firebase Auth users after MongoDB write failure`);
+          } catch (authRollbackError) {
+            console.error(`Failed to rollback Firebase Auth users:`, authRollbackError);
+          }
+        }
+
         throw mongoError;
       }
     }


### PR DESCRIPTION
## What this fixes

The bulk import endpoint (`POST /api/institute/bulk-import`) creates Firebase Auth accounts, sets custom claims, writes Firestore user documents, then writes MongoDB user records — in that order. If the MongoDB bulk write fails, the catch block only deleted Firebase Auth accounts, leaving Firestore documents permanently orphaned. Additionally, `Promise.all` on `setCustomUserClaims` could partially fail (some succeed, one rejects) with no compensation, and the Auth deletion included pre-existing accounts that should not have been touched.

## Root cause

Three independent rollback gaps in `app/api/institute/bulk-import/route.js`:

1. **Firestore compensation was missing** — the Firestore batch commits (lines 145-153) ran before the MongoDB write. When MongoDB failed, the catch block (line 193) only called `admin.auth().deleteUsers()` — no Firestore cleanup was ever attempted.

2. **`Promise.all` on custom claims had no partial-failure handling** — line 119 used `Promise.all()` across all UIDs. A single Firebase Auth API rate-limit or network error would reject the entire promise, but the calls that already succeeded were never rolled back.

3. **Rollback deleted pre-existing Auth accounts** — `createdAuthUids` included both newly created and pre-existing users. The rollback called `deleteUsers` on the full list, potentially destroying accounts that existed before the request.

## What changed

- **Track newly created UIDs separately** (`newlyCreatedUids`) — derived from `usersToCreate` emails matched against the `allAuthUsers` lookup, so rollback only touches accounts this request created.
- **Track Firestore document writes** (`firestoreWrittenUids`) — collected during the batch-write loop so we know exactly which docs to delete on rollback.
- **Replaced `Promise.all` with `Promise.allSettled`** on `setCustomUserClaims` — when any call fails, the successful ones are immediately cleared (set to `null`), then newly created Auth accounts are deleted. The request returns a 500 instead of proceeding with partial state.
- **MongoDB failure catch block now compensates in three phases**: (1) Firestore documents deleted in batches of 500, (2) custom claims cleared on all impacted UIDs, (3) only newly created Auth accounts deleted. Reverse order matches the forward write order.

## How to verify

1. Start with a clean Firebase project and MongoDB instance.
2. Call `POST /api/institute/bulk-import` with 200+ students as an institute admin.
3. Set up the MongoDB `users` collection with a unique index on `email` or `rollNo` that will collide.
4. Without the fix: the API returns 500, but Firestore `users/` collection contains documents for all students, and Firebase Auth still has the accounts for any that weren't deleted (if some were pre-existing they'd be gone too, which is worse).
5. With the fix: after the 500, Firestore `users/` has no documents from the import, custom claims on all impacted users are cleared, and only accounts that existed before the request remain in Firebase Auth.

## Edge cases considered

- **Empty import** (`students: []`): All loops skip, no rollback is triggered — zero operations.
- **All students pre-exist in Auth**: `newlyCreatedUids` stays empty, rollback skips Auth deletion. Firestore docs and claims are still cleaned up.
- **Partial Auth creation failure**: `createResult.failed` populates `failedImports`, only successful creations are included in `createdAuthUids` — no change from existing behavior.
- **Custom claims fail on some UIDs**: `allSettled` captures successes and failures. Successful claims are cleared and newly created Auth accounts are deleted before returning 500 — no partial state persists.
- **Firestore rollback exceeds 500 documents**: Batched in chunks of `BATCH_LIMIT` (500) to stay within Firestore batch operation limits.
- **Rollback itself fails**: Each compensation step is wrapped in try/catch with independent error logging. Subsequent steps still attempt to run. The `mongoError` is always re-thrown so the API returns 500 regardless of rollback success.

Closes #3100
