### PR TITLE
Fix SSE connection tracker leaking memory in serverless environment

### DIFF
--- a/app/api/notices/stream/route.js
+++ b/app/api/notices/stream/route.js
@@ -32,15 +32,27 @@ const redisKeys = {
 };
 
 // ── In-memory connection fallback (used when Redis is unavailable) ────────────
+// Entries carry a TTL so abnormally terminated connections (serverless timeout,
+// browser crash, process kill) self-heal instead of permanently blocking slots.
+const MEMORY_CONNECTION_TTL_MS = 5 * 60 * 1000;
 const memoryConnections = new Map();
 
 function getMemoryConnectionCount(userId) {
-  return memoryConnections.get(userId) || 0;
+  const entry = memoryConnections.get(userId);
+  if (!entry) return 0;
+  if (Date.now() > entry.expiresAt) {
+    memoryConnections.delete(userId);
+    return 0;
+  }
+  return entry.count;
 }
 
 function incrementMemoryConnection(userId) {
   const count = getMemoryConnectionCount(userId) + 1;
-  memoryConnections.set(userId, count);
+  memoryConnections.set(userId, {
+    count,
+    expiresAt: Date.now() + MEMORY_CONNECTION_TTL_MS,
+  });
   return count;
 }
 
@@ -49,10 +61,23 @@ function decrementMemoryConnection(userId) {
   if (count === 0) {
     memoryConnections.delete(userId);
   } else {
-    memoryConnections.set(userId, count);
+    memoryConnections.set(userId, {
+      count,
+      expiresAt: Date.now() + MEMORY_CONNECTION_TTL_MS,
+    });
   }
   return count;
 }
+
+// Periodic eviction of stale entries — same pattern as lib/rateLimit.js
+setInterval(() => {
+  const now = Date.now();
+  for (const [userId, entry] of memoryConnections.entries()) {
+    if (now > entry.expiresAt) {
+      memoryConnections.delete(userId);
+    }
+  }
+}, 60 * 1000).unref();
 
 // ── Connection Registry (Redis-backed with in-memory fallback) ────────────────
 async function registerConnection(userId) {
@@ -70,9 +95,7 @@ async function registerConnection(userId) {
 
   const key = redisKeys.connectionCount(userId);
   const count = await redis.incr(key);
-  if (count === 1) {
-    await redis.expire(key, Math.ceil(IDLE_TIMEOUT_MS / 1000));
-  }
+  await redis.expire(key, Math.ceil(IDLE_TIMEOUT_MS / 1000));
 
   if (count > MAX_PER_USER) {
     await redis.decr(key);


### PR DESCRIPTION
## What this fixes

The SSE notice stream endpoint (`GET /api/notices/stream`) uses a module-level `memoryConnections` Map to track active connections when Redis is unavailable. In a serverless environment, connections that terminate abnormally (serverless timeout, process crash, forced tab close) never trigger `cleanup()`, so `unregisterConnection()` is never called. Each leaked entry permanently consumes one of the three connection slots per user, eventually blocking all legitimate SSE connections for that user. Separately, the Redis connection counter key only had its TTL set on the first `incr`, so a transient `expire` failure left the key without a TTL to clean it up.

## Root cause

Two independent gaps in `app/api/notices/stream/route.js`:

1. **No TTL on in-memory entries** — the `memoryConnections` Map stored raw integer counts with no expiry. When a connection died without calling `decrementMemoryConnection` (because the abort handler never fired), the entry lived forever in that Map, permanently locking that user's connection slots.

2. **Conditional Redis expire** — `redis.expire()` was only called when `incr` returned 1 (key was just created). If that single `expire` call failed due to a transient network error, the key persisted in Redis indefinitely with no TTL, even though subsequent connections would increment it but never set a TTL.

## What changed

All changes in `app/api/notices/stream/route.js`:

- **Replaced raw integer Map values with `{ count, expiresAt }` objects** — every `set()` call stores an absolute expiry timestamp. `getMemoryConnectionCount` checks expiry on access and deletes stale entries. `incrementMemoryConnection` and `decrementMemoryConnection` refresh the TTL on write.

- **Added periodic eviction** — a `setInterval` (every 60s, `.unref()`'d) iterates the Map and removes expired entries. Same pattern used by `lib/rateLimit.js` for its memory fallback.

- **Redis expire runs unconditionally** — moved `redis.expire()` outside the `if (count === 1)` guard so it executes on every connection registration, not just the first one. This ensures the key always has a TTL even if an earlier `expire` call failed.

## How to verify

1. Deploy to Vercel (or any serverless environment).
2. As any authenticated user, open 3 SSE connections to `GET /api/notices/stream` (e.g., 3 browser tabs).
3. Hard-kill one tab (force-close the browser process, or wait for a serverless function timeout).
4. Before the fix: that user is permanently unable to open any new SSE connection — all 3 slots are occupied by leaked entries.
5. After the fix: within 5 minutes (the TTL), the leaked entry expires and the user can connect again. The periodic eviction (every 60s) will also clean up the stale entry on its next pass.
6. For the Redis path: confirm the connection count key always has a TTL by running `TTL sse:conn:<userId>` after multiple connection/disconnect cycles.

## Edge cases considered

- **Empty Map** — eviction interval iterates zero entries, no-op.
- **All three connections simultaneously active with Redis down** — in-memory fallback correctly limits to MAX_PER_USER (3). Connections that disconnect via clean `cleanup()` still decrement properly. If they abort abnormally, the TTL self-heals.
- **Redis expire fails transiently** — the unconditional `expire` call on every `registerConnection` retries the TTL set on every subsequent connection attempt, not just the first.
- **Instance count drift** — in serverless, each instance has its own Map. Redis is the single source of truth via `incr`/`decr`. The in-memory Map only activates when Redis is unreachable, and is now bounded by TTL.

Closes #3101
