### PR TITLE
[Critical] Fix CommandPaletteWrapper import path in layout.js

### DIFF
--- a/app/layout.js
+++ b/app/layout.js
@@ -38,7 +38,7 @@ import AllProviders from "./providers/AllProviders";
 import { siteStructuredData } from "@/lib/seo/siteStructuredData";
 
 // 🎯 FIX: Explicitly loading overlays
-import CommandPaletteWrapper from "@/components/CommandPalette";
+import CommandPaletteWrapper from "@/components/CommandPaletteWrapper";
 import ShortcutsModal from "@/components/ShortcutsModal";
 
 


### PR DESCRIPTION
## Summary

`app/layout.js` line 41 imported `CommandPaletteWrapper` from `@/components/CommandPalette`, which is the wrong path. This imported the presentational `CommandPalette` component (which requires `isOpen` and `onClose` props) instead of the `CommandPaletteWrapper` component that manages its own state.

## What was the issue

**Cause:** The import path was mistyped — using `@/components/CommandPalette` instead of `@/components/CommandPaletteWrapper`.

**Impact:**
- The command palette (Ctrl+K / Cmd+K) always renders nothing because the presentational `CommandPalette` component receives no `isOpen` prop and hits its early return: `if (!isOpen) return null;`
- The palette is completely dead site-wide — `layout.js` wraps all routes
- No error is thrown (silent failure), making debugging extremely difficult

## What was the fix

Changed the import in `app/layout.js` line 41 from:
```javascript
// WRONG: imports presentational CommandPalette that needs props
import CommandPaletteWrapper from "@/components/CommandPalette";
```
To:
```javascript
// CORRECT: imports CommandPaletteWrapper that manages its own isOpen state
import CommandPaletteWrapper from "@/components/CommandPaletteWrapper";
```

The `@/components/CommandPaletteWrapper.js` file already exists and exports a component that manages `isOpen` state internally and renders `<CommandPalette>` with the correct props.

## Additional context

Adding `no-undef` to the ESLint config (if not already present) could catch incorrect path references at lint-time. However, since both files exist, a linter wouldn't catch this — it requires the developer to know which file is importing from the wrong place.

Closes #2933
