### PR TITLE
feat(ui): add toast notification when copying notice link (#2006)

### DIFF
--- a/components/NoticeCard.jsx
+++ b/components/NoticeCard.jsx
@@ -282,11 +282,15 @@ const NoticeCard = ({ notice, isRead, onToggleRead, searchQuery, getRelativeTime
     ].join("\n");
 
     try {
+      // FIX FOR ISSUE #2006: Add toast confirmation on success
       await navigator.clipboard.writeText(mdText);
       setCopyFeedback(true);
+      toast.success('Notice link copied to clipboard!');
       setTimeout(() => setCopyFeedback(false), 2000);
     } catch (err) {
       console.error("Failed to copy markdown to clipboard", err);
+      // Fallback UI/UX error handling
+      toast.error('Failed to copy. Check browser permissions.');
     }
   }, [notice]);
 


### PR DESCRIPTION
Closes #2006

## Overview
This PR improves the UX of the Notice Board by adding clear visual feedback when a user copies a notice to their clipboard. 

## Changes
- Modified `handleCopyMarkdown` inside `components/NoticeCard.jsx`.
- Integrated `react-hot-toast` to trigger a success message upon successful clipboard write.
- Added a fallback error toast to handle browser permission blocks.

## Testing
- Clicked the "Copy Markdown" button on a notice. Verified the success toast appears cleanly.
- Simulated a blocked clipboard API to verify the error toast renders correctly.
- Confirmed the layout works seamlessly across mobile and desktop breakpoints without overlapping the HUD badge.