### PR TITLE
Add authentication to quiz sessions API and create missing route files

### DIFF
--- a/app/api/quiz-sessions/[sessionId]/abandon/route.js
+++ b/app/api/quiz-sessions/[sessionId]/abandon/route.js
@@ -1,0 +1,41 @@
+import { connectDb } from "@/lib/mongodb";
+import { requireAuth } from "@/lib/rbac";
+import { withErrorHandler } from "@/lib/error-handler";
+
+export const POST = withErrorHandler(async (req, { params }) => {
+  const payload = await requireAuth(req);
+  const { sessionId } = await params;
+
+  if (!sessionId) {
+    return new Response(
+      JSON.stringify({ error: "Session ID is required" }),
+      { status: 400, headers: { "Content-Type": "application/json" } }
+    );
+  }
+
+  const db = await connectDb();
+
+  const session = await db
+    .collection("quiz_sessions")
+    .findOne({ _id: sessionId });
+  if (!session) {
+    return new Response(JSON.stringify({ error: "Session not found" }), {
+      status: 404,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  if (session.userId !== payload.uid) {
+    return new Response(JSON.stringify({ error: "Forbidden" }), {
+      status: 403,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  await db.collection("quiz_sessions").deleteOne({ _id: sessionId });
+
+  return new Response(
+    JSON.stringify({ success: true, message: "Session abandoned" }),
+    { status: 200, headers: { "Content-Type": "application/json" } }
+  );
+});

--- a/app/api/quiz-sessions/[sessionId]/progress/route.js
+++ b/app/api/quiz-sessions/[sessionId]/progress/route.js
@@ -1,0 +1,46 @@
+import { connectDb } from "@/lib/mongodb";
+import { requireAuth } from "@/lib/rbac";
+import { withErrorHandler } from "@/lib/error-handler";
+
+export const GET = withErrorHandler(async (req, { params }) => {
+  const payload = await requireAuth(req);
+  const { sessionId } = await params;
+
+  if (!sessionId) {
+    return new Response(
+      JSON.stringify({ error: "Session ID is required" }),
+      { status: 400, headers: { "Content-Type": "application/json" } }
+    );
+  }
+
+  const db = await connectDb();
+
+  const session = await db
+    .collection("quiz_sessions")
+    .findOne({ _id: sessionId });
+  if (!session) {
+    return new Response(JSON.stringify({ error: "Session not found" }), {
+      status: 404,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  if (session.userId !== payload.uid) {
+    return new Response(JSON.stringify({ error: "Forbidden" }), {
+      status: 403,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  const quiz = await db
+    .collection("quizzes")
+    .findOne({ _id: session.quizId });
+
+  return new Response(
+    JSON.stringify({
+      questionsAnswered: Object.keys(session.answers).length,
+      totalQuestions: quiz.questions.length,
+    }),
+    { status: 200, headers: { "Content-Type": "application/json" } }
+  );
+});

--- a/app/api/quiz-sessions/answer/route.js
+++ b/app/api/quiz-sessions/answer/route.js
@@ -1,0 +1,78 @@
+import { connectDb } from "@/lib/mongodb";
+import { requireAuth } from "@/lib/rbac";
+import { withErrorHandler } from "@/lib/error-handler";
+
+export const POST = withErrorHandler(async (req) => {
+  const payload = await requireAuth(req);
+  const { sessionId, questionId, answer, timestamp } = await req.json();
+
+  if (!sessionId || !questionId || answer === undefined) {
+    return new Response(
+      JSON.stringify({ error: "Missing required fields" }),
+      { status: 400, headers: { "Content-Type": "application/json" } }
+    );
+  }
+
+  const db = await connectDb();
+
+  const session = await db
+    .collection("quiz_sessions")
+    .findOne({ _id: sessionId });
+  if (!session) {
+    return new Response(JSON.stringify({ error: "Session not found" }), {
+      status: 404,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  if (session.userId !== payload.uid) {
+    return new Response(JSON.stringify({ error: "Forbidden" }), {
+      status: 403,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  if (new Date() > session.expiresAt) {
+    return new Response(JSON.stringify({ error: "Session expired" }), {
+      status: 403,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  if (session.completed) {
+    return new Response(JSON.stringify({ error: "Quiz already submitted" }), {
+      status: 403,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  const quiz = await db
+    .collection("quizzes")
+    .findOne({ _id: session.quizId });
+  const questionExists = quiz.questions.some((q) => q._id === questionId);
+
+  if (!questionExists) {
+    return new Response(
+      JSON.stringify({ error: "Question not found in quiz" }),
+      { status: 400, headers: { "Content-Type": "application/json" } }
+    );
+  }
+
+  await db.collection("quiz_sessions").updateOne(
+    { _id: sessionId },
+    {
+      $set: {
+        [`answers.${questionId}`]: answer,
+        [`answeredAt.${questionId}`]: new Date(timestamp || Date.now()),
+      },
+    }
+  );
+
+  return new Response(
+    JSON.stringify({
+      success: true,
+      message: "Answer recorded",
+    }),
+    { status: 200, headers: { "Content-Type": "application/json" } }
+  );
+});

--- a/app/api/quiz-sessions/create/route.js
+++ b/app/api/quiz-sessions/create/route.js
@@ -1,0 +1,1 @@
+export { POST } from "../route";

--- a/app/api/quiz-sessions/route.js
+++ b/app/api/quiz-sessions/route.js
@@ -1,241 +1,53 @@
-/**
- * app/api/quiz-sessions/route.js
- *
- * Server-side quiz session API endpoint.
- * All quiz answers and progress stored server-side in secure sessions.
- * Client only holds sessionId token.
- *
- * Prevents XSS attacks from modifying answers via localStorage.
- */
-
 import { connectDb } from "@/lib/mongodb";
 import { v4 as uuidv4 } from "uuid";
+import { requireAuth } from "@/lib/rbac";
+import { withErrorHandler } from "@/lib/error-handler";
 
-const SESSION_TIMEOUT_MS = 2 * 60 * 60 * 1000; // 2 hours
+const SESSION_TIMEOUT_MS = 2 * 60 * 60 * 1000;
 
-/**
- * POST /api/quiz-sessions/create
- * Create a new quiz session
- */
-export async function POST(req) {
-  try {
-    const { quizId } = await req.json();
+export const POST = withErrorHandler(async (req) => {
+  const payload = await requireAuth(req);
+  const { quizId } = await req.json();
 
-    if (!quizId) {
-      return new Response(JSON.stringify({ error: "Quiz ID is required" }), {
-        status: 400,
-        headers: { "Content-Type": "application/json" },
-      });
-    }
-
-    const db = await connectDb();
-
-    // Get quiz metadata
-    const quiz = await db.collection("quizzes").findOne({ _id: quizId });
-    if (!quiz) {
-      return new Response(JSON.stringify({ error: "Quiz not found" }), {
-        status: 404,
-        headers: { "Content-Type": "application/json" },
-      });
-    }
-
-    // Create session (simplified - in production use authenticated user ID)
-    const sessionId = uuidv4();
-    const expiresAt = new Date(Date.now() + SESSION_TIMEOUT_MS);
-
-    const session = {
-      _id: sessionId,
-      quizId,
-      createdAt: new Date(),
-      expiresAt,
-      answers: {}, // Map of questionId -> answer
-      answeredAt: {}, // Map of questionId -> timestamp
-      completed: false,
-      submittedAt: null,
-    };
-
-    await db.collection("quiz_sessions").insertOne(session);
-
-    return new Response(
-      JSON.stringify({
-        sessionId,
-        expiresAt: expiresAt.toISOString(),
-      }),
-      { status: 201, headers: { "Content-Type": "application/json" } }
-    );
-  } catch (error) {
-    console.error("Quiz session creation error:", error);
-    return new Response(JSON.stringify({ error: "Failed to create session" }), {
-      status: 500,
+  if (!quizId) {
+    return new Response(JSON.stringify({ error: "Quiz ID is required" }), {
+      status: 400,
       headers: { "Content-Type": "application/json" },
     });
   }
-}
 
-/**
- * POST /api/quiz-sessions/[sessionId]/answer
- * Submit an answer to a quiz question
- */
-export async function submitAnswer(req, sessionId) {
-  try {
-    const { questionId, answer, timestamp } = await req.json();
+  const db = await connectDb();
 
-    if (!sessionId || !questionId || answer === undefined) {
-      return new Response(
-        JSON.stringify({ error: "Missing required fields" }),
-        { status: 400, headers: { "Content-Type": "application/json" } }
-      );
-    }
-
-    const db = await connectDb();
-
-    // Validate session exists and not expired
-    const session = await db
-      .collection("quiz_sessions")
-      .findOne({ _id: sessionId });
-    if (!session) {
-      return new Response(JSON.stringify({ error: "Session not found" }), {
-        status: 404,
-        headers: { "Content-Type": "application/json" },
-      });
-    }
-
-    if (new Date() > session.expiresAt) {
-      return new Response(JSON.stringify({ error: "Session expired" }), {
-        status: 403,
-        headers: { "Content-Type": "application/json" },
-      });
-    }
-
-    if (session.completed) {
-      return new Response(JSON.stringify({ error: "Quiz already submitted" }), {
-        status: 403,
-        headers: { "Content-Type": "application/json" },
-      });
-    }
-
-    // Validate question exists in quiz
-    const quiz = await db
-      .collection("quizzes")
-      .findOne({ _id: session.quizId });
-    const questionExists = quiz.questions.some((q) => q._id === questionId);
-
-    if (!questionExists) {
-      return new Response(
-        JSON.stringify({ error: "Question not found in quiz" }),
-        { status: 400, headers: { "Content-Type": "application/json" } }
-      );
-    }
-
-    // Store answer server-side
-    await db.collection("quiz_sessions").updateOne(
-      { _id: sessionId },
-      {
-        $set: {
-          [`answers.${questionId}`]: answer,
-          [`answeredAt.${questionId}`]: new Date(timestamp || Date.now()),
-        },
-      }
-    );
-
-    return new Response(
-      JSON.stringify({
-        success: true,
-        message: "Answer recorded",
-      }),
-      { status: 200, headers: { "Content-Type": "application/json" } }
-    );
-  } catch (error) {
-    console.error("Answer submission error:", error);
-    return new Response(JSON.stringify({ error: "Failed to submit answer" }), {
-      status: 500,
+  const quiz = await db.collection("quizzes").findOne({ _id: quizId });
+  if (!quiz) {
+    return new Response(JSON.stringify({ error: "Quiz not found" }), {
+      status: 404,
       headers: { "Content-Type": "application/json" },
     });
   }
-}
 
-/**
- * POST /api/quiz-sessions/[sessionId]/submit
- * Submit completed quiz and calculate score
- */
-export async function submitQuiz(req, sessionId) {
-  try {
-    const db = await connectDb();
+  const sessionId = uuidv4();
+  const expiresAt = new Date(Date.now() + SESSION_TIMEOUT_MS);
 
-    // Validate session
-    const session = await db
-      .collection("quiz_sessions")
-      .findOne({ _id: sessionId });
-    if (!session) {
-      return new Response(JSON.stringify({ error: "Session not found" }), {
-        status: 404,
-        headers: { "Content-Type": "application/json" },
-      });
-    }
+  const session = {
+    _id: sessionId,
+    quizId,
+    userId: payload.uid,
+    createdAt: new Date(),
+    expiresAt,
+    answers: {},
+    answeredAt: {},
+    completed: false,
+    submittedAt: null,
+  };
 
-    if (new Date() > session.expiresAt) {
-      return new Response(JSON.stringify({ error: "Session expired" }), {
-        status: 403,
-        headers: { "Content-Type": "application/json" },
-      });
-    }
+  await db.collection("quiz_sessions").insertOne(session);
 
-    if (session.completed) {
-      return new Response(JSON.stringify({ error: "Quiz already submitted" }), {
-        status: 403,
-        headers: { "Content-Type": "application/json" },
-      });
-    }
-
-    // Get quiz for grading
-    const quiz = await db
-      .collection("quizzes")
-      .findOne({ _id: session.quizId });
-
-    // Grade answers
-    let correctCount = 0;
-    for (const question of quiz.questions) {
-      const studentAnswer = session.answers[question._id];
-      if (studentAnswer === question.correctAnswer) {
-        correctCount++;
-      }
-    }
-
-    const percentage = Math.round((correctCount / quiz.questions.length) * 100);
-    const passed = percentage >= (quiz.passingScore || 70);
-
-    // Mark session as completed
-    const submittedAt = new Date();
-    await db.collection("quiz_sessions").updateOne(
-      { _id: sessionId },
-      {
-        $set: {
-          completed: true,
-          submittedAt,
-          score: correctCount,
-          percentage,
-          passed,
-        },
-      }
-    );
-
-    return new Response(
-      JSON.stringify({
-        score: correctCount,
-        totalQuestions: quiz.questions.length,
-        percentage,
-        passed,
-        feedback: passed
-          ? "Quiz passed!"
-          : "Quiz failed. Please review and try again.",
-      }),
-      { status: 200, headers: { "Content-Type": "application/json" } }
-    );
-  } catch (error) {
-    console.error("Quiz submission error:", error);
-    return new Response(JSON.stringify({ error: "Failed to submit quiz" }), {
-      status: 500,
-      headers: { "Content-Type": "application/json" },
-    });
-  }
-}
+  return new Response(
+    JSON.stringify({
+      sessionId,
+      expiresAt: expiresAt.toISOString(),
+    }),
+    { status: 201, headers: { "Content-Type": "application/json" } }
+  );
+});

--- a/app/api/quiz-sessions/submit/route.js
+++ b/app/api/quiz-sessions/submit/route.js
@@ -1,0 +1,90 @@
+import { connectDb } from "@/lib/mongodb";
+import { requireAuth } from "@/lib/rbac";
+import { withErrorHandler } from "@/lib/error-handler";
+
+export const POST = withErrorHandler(async (req) => {
+  const payload = await requireAuth(req);
+  const { sessionId } = await req.json();
+
+  if (!sessionId) {
+    return new Response(
+      JSON.stringify({ error: "Session ID is required" }),
+      { status: 400, headers: { "Content-Type": "application/json" } }
+    );
+  }
+
+  const db = await connectDb();
+
+  const session = await db
+    .collection("quiz_sessions")
+    .findOne({ _id: sessionId });
+  if (!session) {
+    return new Response(JSON.stringify({ error: "Session not found" }), {
+      status: 404,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  if (session.userId !== payload.uid) {
+    return new Response(JSON.stringify({ error: "Forbidden" }), {
+      status: 403,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  if (new Date() > session.expiresAt) {
+    return new Response(JSON.stringify({ error: "Session expired" }), {
+      status: 403,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  if (session.completed) {
+    return new Response(JSON.stringify({ error: "Quiz already submitted" }), {
+      status: 403,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  const quiz = await db
+    .collection("quizzes")
+    .findOne({ _id: session.quizId });
+
+  let correctCount = 0;
+  for (const question of quiz.questions) {
+    const studentAnswer = session.answers[question._id];
+    if (studentAnswer === question.correctAnswer) {
+      correctCount++;
+    }
+  }
+
+  const percentage = Math.round((correctCount / quiz.questions.length) * 100);
+  const passed = percentage >= (quiz.passingScore || 70);
+
+  const submittedAt = new Date();
+  await db.collection("quiz_sessions").updateOne(
+    { _id: sessionId },
+    {
+      $set: {
+        completed: true,
+        submittedAt,
+        score: correctCount,
+        percentage,
+        passed,
+      },
+    }
+  );
+
+  return new Response(
+    JSON.stringify({
+      score: correctCount,
+      totalQuestions: quiz.questions.length,
+      percentage,
+      passed,
+      feedback: passed
+        ? "Quiz passed!"
+        : "Quiz failed. Please review and try again.",
+    }),
+    { status: 200, headers: { "Content-Type": "application/json" } }
+  );
+});


### PR DESCRIPTION
Closes #3147

## What this fixes

The quiz sessions API had no authentication — anyone could create quiz sessions, submit answers, and complete quizzes without being logged in. The route file also exported submitAnswer and submitQuiz as top-level functions that were unreachable via HTTP (Next.js only routes named HTTP method exports), making the answer and submit endpoints return 404. The client-side quiz-session-manager.js called endpoints like /api/quiz-sessions/create, /api/quiz-sessions/answer, and /api/quiz-sessions/submit that had no corresponding route files.

## Root cause

The original route.js was written as a monolithic file with three exported functions (POST, submitAnswer, submitQuiz) but only the POST export was reachable via the Next.js App Router. The submitAnswer and submitQuiz functions contained the answer and submission logic but were dead code. Additionally, none of the handlers called requireAuth or authenticatedRequest, so any unauthenticated request could create and manipulate quiz sessions.

## What changed

- app/api/quiz-sessions/route.js: Rewrote the POST handler to call requireAuth, link each session to the authenticated user's UID, and remove the dead submitAnswer/submitQuiz exports
- app/api/quiz-sessions/create/route.js: Re-exports POST from the root route so POST /api/quiz-sessions/create works as expected by the client
- app/api/quiz-sessions/answer/route.js: New POST handler that validates the session, verifies ownership via userId, checks expiration, and stores the answer server-side
- app/api/quiz-sessions/submit/route.js: New POST handler that grades the quiz, calculates score/percentage, and marks the session as completed
- app/api/quiz-sessions/[sessionId]/progress/route.js: New GET handler that returns the count of answered questions and total questions
- app/api/quiz-sessions/[sessionId]/abandon/route.js: New POST handler that deletes the session document

All new handlers call requireAuth and verify that session.userId matches the authenticated user before allowing access.

## How to verify

1. Send POST /api/quiz-sessions/create without an Authorization header or authToken cookie — should return 401
2. Send POST /api/quiz-sessions/create with a valid Firebase token — should return 201 with sessionId
3. Send POST /api/quiz-sessions/answer with a valid token but a sessionId owned by a different user — should return 403
4. Send GET /api/quiz-sessions/{sessionId}/progress with the correct owner's token — should return questionsAnswered and totalQuestions
5. Send POST /api/quiz-sessions/{sessionId}/abandon with the correct owner's token — should delete the session and return 200

## Edge cases considered

- Session ownership is enforced on every endpoint — users cannot access or modify sessions created by other users
- Expired sessions are rejected before any write operation
- Already-submitted quizzes reject new answer submissions
- Missing or malformed sessionId returns 400/404
- create/route.js re-exports the root POST handler so both /api/quiz-sessions and /api/quiz-sessions/create work identically
