### PR TITLE
Add indexes to pending_operations collection used by saga coordinator

### DIFF
--- a/lib/mongodb.js
+++ b/lib/mongodb.js
@@ -36,6 +36,8 @@ const getClientPromise = () => {
 };
 
 let cachedPromise = null;
+let indexesEnsured = false;
+
 const getCachedClientPromise = () => {
   if (!cachedPromise) {
     cachedPromise = getClientPromise().catch((err) => {
@@ -73,12 +75,44 @@ const sseOptions = {
  * const db = await connectDb();
  * const activities = await db.collection('activities').find().toArray();
  */
+async function ensureIndexes(db) {
+  try {
+    await Promise.all([
+      db.collection("rate_limits").createIndex(
+        { expiresAt: 1 },
+        { expireAfterSeconds: 0, background: true }
+      ),
+      db.collection("pending_operations").createIndex(
+        { operationId: 1 },
+        { background: true }
+      ),
+      db.collection("pending_operations").createIndex(
+        { status: 1, updatedAt: 1 },
+        { background: true }
+      ),
+      db.collection("pending_operations").createIndex(
+        { status: 1, createdAt: 1 },
+        { background: true }
+      ),
+    ]);
+  } catch {
+    // Index creation is best-effort
+  }
+}
+
 export async function connectDb() {
   const dbName = process.env.MONGODB_DB;
 
   try {
     const connectedClient = await getClientPromise();
-    return connectedClient.db(dbName);
+    const db = connectedClient.db(dbName);
+
+    if (!indexesEnsured) {
+      indexesEnsured = true;
+      ensureIndexes(db);
+    }
+
+    return db;
   } catch (error) {
     throw new Error(
       `Failed to establish database connection: ${error.message}`
@@ -137,23 +171,6 @@ export async function connectDbForSSE() {
     throw new Error(
       `Failed to establish database connection: ${error.message}`
     );
-  }
-}
-
-/**
- * Ensures a TTL index on the rate_limits collection.
- * Old rate-limit documents are automatically cleaned up by MongoDB.
- */
-export async function ensureRateLimitTTLIndex() {
-  try {
-    const db = await connectDb();
-    const collection = db.collection("rate_limits");
-    await collection.createIndex(
-      { expiresAt: 1 },
-      { expireAfterSeconds: 0, background: true }
-    );
-  } catch {
-    // Silently ignore — index creation is best-effort
   }
 }
 


### PR DESCRIPTION
Closes #3149

## What this fixes

The pending_operations collection, which is the durability backbone of the saga pattern in transactionCoordinator.js, had no indexes beyond the default _id index. Every query against it — findStaleOperations (compound filter on status + updatedAt), cleanupOldOperations (compound filter on createdAt + status), findExistingOperation (operationId lookup), and the idempotency check in executeSaga — performed a full collection scan. For a platform processing thousands of attendance records, role assignments, and registrations daily, this collection grows without bound and every saga operation pays an O(n) scan cost.

## Root cause

The ensureRateLimitTTLIndex function existed for the rate_limits collection but no equivalent index-creation logic was ever written for pending_operations. The collection was created implicitly by upsert operations in the transaction coordinator without any index management.

## What changed

- Added an `ensureIndexes` function called once (fire-and-forget) on the first `connectDb` call, creating:
  - `{ operationId: 1 }` — covers all operationId-based lookups and the upsert in recordPendingOperation
  - `{ status: 1, updatedAt: 1 }` — covers the compound query in findStaleOperations
  - `{ status: 1, createdAt: 1 }` — covers the compound query in cleanupOldOperations
  - `{ expiresAt: 1 }` (TTL) — moved from the orphaned ensureRateLimitTTLIndex function to the same unified call
- Removed the orphaned `ensureRateLimitTTLIndex` export that was never called anywhere
- Index creation is best-effort and non-blocking — if it fails, the application continues without indexes

## How to verify

1. Deploy the change and call any API that triggers a saga (e.g., attendance record, registration)
2. Connect to MongoDB and verify indexes exist on pending_operations:
   ```
   db.pending_operations.getIndexes()
   ```
   Expected output includes entries for operationId_1, status_1_updatedAt_1, and status_1_createdAt_1
3. Run explain() on findStaleOperations and verify it shows IXSCAN instead of COLLSCAN

## Edge cases considered

- Index creation is fire-and-forget — it won't block the first request if MongoDB is slow
- createIndex is idempotent — re-deployments won't create duplicate indexes
- Serverless cold starts: indexesEnsured flag is per-instance, so each new instance creates indexes once
- The rate_limits TTL index creation was previously dead code (exported but never imported) — now it runs on first connectDb call alongside the pending_operations indexes
