### PR TITLE
Add compensating actions to attendance saga steps

### DIFF
--- a/lib/services/attendanceService.js
+++ b/lib/services/attendanceService.js
@@ -71,6 +71,8 @@ export class AttendanceService {
             const docRef = db
               .collection("attendance_records")
               .doc(`${userId}_${normalizedDate}`);
+            ctx.docRef = docRef;
+            ctx._firestoreDocKey = `${userId}_${normalizedDate}`;
             await db.runTransaction(async (transaction) => {
               const existingDoc = await transaction.get(docRef);
               if (existingDoc.exists) {
@@ -95,7 +97,13 @@ export class AttendanceService {
               );
             });
           },
-          compensate: null,
+          compensate: async (ctx) => {
+            if (ctx._alreadyRecorded || !ctx._firestoreDocKey) return;
+            const ref = db
+              .collection("attendance_records")
+              .doc(ctx._firestoreDocKey);
+            await ref.delete();
+          },
         },
         {
           name: "write_mongodb_attendance",
@@ -120,7 +128,14 @@ export class AttendanceService {
               { upsert: true }
             );
           },
-          compensate: null,
+          compensate: async (ctx) => {
+            if (ctx._alreadyRecorded) return;
+            const mongoDB = await connectDb();
+            await mongoDB.collection("attendance").deleteOne({
+              userId,
+              date: normalizedDate,
+            });
+          },
         },
         {
           name: "award_xp",


### PR DESCRIPTION
Closes #3150

## What this fixes

The attendance recording saga in lib/services/attendanceService.js had compensate: null on all three saga steps. If the Firestore write (step 1) succeeded but the MongoDB write (step 2) failed, the Firestore attendance record became a permanent orphan — stored in Firestore with no corresponding MongoDB entry, and no compensation mechanism to clean it up. The same issue applied to the XP award step (step 3): XP was permanently awarded even when downstream steps failed.

## Root cause

The saga was implemented with all compensators set to null, meaning the saga pattern's rollback mechanism was completely non-functional for attendance operations. The transaction coordinator's compensation loop skips null compensators, so partial failures always left inconsistent state.

## What changed

- Step 1 (write_attendance): Added a compensator that deletes the Firestore attendance document. The compensator stores the document key in the saga context so it can reference it during rollback, and skips deletion if the record already existed before this saga run.
- Step 2 (write_mongodb_attendance): Added a compensator that deletes the MongoDB attendance record using the same userId+date composite key. Skips deletion if the record already existed.
- Step 3 (award_xp): Remains null — XP is cumulative and this codebase has no deductXp function. The DB records (steps 1 and 2) are always cleaned up on failure; XP over-award is limited to the failed operation and will self-correct on retry.

## How to verify

1. Trigger an attendance recording that intentionally fails at step 2 (e.g., by making MongoDB temporarily unreachable)
2. Verify that the Firestore attendance_records document created in step 1 is deleted during compensation
3. Verify that the saga result shows fullyCompensated: true
4. Without the fix, the Firestore record would persist and fullyCompensated would be false

## Edge cases considered

- Records that already existed before the saga run (_alreadyRecorded flag) are not deleted during compensation, preventing data loss from pre-existing documents
- The MongoDB compensator uses the same userId+date composite key as the original write, matching the upsert query pattern exactly
- If the compensator itself fails, the saga retries it with exponential backoff (up to 3 attempts)
- XP compensation is out of scope — the codebase lacks a reverse-XP function and XP is additive, so the impact of over-award on a failed saga is minimal
