### PR TITLE
Add stateful session validation to edge middleware

### DIFF
--- a/middleware.js
+++ b/middleware.js
@@ -3,6 +3,22 @@ import * as jose from "jose";
 import { Redis } from "@upstash/redis";
 import { validateCsrfOriginAndReferer, validateCsrfRequest } from "@/lib/csrf";
 
+let redisClient;
+
+function getRedisClient() {
+  if (
+    !redisClient &&
+    process.env.UPSTASH_REDIS_REST_URL &&
+    process.env.UPSTASH_REDIS_REST_TOKEN
+  ) {
+    redisClient = new Redis({
+      url: process.env.UPSTASH_REDIS_REST_URL,
+      token: process.env.UPSTASH_REDIS_REST_TOKEN,
+    });
+  }
+  return redisClient;
+}
+
 const FIREBASE_PROJECT_ID = process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID;
 const FIREBASE_AUTH_DOMAIN = process.env.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN;
 const FIREBASE_API_KEY = process.env.NEXT_PUBLIC_FIREBASE_API_KEY;
@@ -268,6 +284,28 @@ export async function middleware(request) {
       isTokenValid = true;
       isEmailVerified = !!payload.email_verified;
       userRole = payload.role || null;
+    }
+  }
+
+  if (isTokenValid && pathname.startsWith("/api/")) {
+    const sessionId =
+      request.cookies.get("sessionId")?.value ||
+      request.headers.get("x-session-id");
+    if (sessionId) {
+      try {
+        const redis = getRedisClient();
+        if (redis) {
+          const exists = await redis.exists(`session:${sessionId}`);
+          if (exists !== 1) {
+            return NextResponse.json(
+              { error: "Session expired or terminated concurrently" },
+              { status: 401 }
+            );
+          }
+        }
+      } catch {
+        // Redis unavailable — continue without session validation
+      }
     }
   }
 


### PR DESCRIPTION
Closes #3152

## What this fixes

The edge middleware validated Firebase JWT signatures and expiration but never checked whether the request's stateful Redis session was still active. A user who logged out on another device, or whose session was terminated by an admin, could still make authenticated requests until their JWT expired (up to 1 hour). The middleware accepted the request, and it only got rejected at the route level by authenticateRequest, wasting serverless compute time on every such request.

## Root cause

The middleware's verifyIdToken function only performs local JWT verification using the jose library. It checks the token's signature and exp claim but has no mechanism to check session state stored in Redis. The route-level authenticateRequest calls validateSession which checks Redis — but that runs after the request has already passed the edge.

## What changed

- Added a getRedisClient helper that lazily creates and caches an Upstash Redis client, reusing the already-imported @upstash/redis package
- After JWT verification succeeds, the middleware now extracts the sessionId from the sessionId cookie or x-session-id header
- If a sessionId is present, the middleware checks whether the session:<sessionId> key exists in Redis
- If the key doesn't exist (session was terminated), the middleware returns 401 immediately at the edge, before the request reaches the route handler
- Redis unavailability is handled gracefully — the middleware skips session validation and lets the request proceed, preserving existing behavior when Redis is down

## How to verify

1. Log in and get a valid JWT + sessionId cookie
2. Terminate the session manually: `redis.del("session:<sessionId>")` or call the session termination endpoint
3. Send an API request with the same JWT and sessionId cookie — should return 401 from the middleware (before the route handler runs)
4. Without the fix, the same request would pass the middleware and only be rejected at the route level
5. Send a request with a valid session — should pass the middleware and reach the route handler as before

## Edge cases considered

- Redis configuration is optional: if UPSTASH_REDIS_REST_URL and UPSTASH_REDIS_REST_TOKEN are not set, getRedisClient returns null and session validation is skipped entirely, matching the existing bypass behavior in sessionManager.js
- Redis unavailability at request time: the try/catch around redis.exists means a Redis timeout or error won't block authenticated requests
- No sessionId present: sessions are still being rolled out; existing clients without sessionId cookies are unaffected — validation is skipped
- The session check runs only for /api/* paths, not for page requests, matching the scope of JWT validation
