### PR TITLE
Fixes a module system mismatch that causes a runtime crash.

### DIFF
--- a/utils/apiErrorHandler.js
+++ b/utils/apiErrorHandler.js
@@ -1,5 +1,5 @@
-const logger = require("./logger");
-const AppError = require("./appError");
+import logger from './logger';
+import { AppError } from './appError';
 
 /**
  * Wraps a Next.js API Route Handler with centralized error handling and logging.

--- a/utils/appError.js
+++ b/utils/appError.js
@@ -1,11 +1,8 @@
-class AppError extends Error {
+export class AppError extends Error {
   constructor(message, statusCode) {
     super(message);
     this.statusCode = statusCode;
-    this.isOperational = true; // Distinguishes operational errors from system bugs
-
+    this.isOperational = true;
     Error.captureStackTrace(this, this.constructor);
   }
 }
-
-module.exports = AppError;

--- a/utils/logger.js
+++ b/utils/logger.js
@@ -1,4 +1,4 @@
-const winston = require("winston");
+import winston from 'winston';
 
 const logger = winston.createLogger({
   level: process.env.NODE_ENV === "production" ? "info" : "debug",
@@ -16,4 +16,4 @@ const logger = winston.createLogger({
   ],
 });
 
-module.exports = logger;
+export default logger;


### PR DESCRIPTION
## Description

Fixes a module system mismatch that causes a runtime crash. utils/apiErrorHandler.js used require() (CommonJS) to import its dependencies while using export (ESM) for its own exports , an invalid combination in this Next.js ESM project.

Fixes #3161 

## Type of change
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:
- [ x] My code follows the style guidelines of this project
- [ x] My changes generate no new warnings
- [ x] I have performed a self-review of my own code
