### PR TITLE
fix: clamp and validate limit and page query params in /api/courses

### DIFF
--- a/app/api/courses/route.js
+++ b/app/api/courses/route.js
@@ -5,20 +5,28 @@ import { getPaginatedCourses } from "@/lib/courses";
  * GET /api/courses
  * Retrieves a paginated, filtered list of courses.
  */
+const MAX_LIMIT    = 100;
+const DEFAULT_PAGE  = 1;
+const DEFAULT_LIMIT = 12;
+
 export async function GET(request) {
   try {
     const { searchParams } = new URL(request.url);
-    const q = searchParams.get("q") || "";
+    const q        = searchParams.get("q")        || "";
     const category = searchParams.get("category") || "all";
-    const page = parseInt(searchParams.get("page") || "1", 10);
-    const limit = parseInt(searchParams.get("limit") || "12", 10);
+
+    const rawPage  = parseInt(searchParams.get("page")  || String(DEFAULT_PAGE),  10);
+    const rawLimit = parseInt(searchParams.get("limit") || String(DEFAULT_LIMIT), 10);
+
+    // Clamp: reject NaN, enforce min/max bounds
+    const page  = Number.isFinite(rawPage)  && rawPage  >= 1 ? rawPage  : DEFAULT_PAGE;
+    const limit = Number.isFinite(rawLimit) && rawLimit >= 1
+      ? Math.min(rawLimit, MAX_LIMIT)
+      : DEFAULT_LIMIT;
 
     const result = getPaginatedCourses({ q, category, page, limit });
 
-    return NextResponse.json({
-      success: true,
-      ...result,
-    });
+    return NextResponse.json({ success: true, ...result });
   } catch (error) {
     console.error("API Course Fetch Error:", error);
     return NextResponse.json(


### PR DESCRIPTION
## Description
Fixes unvalidated pagination query parameters in GET /api/courses.
Previously, limit and page were parsed with parseInt() and passed directly to getPaginatedCourses() with no bounds checking. This allowed:
-limit=999999 — wasteful computation across the entire dataset
-page=0 / page=-5 — negative startIndex producing incorrect slice results
-limit=abc — parseInt returns NaN, causing slice(NaN, NaN) to silently return [] with no error

Fixes #3165 

## Type of change
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:
- [ x] My code follows the style guidelines of this project
- [ x] My changes generate no new warnings
- [ x] I have performed a self-review of my own code
