### PR TITLE
fix: remove dead loadFirestoreAttendanceByUser function and unused firestore init from cron job

### DIFF
--- a/app/api/cron/attendance-warnings/route.js
+++ b/app/api/cron/attendance-warnings/route.js
@@ -1,8 +1,6 @@
 import { NextResponse } from "next/server";
-import admin from "firebase-admin";
 import { authorizeCronRequest } from "@/lib/cronAuth";
 import { connectDb } from "@/lib/mongodb";
-import { initializeFirebase } from "@/lib/firebase-admin";
 import { evaluateStudentAttendance } from "@/lib/attendanceUtils";
 
 export const dynamic = "force-dynamic";
@@ -86,25 +84,6 @@ async function getRecentWarningUserIds(db, userIds, cooldownDate) {
   return new Set(checks.filter(Boolean));
 }
 
-async function loadFirestoreAttendanceByUser(firestore, studentIds) {
-  const attendanceByUser = new Map();
-
-  await Promise.all(
-    studentIds.map(async (uid) => {
-      const snapshot = await firestore
-        .collection("attendance_records")
-        .where("userId", "==", uid)
-        .get();
-
-      attendanceByUser.set(
-        uid,
-        snapshot.docs.map((doc) => doc.data())
-      );
-    })
-  );
-
-  return attendanceByUser;
-}
 
 async function sendWarningEmails(emailsToSend) {
   const hasEmailConfig =


### PR DESCRIPTION
Removed unused Firestore attendance loading function.

## Description
Cleans up dead code in app/api/cron/attendance-warnings/route.js left over from a refactor that migrated attendance data fetching from Firestore to MongoDB.

Fixes #3167 

## Type of change
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:
- [ x] My code follows the style guidelines of this project
- [ x] My changes generate no new warnings
- [ x] I have performed a self-review of my own code
