### PR TITLE
fix: replace window.__sessionExpired global with a local ref and cancel timer on unmount in useSessionMonitor

### DIFF
--- a/hooks/useSessionMonitor.js
+++ b/hooks/useSessionMonitor.js
@@ -1,3 +1,4 @@
+
 "use client";
 
 import { useEffect, useRef } from "react";
@@ -9,9 +10,10 @@ export function useSessionMonitor() {
   const { signOut } = useAuth();
   const router = useRouter();
   const isIntercepting = useRef(false);
+  const isSessionExpired = useRef(false);   //  local ref — no window pollution
+  const resetTimerRef = useRef(null);        //  store timer ID so we can cancel it
 
   useEffect(() => {
-    // Only run in the browser and only attach once
     if (typeof window === "undefined" || isIntercepting.current) return;
 
     isIntercepting.current = true;
@@ -20,8 +22,6 @@ export function useSessionMonitor() {
     window.fetch = async (...args) => {
       const response = await originalFetch(...args);
 
-      // Check for 401 Unauthorized
-      // Only intercept our own API calls, not third-party requests
       const requestUrl =
         typeof args[0] === "string" ? args[0] : args[0]?.url || "";
       const isOwnApi =
@@ -31,12 +31,9 @@ export function useSessionMonitor() {
 
       if (!isOwnApi) return response;
 
-      // Only 401 Unauthorized indicates session expiry.
-      // 403 Forbidden is used for RBAC, CSRF, and other non-session errors.
       if (response.status === 401) {
-        // Prevent multiple toasts/redirects if multiple requests fail simultaneously
-        if (!window.__sessionExpired) {
-          window.__sessionExpired = true;
+        if (!isSessionExpired.current) {       
+          isSessionExpired.current = true;    
 
           toast.error("Session expired. Please log in again.");
 
@@ -48,9 +45,9 @@ export function useSessionMonitor() {
 
           router.push("/auth");
 
-          // Reset flag after a short delay allowing redirect to happen
-          setTimeout(() => {
-            window.__sessionExpired = false;
+          resetTimerRef.current = setTimeout(() => {
+            isSessionExpired.current = false;  
+            resetTimerRef.current = null;
           }, 5000);
         }
       }
@@ -61,6 +58,12 @@ export function useSessionMonitor() {
     return () => {
       window.fetch = originalFetch;
       isIntercepting.current = false;
+      isSessionExpired.current = false;        //  always reset on unmount
+
+      if (resetTimerRef.current) {             //  cancel pending timer on unmount
+        clearTimeout(resetTimerRef.current);
+        resetTimerRef.current = null;
+      }
     };
   }, [signOut, router]);
 }


### PR DESCRIPTION
## Description
window.__sessionExpired was set to true when a 401 was detected, and reset to false after a 5-second setTimeout. But the cleanup function never reset the flag on unmount. If the component unmounted before the timer fired (fast redirect, test teardown, navigation), window.__sessionExpired stayed true permanently , silently swallowing every future 401 in the same tab session.

Fixes #3169 

## Type of change
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:
- [ x] My code follows the style guidelines of this project
- [ x] My changes generate no new warnings
- [ x] I have performed a self-review of my own code
