### PR TITLE
fix: add rate limiting to POST /api/complaints to prevent spam and DoS

### DIFF
--- a/app/api/complaints/route.js
+++ b/app/api/complaints/route.js
@@ -1,10 +1,12 @@
+
 import { connectDb } from "@/lib/mongodb";
 import { requireAuth } from "@/lib/rbac";
 import { parseJSON, withErrorHandler } from "@/lib/error-handler";
 import { AppError, ValidationError } from "@/lib/errors";
-import { jsonSuccess } from "@/lib/api-response";
+import { jsonSuccess, fail } from "@/lib/api-response"; //  added fail import
 import { createComplaintSchema } from "@/lib/validations/complaints";
 import { validateRequest } from "@/lib/validations/validateRequest";
+import { checkRateLimit } from "@/lib/rateLimit"; //  added import
 
 export const dynamic = "force-dynamic";
 
@@ -12,6 +14,19 @@ const MAX_COMPLAINT_PAYLOAD_BYTES = 1024 * 10;
 
 export const POST = withErrorHandler(async (req) => {
   const decodedToken = await requireAuth(req);
+
+  //  Rate limit by both IP and userId to prevent spam from authenticated users
+  const ip = req.headers.get("x-forwarded-for") || "127.0.0.1";
+  const rateLimitResult = await checkRateLimit(
+    `complaints_post_${ip}_${decodedToken.uid}`
+  );
+  if (!rateLimitResult.allowed) {
+    return fail(
+      429,
+      "TOO_MANY_REQUESTS",
+      "Too many complaint submissions. Please wait before submitting again."
+    );
+  }
 
   const validationResult = await validateRequest(
     req,


### PR DESCRIPTION
## Description
Added checkRateLimit() using a composite key of complaints_post, consistent with the pattern used across the rest of the API. Rate limiting is applied after authentication (so the uid is available for the key) and before validation and the DB write , matching the order used in other routes.

Fixes #3171 

## Type of change
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:
- [ x] My code follows the style guidelines of this project
- [ x] My changes generate no new warnings
- [ x] I have performed a self-review of my own code
