### PR TITLE
fix(ui): reset scroll-dependent components on route change

### DIFF
--- a/components/Navbar.js
+++ b/components/Navbar.js
@@ -137,8 +137,10 @@ export function Navbar() {
   useEffect(() => {
     const onScroll = () => setScrolled(window.scrollY > 20);
     window.addEventListener("scroll", onScroll, { passive: true });
+    // Initial check on mount or route change
+    onScroll();
     return () => window.removeEventListener("scroll", onScroll);
-  }, []);
+  }, [pathname]);
 
   const handleClickOutside = useCallback((e) => {
     if (dropdownRef.current && !dropdownRef.current.contains(e.target)) {

--- a/components/ui/BackToTop.jsx
+++ b/components/ui/BackToTop.jsx
@@ -2,6 +2,7 @@
 
 import React, { useState, useEffect } from "react";
 import { ChevronUp } from "lucide-react";
+import { usePathname } from "next/navigation";
 
 /**
  * BackToTop Component
@@ -10,6 +11,7 @@ import { ChevronUp } from "lucide-react";
  */
 export default function BackToTop() {
   const [isVisible, setIsVisible] = useState(false);
+  const pathname = usePathname();
 
   useEffect(() => {
     const handleScroll = () => {
@@ -20,13 +22,13 @@ export default function BackToTop() {
     // Attach event listener using passive option for scroll performance
     window.addEventListener("scroll", handleScroll, { passive: true });
 
-    // Initial check in case page mounts pre-scrolled
+    // Initial check and reset visibility on mount or route change
     handleScroll();
 
     return () => {
       window.removeEventListener("scroll", handleScroll);
     };
-  }, []);
+  }, [pathname]);
 
   const scrollToTop = () => {
     window.scrollTo({

--- a/components/ui/ScrollProgress.jsx
+++ b/components/ui/ScrollProgress.jsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React, { useEffect, useRef } from "react";
+import { usePathname } from "next/navigation";
 
 /**
  * ScrollProgress Component
@@ -9,6 +10,7 @@ import React, { useEffect, useRef } from "react";
  */
 export default function ScrollProgress() {
   const progressRef = useRef(null);
+  const pathname = usePathname();
 
   useEffect(() => {
     let ticking = false;
@@ -44,12 +46,14 @@ export default function ScrollProgress() {
       passive: true,
     });
 
+    // Reset scroll and progress on mount or route change
+    window.scrollTo(0, 0);
     updateProgress();
 
     return () => {
       window.removeEventListener("scroll", handleScroll);
     };
-  }, []);
+  }, [pathname]);
 
   return (
     <div

--- a/components/ui/ScrollToTop.jsx
+++ b/components/ui/ScrollToTop.jsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from "react";
+import { usePathname } from "next/navigation";
 import Tooltip from "./Tooltip";
 
 /**
@@ -11,6 +12,7 @@ import Tooltip from "./Tooltip";
 const ScrollToTop = () => {
   const [showScrollTop, setShowScrollTop] = useState(false);
   const [showScrollBottom, setShowScrollBottom] = useState(false);
+  const pathname = usePathname();
 
   useEffect(() => {
     const toggleVisibility = () => {
@@ -26,13 +28,13 @@ const ScrollToTop = () => {
     };
 
     window.addEventListener("scroll", toggleVisibility, { passive: true });
-    // Run once on mount to set initial state
+    // Run once on mount or route change to set initial state
     toggleVisibility();
 
     return () => {
       window.removeEventListener("scroll", toggleVisibility);
     };
-  }, []);
+  }, [pathname]);
 
   const scrollToTop = () => {
     window.scrollTo({ top: 0, behavior: "smooth" });


### PR DESCRIPTION
### Description
   2     This PR fixes the bug where the `ScrollProgress` and other scroll-dependent components (BackToTop, ScrollToTop, and Navbar) failed to reset their state during client-side navigation
     in Next.js.
   3
   4     ### Changes
   5     - Integrated `usePathname` from `next/navigation` into `ScrollProgress`, `BackToTop`, `ScrollToTop`, and `Navbar`.
   6     - Added `pathname` as a dependency to the `useEffect` hooks in these components to ensure visibility and progress are recalculated on every route change.
   7     - Added explicit `window.scrollTo(0, 0)` in the `ScrollProgress` component to ensure a reliable initial state when navigating to new pages.
   8
   9     Closes #3185

