### PR TITLE
fix: resolve ChatBot ReferenceError and action handler overwrite

### DIFF
--- a/components/ChatBot.js
+++ b/components/ChatBot.js
@@ -715,6 +715,7 @@ export default function LearnovaChatbot() {
         if (!user) {
           botText = "[**Please sign in**](/auth) to use the AI chatbot.";
         } else {
+          idToken = await user.getIdToken();
           // 🛠️ STEP 2 INTERCEPT: Check text signature against local action handlers first!
           const actionResponse = await parseUserIntent(text, {
             instituteId: userProfile?.instituteId,
@@ -726,7 +727,6 @@ export default function LearnovaChatbot() {
             botText = `🤖 **Action Handler Initiated Successfully**\n\n\`\`\`json\n${JSON.stringify(parsedResult, null, 2)}\n\`\`\``;
           } else {
             // No local action regex matched. Fall through safely to normal processing pipeline
-            const idToken = await user.getIdToken();
             botText = await generateBotResponse(
               text,
               currentCategory,

--- a/components/ChatBot.js
+++ b/components/ChatBot.js
@@ -286,7 +286,8 @@ async function generateBotResponse(
   userMessage,
   currentCategory,
   idToken,
-  updatedMessages = []
+  updatedMessages = [],
+  user = null
 ) {
   const lower = userMessage.toLowerCase();
 
@@ -730,14 +731,10 @@ export default function LearnovaChatbot() {
               text,
               currentCategory,
               idToken,
-              [...messages, userMsg]
+              [...messages, userMsg],
+              user
             );
           }
-          idToken = await user.getIdToken();
-          botText = await generateBotResponse(text, currentCategory, idToken, [
-            ...messages,
-            userMsg,
-          ]);
         }
       } catch {
         botText = `I apologize for the technical difficulty. Our team is here to help:\n\n📧 **Email:** ${CONTACT_INFO.email}\n📞 **Phone:** ${CONTACT_INFO.phone}\n🎯 **Live Demo:** ${CONTACT_INFO.demo}`;


### PR DESCRIPTION
## Summary

Fixes a critical bug in the AI chatbot client-side component where referencing the out-of-scope `user` variable causes a `ReferenceError` and blocks all backend AI calls, forcing a fall-through to static fallback messages. Also removes duplicate/redundant API invocations that bypassed the local intent action routing.

## Problem

1. **ReferenceError (out-of-scope)**:
   In `components/ChatBot.js`, the helper `generateBotResponse` tries to access `user.uid`, `user.role`, etc. from the `user` object to construct the request context. However, `user` is only defined inside the `LearnovaChatbot` functional component and is not passed to `generateBotResponse`. This throws a `ReferenceError: user is not defined`, which is caught in the `catch` block on line 391, making it fall back to hardcoded text response for 100% of custom inputs.

2. **Action Handler Overwrite**:
   When checking the action registry with `parseUserIntent`, the code sets `botText` with the action response. However, right after the `if/else` block, `generateBotResponse` is invoked unconditionally, overwriting `botText` and completely bypassing the action registry trigger.

## Changes

- Updated signature of `generateBotResponse` to accept `user` as an optional parameter.
- Passed `user` from the `LearnovaChatbot` handler to `generateBotResponse`.
- Removed duplicate/redundant call to `generateBotResponse` which overwrote the local action intent router result.

## Verification

- Ran local tests in `components/__tests__/groqRoute.test.js` to ensure correct route handling.

Closes #3194