### PR TITLE
fix: resolve React hydration mismatch warnings caused by dynamic defaultTheme in next-themes

### DIFF
--- a/components/ThemeProvider.js
+++ b/components/ThemeProvider.js
@@ -3,28 +3,12 @@
 import { ThemeProvider as NextThemesProvider } from "next-themes";
 
 export function ThemeProvider({ children }) {
-  // Choose initial default: dark unless user explicitly stored 'light'
-  const initialTheme = (() => {
-    if (typeof window === "undefined") return "dark";
-    try {
-      const saved = localStorage.getItem("theme");
-      if (saved === "light") return "light";
-      if (saved === "dark") return "dark";
-      // If no saved preference, prefer system light only if explicitly light
-      const prefersLight =
-        typeof window.matchMedia === "function" &&
-        window.matchMedia("(prefers-color-scheme: light)").matches;
-      return prefersLight ? "light" : "dark";
-    } catch (e) {
-      return "dark";
-    }
-  })();
-
   return (
     <NextThemesProvider
       attribute="class"
-      defaultTheme={initialTheme}
+      defaultTheme="dark"
       enableSystem={true}
+      disableTransitionOnChange
     >
       {children}
     </NextThemesProvider>


### PR DESCRIPTION
## Description
This PR resolves React hydration mismatch warnings appearing in the console caused by the `next-themes` implementation. The `ThemeProvider` component was previously using an anti-pattern by dynamically computing the initial theme via `localStorage` and `window.matchMedia` within the render cycle. Since `window` is undefined on the server, the server rendered the "dark" theme, causing a mismatch if the client hydrated with "light". 

The fix removes this dynamic calculation, delegating theme management completely to `next-themes`, utilizing `defaultTheme="dark"`, `enableSystem={true}`, and `disableTransitionOnChange`. This correctly injects the theme script early and prevents React hydration discrepancies.

Fixes #3199

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] My changes generate no new warnings
- [x] I have performed a self-review of my own code