### PR TITLE
fix: add localized error boundaries to nested routes to prevent full-page crashes

### DIFF
--- a/app/StudyAI/error.js
+++ b/app/StudyAI/error.js
@@ -1,0 +1,33 @@
+"use client";
+
+import { useEffect } from "react";
+import { AlertTriangle, RefreshCw } from "lucide-react";
+
+export default function Error({ error, reset }) {
+  useEffect(() => {
+    console.error("Route error:", error);
+  }, [error]);
+
+  return (
+    <div className="flex flex-col items-center justify-center w-full min-h-[60vh] p-8 text-center">
+      <div className="bg-card/40 dark:bg-black/40 backdrop-blur-xl rounded-3xl border border-border dark:border-white/10 p-10 max-w-lg w-full shadow-2xl flex flex-col items-center">
+        <div className="w-20 h-20 bg-red-500/10 dark:bg-red-500/20 rounded-full flex items-center justify-center mb-6 border border-red-500/20">
+          <AlertTriangle className="w-10 h-10 text-red-500" />
+        </div>
+        <h2 className="text-2xl font-bold text-foreground dark:text-white mb-3">
+          Something went wrong!
+        </h2>
+        <p className="text-muted-foreground dark:text-gray-400 mb-8 leading-relaxed">
+          We encountered an unexpected error while rendering this section. Our system has logged the issue.
+        </p>
+        <button
+          onClick={() => reset()}
+          className="flex items-center gap-2 px-6 py-3 bg-gradient-to-r from-purple-600 to-blue-600 hover:from-purple-700 hover:to-blue-700 text-white rounded-xl font-medium transition-all duration-300 hover:scale-105 active:scale-95 shadow-lg shadow-purple-500/25"
+        >
+          <RefreshCw className="w-4 h-4" />
+          Try Again
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/app/about/error.js
+++ b/app/about/error.js
@@ -1,0 +1,33 @@
+"use client";
+
+import { useEffect } from "react";
+import { AlertTriangle, RefreshCw } from "lucide-react";
+
+export default function Error({ error, reset }) {
+  useEffect(() => {
+    console.error("Route error:", error);
+  }, [error]);
+
+  return (
+    <div className="flex flex-col items-center justify-center w-full min-h-[60vh] p-8 text-center">
+      <div className="bg-card/40 dark:bg-black/40 backdrop-blur-xl rounded-3xl border border-border dark:border-white/10 p-10 max-w-lg w-full shadow-2xl flex flex-col items-center">
+        <div className="w-20 h-20 bg-red-500/10 dark:bg-red-500/20 rounded-full flex items-center justify-center mb-6 border border-red-500/20">
+          <AlertTriangle className="w-10 h-10 text-red-500" />
+        </div>
+        <h2 className="text-2xl font-bold text-foreground dark:text-white mb-3">
+          Something went wrong!
+        </h2>
+        <p className="text-muted-foreground dark:text-gray-400 mb-8 leading-relaxed">
+          We encountered an unexpected error while rendering this section. Our system has logged the issue.
+        </p>
+        <button
+          onClick={() => reset()}
+          className="flex items-center gap-2 px-6 py-3 bg-gradient-to-r from-purple-600 to-blue-600 hover:from-purple-700 hover:to-blue-700 text-white rounded-xl font-medium transition-all duration-300 hover:scale-105 active:scale-95 shadow-lg shadow-purple-500/25"
+        >
+          <RefreshCw className="w-4 h-4" />
+          Try Again
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/app/activity/[id]/error.js
+++ b/app/activity/[id]/error.js
@@ -1,0 +1,33 @@
+"use client";
+
+import { useEffect } from "react";
+import { AlertTriangle, RefreshCw } from "lucide-react";
+
+export default function Error({ error, reset }) {
+  useEffect(() => {
+    console.error("Route error:", error);
+  }, [error]);
+
+  return (
+    <div className="flex flex-col items-center justify-center w-full min-h-[60vh] p-8 text-center">
+      <div className="bg-card/40 dark:bg-black/40 backdrop-blur-xl rounded-3xl border border-border dark:border-white/10 p-10 max-w-lg w-full shadow-2xl flex flex-col items-center">
+        <div className="w-20 h-20 bg-red-500/10 dark:bg-red-500/20 rounded-full flex items-center justify-center mb-6 border border-red-500/20">
+          <AlertTriangle className="w-10 h-10 text-red-500" />
+        </div>
+        <h2 className="text-2xl font-bold text-foreground dark:text-white mb-3">
+          Something went wrong!
+        </h2>
+        <p className="text-muted-foreground dark:text-gray-400 mb-8 leading-relaxed">
+          We encountered an unexpected error while rendering this section. Our system has logged the issue.
+        </p>
+        <button
+          onClick={() => reset()}
+          className="flex items-center gap-2 px-6 py-3 bg-gradient-to-r from-purple-600 to-blue-600 hover:from-purple-700 hover:to-blue-700 text-white rounded-xl font-medium transition-all duration-300 hover:scale-105 active:scale-95 shadow-lg shadow-purple-500/25"
+        >
+          <RefreshCw className="w-4 h-4" />
+          Try Again
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/app/admin/dashboard/error.js
+++ b/app/admin/dashboard/error.js
@@ -1,0 +1,33 @@
+"use client";
+
+import { useEffect } from "react";
+import { AlertTriangle, RefreshCw } from "lucide-react";
+
+export default function Error({ error, reset }) {
+  useEffect(() => {
+    console.error("Route error:", error);
+  }, [error]);
+
+  return (
+    <div className="flex flex-col items-center justify-center w-full min-h-[60vh] p-8 text-center">
+      <div className="bg-card/40 dark:bg-black/40 backdrop-blur-xl rounded-3xl border border-border dark:border-white/10 p-10 max-w-lg w-full shadow-2xl flex flex-col items-center">
+        <div className="w-20 h-20 bg-red-500/10 dark:bg-red-500/20 rounded-full flex items-center justify-center mb-6 border border-red-500/20">
+          <AlertTriangle className="w-10 h-10 text-red-500" />
+        </div>
+        <h2 className="text-2xl font-bold text-foreground dark:text-white mb-3">
+          Something went wrong!
+        </h2>
+        <p className="text-muted-foreground dark:text-gray-400 mb-8 leading-relaxed">
+          We encountered an unexpected error while rendering this section. Our system has logged the issue.
+        </p>
+        <button
+          onClick={() => reset()}
+          className="flex items-center gap-2 px-6 py-3 bg-gradient-to-r from-purple-600 to-blue-600 hover:from-purple-700 hover:to-blue-700 text-white rounded-xl font-medium transition-all duration-300 hover:scale-105 active:scale-95 shadow-lg shadow-purple-500/25"
+        >
+          <RefreshCw className="w-4 h-4" />
+          Try Again
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/app/attendance/error.js
+++ b/app/attendance/error.js
@@ -1,0 +1,33 @@
+"use client";
+
+import { useEffect } from "react";
+import { AlertTriangle, RefreshCw } from "lucide-react";
+
+export default function Error({ error, reset }) {
+  useEffect(() => {
+    console.error("Route error:", error);
+  }, [error]);
+
+  return (
+    <div className="flex flex-col items-center justify-center w-full min-h-[60vh] p-8 text-center">
+      <div className="bg-card/40 dark:bg-black/40 backdrop-blur-xl rounded-3xl border border-border dark:border-white/10 p-10 max-w-lg w-full shadow-2xl flex flex-col items-center">
+        <div className="w-20 h-20 bg-red-500/10 dark:bg-red-500/20 rounded-full flex items-center justify-center mb-6 border border-red-500/20">
+          <AlertTriangle className="w-10 h-10 text-red-500" />
+        </div>
+        <h2 className="text-2xl font-bold text-foreground dark:text-white mb-3">
+          Something went wrong!
+        </h2>
+        <p className="text-muted-foreground dark:text-gray-400 mb-8 leading-relaxed">
+          We encountered an unexpected error while rendering this section. Our system has logged the issue.
+        </p>
+        <button
+          onClick={() => reset()}
+          className="flex items-center gap-2 px-6 py-3 bg-gradient-to-r from-purple-600 to-blue-600 hover:from-purple-700 hover:to-blue-700 text-white rounded-xl font-medium transition-all duration-300 hover:scale-105 active:scale-95 shadow-lg shadow-purple-500/25"
+        >
+          <RefreshCw className="w-4 h-4" />
+          Try Again
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/app/auth/error.js
+++ b/app/auth/error.js
@@ -1,0 +1,33 @@
+"use client";
+
+import { useEffect } from "react";
+import { AlertTriangle, RefreshCw } from "lucide-react";
+
+export default function Error({ error, reset }) {
+  useEffect(() => {
+    console.error("Route error:", error);
+  }, [error]);
+
+  return (
+    <div className="flex flex-col items-center justify-center w-full min-h-[60vh] p-8 text-center">
+      <div className="bg-card/40 dark:bg-black/40 backdrop-blur-xl rounded-3xl border border-border dark:border-white/10 p-10 max-w-lg w-full shadow-2xl flex flex-col items-center">
+        <div className="w-20 h-20 bg-red-500/10 dark:bg-red-500/20 rounded-full flex items-center justify-center mb-6 border border-red-500/20">
+          <AlertTriangle className="w-10 h-10 text-red-500" />
+        </div>
+        <h2 className="text-2xl font-bold text-foreground dark:text-white mb-3">
+          Something went wrong!
+        </h2>
+        <p className="text-muted-foreground dark:text-gray-400 mb-8 leading-relaxed">
+          We encountered an unexpected error while rendering this section. Our system has logged the issue.
+        </p>
+        <button
+          onClick={() => reset()}
+          className="flex items-center gap-2 px-6 py-3 bg-gradient-to-r from-purple-600 to-blue-600 hover:from-purple-700 hover:to-blue-700 text-white rounded-xl font-medium transition-all duration-300 hover:scale-105 active:scale-95 shadow-lg shadow-purple-500/25"
+        >
+          <RefreshCw className="w-4 h-4" />
+          Try Again
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/app/case-studies/[slug]/error.js
+++ b/app/case-studies/[slug]/error.js
@@ -1,0 +1,33 @@
+"use client";
+
+import { useEffect } from "react";
+import { AlertTriangle, RefreshCw } from "lucide-react";
+
+export default function Error({ error, reset }) {
+  useEffect(() => {
+    console.error("Route error:", error);
+  }, [error]);
+
+  return (
+    <div className="flex flex-col items-center justify-center w-full min-h-[60vh] p-8 text-center">
+      <div className="bg-card/40 dark:bg-black/40 backdrop-blur-xl rounded-3xl border border-border dark:border-white/10 p-10 max-w-lg w-full shadow-2xl flex flex-col items-center">
+        <div className="w-20 h-20 bg-red-500/10 dark:bg-red-500/20 rounded-full flex items-center justify-center mb-6 border border-red-500/20">
+          <AlertTriangle className="w-10 h-10 text-red-500" />
+        </div>
+        <h2 className="text-2xl font-bold text-foreground dark:text-white mb-3">
+          Something went wrong!
+        </h2>
+        <p className="text-muted-foreground dark:text-gray-400 mb-8 leading-relaxed">
+          We encountered an unexpected error while rendering this section. Our system has logged the issue.
+        </p>
+        <button
+          onClick={() => reset()}
+          className="flex items-center gap-2 px-6 py-3 bg-gradient-to-r from-purple-600 to-blue-600 hover:from-purple-700 hover:to-blue-700 text-white rounded-xl font-medium transition-all duration-300 hover:scale-105 active:scale-95 shadow-lg shadow-purple-500/25"
+        >
+          <RefreshCw className="w-4 h-4" />
+          Try Again
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/app/complaints/error.js
+++ b/app/complaints/error.js
@@ -1,0 +1,33 @@
+"use client";
+
+import { useEffect } from "react";
+import { AlertTriangle, RefreshCw } from "lucide-react";
+
+export default function Error({ error, reset }) {
+  useEffect(() => {
+    console.error("Route error:", error);
+  }, [error]);
+
+  return (
+    <div className="flex flex-col items-center justify-center w-full min-h-[60vh] p-8 text-center">
+      <div className="bg-card/40 dark:bg-black/40 backdrop-blur-xl rounded-3xl border border-border dark:border-white/10 p-10 max-w-lg w-full shadow-2xl flex flex-col items-center">
+        <div className="w-20 h-20 bg-red-500/10 dark:bg-red-500/20 rounded-full flex items-center justify-center mb-6 border border-red-500/20">
+          <AlertTriangle className="w-10 h-10 text-red-500" />
+        </div>
+        <h2 className="text-2xl font-bold text-foreground dark:text-white mb-3">
+          Something went wrong!
+        </h2>
+        <p className="text-muted-foreground dark:text-gray-400 mb-8 leading-relaxed">
+          We encountered an unexpected error while rendering this section. Our system has logged the issue.
+        </p>
+        <button
+          onClick={() => reset()}
+          className="flex items-center gap-2 px-6 py-3 bg-gradient-to-r from-purple-600 to-blue-600 hover:from-purple-700 hover:to-blue-700 text-white rounded-xl font-medium transition-all duration-300 hover:scale-105 active:scale-95 shadow-lg shadow-purple-500/25"
+        >
+          <RefreshCw className="w-4 h-4" />
+          Try Again
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/app/contact/error.js
+++ b/app/contact/error.js
@@ -1,0 +1,33 @@
+"use client";
+
+import { useEffect } from "react";
+import { AlertTriangle, RefreshCw } from "lucide-react";
+
+export default function Error({ error, reset }) {
+  useEffect(() => {
+    console.error("Route error:", error);
+  }, [error]);
+
+  return (
+    <div className="flex flex-col items-center justify-center w-full min-h-[60vh] p-8 text-center">
+      <div className="bg-card/40 dark:bg-black/40 backdrop-blur-xl rounded-3xl border border-border dark:border-white/10 p-10 max-w-lg w-full shadow-2xl flex flex-col items-center">
+        <div className="w-20 h-20 bg-red-500/10 dark:bg-red-500/20 rounded-full flex items-center justify-center mb-6 border border-red-500/20">
+          <AlertTriangle className="w-10 h-10 text-red-500" />
+        </div>
+        <h2 className="text-2xl font-bold text-foreground dark:text-white mb-3">
+          Something went wrong!
+        </h2>
+        <p className="text-muted-foreground dark:text-gray-400 mb-8 leading-relaxed">
+          We encountered an unexpected error while rendering this section. Our system has logged the issue.
+        </p>
+        <button
+          onClick={() => reset()}
+          className="flex items-center gap-2 px-6 py-3 bg-gradient-to-r from-purple-600 to-blue-600 hover:from-purple-700 hover:to-blue-700 text-white rounded-xl font-medium transition-all duration-300 hover:scale-105 active:scale-95 shadow-lg shadow-purple-500/25"
+        >
+          <RefreshCw className="w-4 h-4" />
+          Try Again
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/app/contributors/error.js
+++ b/app/contributors/error.js
@@ -1,0 +1,33 @@
+"use client";
+
+import { useEffect } from "react";
+import { AlertTriangle, RefreshCw } from "lucide-react";
+
+export default function Error({ error, reset }) {
+  useEffect(() => {
+    console.error("Route error:", error);
+  }, [error]);
+
+  return (
+    <div className="flex flex-col items-center justify-center w-full min-h-[60vh] p-8 text-center">
+      <div className="bg-card/40 dark:bg-black/40 backdrop-blur-xl rounded-3xl border border-border dark:border-white/10 p-10 max-w-lg w-full shadow-2xl flex flex-col items-center">
+        <div className="w-20 h-20 bg-red-500/10 dark:bg-red-500/20 rounded-full flex items-center justify-center mb-6 border border-red-500/20">
+          <AlertTriangle className="w-10 h-10 text-red-500" />
+        </div>
+        <h2 className="text-2xl font-bold text-foreground dark:text-white mb-3">
+          Something went wrong!
+        </h2>
+        <p className="text-muted-foreground dark:text-gray-400 mb-8 leading-relaxed">
+          We encountered an unexpected error while rendering this section. Our system has logged the issue.
+        </p>
+        <button
+          onClick={() => reset()}
+          className="flex items-center gap-2 px-6 py-3 bg-gradient-to-r from-purple-600 to-blue-600 hover:from-purple-700 hover:to-blue-700 text-white rounded-xl font-medium transition-all duration-300 hover:scale-105 active:scale-95 shadow-lg shadow-purple-500/25"
+        >
+          <RefreshCw className="w-4 h-4" />
+          Try Again
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/app/courses/[id]/error.js
+++ b/app/courses/[id]/error.js
@@ -1,0 +1,33 @@
+"use client";
+
+import { useEffect } from "react";
+import { AlertTriangle, RefreshCw } from "lucide-react";
+
+export default function Error({ error, reset }) {
+  useEffect(() => {
+    console.error("Route error:", error);
+  }, [error]);
+
+  return (
+    <div className="flex flex-col items-center justify-center w-full min-h-[60vh] p-8 text-center">
+      <div className="bg-card/40 dark:bg-black/40 backdrop-blur-xl rounded-3xl border border-border dark:border-white/10 p-10 max-w-lg w-full shadow-2xl flex flex-col items-center">
+        <div className="w-20 h-20 bg-red-500/10 dark:bg-red-500/20 rounded-full flex items-center justify-center mb-6 border border-red-500/20">
+          <AlertTriangle className="w-10 h-10 text-red-500" />
+        </div>
+        <h2 className="text-2xl font-bold text-foreground dark:text-white mb-3">
+          Something went wrong!
+        </h2>
+        <p className="text-muted-foreground dark:text-gray-400 mb-8 leading-relaxed">
+          We encountered an unexpected error while rendering this section. Our system has logged the issue.
+        </p>
+        <button
+          onClick={() => reset()}
+          className="flex items-center gap-2 px-6 py-3 bg-gradient-to-r from-purple-600 to-blue-600 hover:from-purple-700 hover:to-blue-700 text-white rounded-xl font-medium transition-all duration-300 hover:scale-105 active:scale-95 shadow-lg shadow-purple-500/25"
+        >
+          <RefreshCw className="w-4 h-4" />
+          Try Again
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/app/courses/error.js
+++ b/app/courses/error.js
@@ -1,0 +1,33 @@
+"use client";
+
+import { useEffect } from "react";
+import { AlertTriangle, RefreshCw } from "lucide-react";
+
+export default function Error({ error, reset }) {
+  useEffect(() => {
+    console.error("Route error:", error);
+  }, [error]);
+
+  return (
+    <div className="flex flex-col items-center justify-center w-full min-h-[60vh] p-8 text-center">
+      <div className="bg-card/40 dark:bg-black/40 backdrop-blur-xl rounded-3xl border border-border dark:border-white/10 p-10 max-w-lg w-full shadow-2xl flex flex-col items-center">
+        <div className="w-20 h-20 bg-red-500/10 dark:bg-red-500/20 rounded-full flex items-center justify-center mb-6 border border-red-500/20">
+          <AlertTriangle className="w-10 h-10 text-red-500" />
+        </div>
+        <h2 className="text-2xl font-bold text-foreground dark:text-white mb-3">
+          Something went wrong!
+        </h2>
+        <p className="text-muted-foreground dark:text-gray-400 mb-8 leading-relaxed">
+          We encountered an unexpected error while rendering this section. Our system has logged the issue.
+        </p>
+        <button
+          onClick={() => reset()}
+          className="flex items-center gap-2 px-6 py-3 bg-gradient-to-r from-purple-600 to-blue-600 hover:from-purple-700 hover:to-blue-700 text-white rounded-xl font-medium transition-all duration-300 hover:scale-105 active:scale-95 shadow-lg shadow-purple-500/25"
+        >
+          <RefreshCw className="w-4 h-4" />
+          Try Again
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/app/institute/dashboard/error.js
+++ b/app/institute/dashboard/error.js
@@ -1,0 +1,33 @@
+"use client";
+
+import { useEffect } from "react";
+import { AlertTriangle, RefreshCw } from "lucide-react";
+
+export default function Error({ error, reset }) {
+  useEffect(() => {
+    console.error("Route error:", error);
+  }, [error]);
+
+  return (
+    <div className="flex flex-col items-center justify-center w-full min-h-[60vh] p-8 text-center">
+      <div className="bg-card/40 dark:bg-black/40 backdrop-blur-xl rounded-3xl border border-border dark:border-white/10 p-10 max-w-lg w-full shadow-2xl flex flex-col items-center">
+        <div className="w-20 h-20 bg-red-500/10 dark:bg-red-500/20 rounded-full flex items-center justify-center mb-6 border border-red-500/20">
+          <AlertTriangle className="w-10 h-10 text-red-500" />
+        </div>
+        <h2 className="text-2xl font-bold text-foreground dark:text-white mb-3">
+          Something went wrong!
+        </h2>
+        <p className="text-muted-foreground dark:text-gray-400 mb-8 leading-relaxed">
+          We encountered an unexpected error while rendering this section. Our system has logged the issue.
+        </p>
+        <button
+          onClick={() => reset()}
+          className="flex items-center gap-2 px-6 py-3 bg-gradient-to-r from-purple-600 to-blue-600 hover:from-purple-700 hover:to-blue-700 text-white rounded-xl font-medium transition-all duration-300 hover:scale-105 active:scale-95 shadow-lg shadow-purple-500/25"
+        >
+          <RefreshCw className="w-4 h-4" />
+          Try Again
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/app/leaderboards/error.js
+++ b/app/leaderboards/error.js
@@ -1,0 +1,33 @@
+"use client";
+
+import { useEffect } from "react";
+import { AlertTriangle, RefreshCw } from "lucide-react";
+
+export default function Error({ error, reset }) {
+  useEffect(() => {
+    console.error("Route error:", error);
+  }, [error]);
+
+  return (
+    <div className="flex flex-col items-center justify-center w-full min-h-[60vh] p-8 text-center">
+      <div className="bg-card/40 dark:bg-black/40 backdrop-blur-xl rounded-3xl border border-border dark:border-white/10 p-10 max-w-lg w-full shadow-2xl flex flex-col items-center">
+        <div className="w-20 h-20 bg-red-500/10 dark:bg-red-500/20 rounded-full flex items-center justify-center mb-6 border border-red-500/20">
+          <AlertTriangle className="w-10 h-10 text-red-500" />
+        </div>
+        <h2 className="text-2xl font-bold text-foreground dark:text-white mb-3">
+          Something went wrong!
+        </h2>
+        <p className="text-muted-foreground dark:text-gray-400 mb-8 leading-relaxed">
+          We encountered an unexpected error while rendering this section. Our system has logged the issue.
+        </p>
+        <button
+          onClick={() => reset()}
+          className="flex items-center gap-2 px-6 py-3 bg-gradient-to-r from-purple-600 to-blue-600 hover:from-purple-700 hover:to-blue-700 text-white rounded-xl font-medium transition-all duration-300 hover:scale-105 active:scale-95 shadow-lg shadow-purple-500/25"
+        >
+          <RefreshCw className="w-4 h-4" />
+          Try Again
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/app/metrics/attendance/error.js
+++ b/app/metrics/attendance/error.js
@@ -1,0 +1,33 @@
+"use client";
+
+import { useEffect } from "react";
+import { AlertTriangle, RefreshCw } from "lucide-react";
+
+export default function Error({ error, reset }) {
+  useEffect(() => {
+    console.error("Route error:", error);
+  }, [error]);
+
+  return (
+    <div className="flex flex-col items-center justify-center w-full min-h-[60vh] p-8 text-center">
+      <div className="bg-card/40 dark:bg-black/40 backdrop-blur-xl rounded-3xl border border-border dark:border-white/10 p-10 max-w-lg w-full shadow-2xl flex flex-col items-center">
+        <div className="w-20 h-20 bg-red-500/10 dark:bg-red-500/20 rounded-full flex items-center justify-center mb-6 border border-red-500/20">
+          <AlertTriangle className="w-10 h-10 text-red-500" />
+        </div>
+        <h2 className="text-2xl font-bold text-foreground dark:text-white mb-3">
+          Something went wrong!
+        </h2>
+        <p className="text-muted-foreground dark:text-gray-400 mb-8 leading-relaxed">
+          We encountered an unexpected error while rendering this section. Our system has logged the issue.
+        </p>
+        <button
+          onClick={() => reset()}
+          className="flex items-center gap-2 px-6 py-3 bg-gradient-to-r from-purple-600 to-blue-600 hover:from-purple-700 hover:to-blue-700 text-white rounded-xl font-medium transition-all duration-300 hover:scale-105 active:scale-95 shadow-lg shadow-purple-500/25"
+        >
+          <RefreshCw className="w-4 h-4" />
+          Try Again
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/app/metrics/efficiency/error.js
+++ b/app/metrics/efficiency/error.js
@@ -1,0 +1,33 @@
+"use client";
+
+import { useEffect } from "react";
+import { AlertTriangle, RefreshCw } from "lucide-react";
+
+export default function Error({ error, reset }) {
+  useEffect(() => {
+    console.error("Route error:", error);
+  }, [error]);
+
+  return (
+    <div className="flex flex-col items-center justify-center w-full min-h-[60vh] p-8 text-center">
+      <div className="bg-card/40 dark:bg-black/40 backdrop-blur-xl rounded-3xl border border-border dark:border-white/10 p-10 max-w-lg w-full shadow-2xl flex flex-col items-center">
+        <div className="w-20 h-20 bg-red-500/10 dark:bg-red-500/20 rounded-full flex items-center justify-center mb-6 border border-red-500/20">
+          <AlertTriangle className="w-10 h-10 text-red-500" />
+        </div>
+        <h2 className="text-2xl font-bold text-foreground dark:text-white mb-3">
+          Something went wrong!
+        </h2>
+        <p className="text-muted-foreground dark:text-gray-400 mb-8 leading-relaxed">
+          We encountered an unexpected error while rendering this section. Our system has logged the issue.
+        </p>
+        <button
+          onClick={() => reset()}
+          className="flex items-center gap-2 px-6 py-3 bg-gradient-to-r from-purple-600 to-blue-600 hover:from-purple-700 hover:to-blue-700 text-white rounded-xl font-medium transition-all duration-300 hover:scale-105 active:scale-95 shadow-lg shadow-purple-500/25"
+        >
+          <RefreshCw className="w-4 h-4" />
+          Try Again
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/app/mission/error.js
+++ b/app/mission/error.js
@@ -1,0 +1,33 @@
+"use client";
+
+import { useEffect } from "react";
+import { AlertTriangle, RefreshCw } from "lucide-react";
+
+export default function Error({ error, reset }) {
+  useEffect(() => {
+    console.error("Route error:", error);
+  }, [error]);
+
+  return (
+    <div className="flex flex-col items-center justify-center w-full min-h-[60vh] p-8 text-center">
+      <div className="bg-card/40 dark:bg-black/40 backdrop-blur-xl rounded-3xl border border-border dark:border-white/10 p-10 max-w-lg w-full shadow-2xl flex flex-col items-center">
+        <div className="w-20 h-20 bg-red-500/10 dark:bg-red-500/20 rounded-full flex items-center justify-center mb-6 border border-red-500/20">
+          <AlertTriangle className="w-10 h-10 text-red-500" />
+        </div>
+        <h2 className="text-2xl font-bold text-foreground dark:text-white mb-3">
+          Something went wrong!
+        </h2>
+        <p className="text-muted-foreground dark:text-gray-400 mb-8 leading-relaxed">
+          We encountered an unexpected error while rendering this section. Our system has logged the issue.
+        </p>
+        <button
+          onClick={() => reset()}
+          className="flex items-center gap-2 px-6 py-3 bg-gradient-to-r from-purple-600 to-blue-600 hover:from-purple-700 hover:to-blue-700 text-white rounded-xl font-medium transition-all duration-300 hover:scale-105 active:scale-95 shadow-lg shadow-purple-500/25"
+        >
+          <RefreshCw className="w-4 h-4" />
+          Try Again
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/app/notices/[id]/error.js
+++ b/app/notices/[id]/error.js
@@ -1,0 +1,33 @@
+"use client";
+
+import { useEffect } from "react";
+import { AlertTriangle, RefreshCw } from "lucide-react";
+
+export default function Error({ error, reset }) {
+  useEffect(() => {
+    console.error("Route error:", error);
+  }, [error]);
+
+  return (
+    <div className="flex flex-col items-center justify-center w-full min-h-[60vh] p-8 text-center">
+      <div className="bg-card/40 dark:bg-black/40 backdrop-blur-xl rounded-3xl border border-border dark:border-white/10 p-10 max-w-lg w-full shadow-2xl flex flex-col items-center">
+        <div className="w-20 h-20 bg-red-500/10 dark:bg-red-500/20 rounded-full flex items-center justify-center mb-6 border border-red-500/20">
+          <AlertTriangle className="w-10 h-10 text-red-500" />
+        </div>
+        <h2 className="text-2xl font-bold text-foreground dark:text-white mb-3">
+          Something went wrong!
+        </h2>
+        <p className="text-muted-foreground dark:text-gray-400 mb-8 leading-relaxed">
+          We encountered an unexpected error while rendering this section. Our system has logged the issue.
+        </p>
+        <button
+          onClick={() => reset()}
+          className="flex items-center gap-2 px-6 py-3 bg-gradient-to-r from-purple-600 to-blue-600 hover:from-purple-700 hover:to-blue-700 text-white rounded-xl font-medium transition-all duration-300 hover:scale-105 active:scale-95 shadow-lg shadow-purple-500/25"
+        >
+          <RefreshCw className="w-4 h-4" />
+          Try Again
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/app/notices/error.js
+++ b/app/notices/error.js
@@ -1,0 +1,33 @@
+"use client";
+
+import { useEffect } from "react";
+import { AlertTriangle, RefreshCw } from "lucide-react";
+
+export default function Error({ error, reset }) {
+  useEffect(() => {
+    console.error("Route error:", error);
+  }, [error]);
+
+  return (
+    <div className="flex flex-col items-center justify-center w-full min-h-[60vh] p-8 text-center">
+      <div className="bg-card/40 dark:bg-black/40 backdrop-blur-xl rounded-3xl border border-border dark:border-white/10 p-10 max-w-lg w-full shadow-2xl flex flex-col items-center">
+        <div className="w-20 h-20 bg-red-500/10 dark:bg-red-500/20 rounded-full flex items-center justify-center mb-6 border border-red-500/20">
+          <AlertTriangle className="w-10 h-10 text-red-500" />
+        </div>
+        <h2 className="text-2xl font-bold text-foreground dark:text-white mb-3">
+          Something went wrong!
+        </h2>
+        <p className="text-muted-foreground dark:text-gray-400 mb-8 leading-relaxed">
+          We encountered an unexpected error while rendering this section. Our system has logged the issue.
+        </p>
+        <button
+          onClick={() => reset()}
+          className="flex items-center gap-2 px-6 py-3 bg-gradient-to-r from-purple-600 to-blue-600 hover:from-purple-700 hover:to-blue-700 text-white rounded-xl font-medium transition-all duration-300 hover:scale-105 active:scale-95 shadow-lg shadow-purple-500/25"
+        >
+          <RefreshCw className="w-4 h-4" />
+          Try Again
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/app/offline/error.js
+++ b/app/offline/error.js
@@ -1,0 +1,33 @@
+"use client";
+
+import { useEffect } from "react";
+import { AlertTriangle, RefreshCw } from "lucide-react";
+
+export default function Error({ error, reset }) {
+  useEffect(() => {
+    console.error("Route error:", error);
+  }, [error]);
+
+  return (
+    <div className="flex flex-col items-center justify-center w-full min-h-[60vh] p-8 text-center">
+      <div className="bg-card/40 dark:bg-black/40 backdrop-blur-xl rounded-3xl border border-border dark:border-white/10 p-10 max-w-lg w-full shadow-2xl flex flex-col items-center">
+        <div className="w-20 h-20 bg-red-500/10 dark:bg-red-500/20 rounded-full flex items-center justify-center mb-6 border border-red-500/20">
+          <AlertTriangle className="w-10 h-10 text-red-500" />
+        </div>
+        <h2 className="text-2xl font-bold text-foreground dark:text-white mb-3">
+          Something went wrong!
+        </h2>
+        <p className="text-muted-foreground dark:text-gray-400 mb-8 leading-relaxed">
+          We encountered an unexpected error while rendering this section. Our system has logged the issue.
+        </p>
+        <button
+          onClick={() => reset()}
+          className="flex items-center gap-2 px-6 py-3 bg-gradient-to-r from-purple-600 to-blue-600 hover:from-purple-700 hover:to-blue-700 text-white rounded-xl font-medium transition-all duration-300 hover:scale-105 active:scale-95 shadow-lg shadow-purple-500/25"
+        >
+          <RefreshCw className="w-4 h-4" />
+          Try Again
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/app/parent/dashboard/error.js
+++ b/app/parent/dashboard/error.js
@@ -1,0 +1,33 @@
+"use client";
+
+import { useEffect } from "react";
+import { AlertTriangle, RefreshCw } from "lucide-react";
+
+export default function Error({ error, reset }) {
+  useEffect(() => {
+    console.error("Route error:", error);
+  }, [error]);
+
+  return (
+    <div className="flex flex-col items-center justify-center w-full min-h-[60vh] p-8 text-center">
+      <div className="bg-card/40 dark:bg-black/40 backdrop-blur-xl rounded-3xl border border-border dark:border-white/10 p-10 max-w-lg w-full shadow-2xl flex flex-col items-center">
+        <div className="w-20 h-20 bg-red-500/10 dark:bg-red-500/20 rounded-full flex items-center justify-center mb-6 border border-red-500/20">
+          <AlertTriangle className="w-10 h-10 text-red-500" />
+        </div>
+        <h2 className="text-2xl font-bold text-foreground dark:text-white mb-3">
+          Something went wrong!
+        </h2>
+        <p className="text-muted-foreground dark:text-gray-400 mb-8 leading-relaxed">
+          We encountered an unexpected error while rendering this section. Our system has logged the issue.
+        </p>
+        <button
+          onClick={() => reset()}
+          className="flex items-center gap-2 px-6 py-3 bg-gradient-to-r from-purple-600 to-blue-600 hover:from-purple-700 hover:to-blue-700 text-white rounded-xl font-medium transition-all duration-300 hover:scale-105 active:scale-95 shadow-lg shadow-purple-500/25"
+        >
+          <RefreshCw className="w-4 h-4" />
+          Try Again
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/app/productivity/error.js
+++ b/app/productivity/error.js
@@ -1,0 +1,33 @@
+"use client";
+
+import { useEffect } from "react";
+import { AlertTriangle, RefreshCw } from "lucide-react";
+
+export default function Error({ error, reset }) {
+  useEffect(() => {
+    console.error("Route error:", error);
+  }, [error]);
+
+  return (
+    <div className="flex flex-col items-center justify-center w-full min-h-[60vh] p-8 text-center">
+      <div className="bg-card/40 dark:bg-black/40 backdrop-blur-xl rounded-3xl border border-border dark:border-white/10 p-10 max-w-lg w-full shadow-2xl flex flex-col items-center">
+        <div className="w-20 h-20 bg-red-500/10 dark:bg-red-500/20 rounded-full flex items-center justify-center mb-6 border border-red-500/20">
+          <AlertTriangle className="w-10 h-10 text-red-500" />
+        </div>
+        <h2 className="text-2xl font-bold text-foreground dark:text-white mb-3">
+          Something went wrong!
+        </h2>
+        <p className="text-muted-foreground dark:text-gray-400 mb-8 leading-relaxed">
+          We encountered an unexpected error while rendering this section. Our system has logged the issue.
+        </p>
+        <button
+          onClick={() => reset()}
+          className="flex items-center gap-2 px-6 py-3 bg-gradient-to-r from-purple-600 to-blue-600 hover:from-purple-700 hover:to-blue-700 text-white rounded-xl font-medium transition-all duration-300 hover:scale-105 active:scale-95 shadow-lg shadow-purple-500/25"
+        >
+          <RefreshCw className="w-4 h-4" />
+          Try Again
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/app/profile/error.js
+++ b/app/profile/error.js
@@ -1,0 +1,33 @@
+"use client";
+
+import { useEffect } from "react";
+import { AlertTriangle, RefreshCw } from "lucide-react";
+
+export default function Error({ error, reset }) {
+  useEffect(() => {
+    console.error("Route error:", error);
+  }, [error]);
+
+  return (
+    <div className="flex flex-col items-center justify-center w-full min-h-[60vh] p-8 text-center">
+      <div className="bg-card/40 dark:bg-black/40 backdrop-blur-xl rounded-3xl border border-border dark:border-white/10 p-10 max-w-lg w-full shadow-2xl flex flex-col items-center">
+        <div className="w-20 h-20 bg-red-500/10 dark:bg-red-500/20 rounded-full flex items-center justify-center mb-6 border border-red-500/20">
+          <AlertTriangle className="w-10 h-10 text-red-500" />
+        </div>
+        <h2 className="text-2xl font-bold text-foreground dark:text-white mb-3">
+          Something went wrong!
+        </h2>
+        <p className="text-muted-foreground dark:text-gray-400 mb-8 leading-relaxed">
+          We encountered an unexpected error while rendering this section. Our system has logged the issue.
+        </p>
+        <button
+          onClick={() => reset()}
+          className="flex items-center gap-2 px-6 py-3 bg-gradient-to-r from-purple-600 to-blue-600 hover:from-purple-700 hover:to-blue-700 text-white rounded-xl font-medium transition-all duration-300 hover:scale-105 active:scale-95 shadow-lg shadow-purple-500/25"
+        >
+          <RefreshCw className="w-4 h-4" />
+          Try Again
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/app/register/error.js
+++ b/app/register/error.js
@@ -1,0 +1,33 @@
+"use client";
+
+import { useEffect } from "react";
+import { AlertTriangle, RefreshCw } from "lucide-react";
+
+export default function Error({ error, reset }) {
+  useEffect(() => {
+    console.error("Route error:", error);
+  }, [error]);
+
+  return (
+    <div className="flex flex-col items-center justify-center w-full min-h-[60vh] p-8 text-center">
+      <div className="bg-card/40 dark:bg-black/40 backdrop-blur-xl rounded-3xl border border-border dark:border-white/10 p-10 max-w-lg w-full shadow-2xl flex flex-col items-center">
+        <div className="w-20 h-20 bg-red-500/10 dark:bg-red-500/20 rounded-full flex items-center justify-center mb-6 border border-red-500/20">
+          <AlertTriangle className="w-10 h-10 text-red-500" />
+        </div>
+        <h2 className="text-2xl font-bold text-foreground dark:text-white mb-3">
+          Something went wrong!
+        </h2>
+        <p className="text-muted-foreground dark:text-gray-400 mb-8 leading-relaxed">
+          We encountered an unexpected error while rendering this section. Our system has logged the issue.
+        </p>
+        <button
+          onClick={() => reset()}
+          className="flex items-center gap-2 px-6 py-3 bg-gradient-to-r from-purple-600 to-blue-600 hover:from-purple-700 hover:to-blue-700 text-white rounded-xl font-medium transition-all duration-300 hover:scale-105 active:scale-95 shadow-lg shadow-purple-500/25"
+        >
+          <RefreshCw className="w-4 h-4" />
+          Try Again
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/app/settings/error.js
+++ b/app/settings/error.js
@@ -1,0 +1,33 @@
+"use client";
+
+import { useEffect } from "react";
+import { AlertTriangle, RefreshCw } from "lucide-react";
+
+export default function Error({ error, reset }) {
+  useEffect(() => {
+    console.error("Route error:", error);
+  }, [error]);
+
+  return (
+    <div className="flex flex-col items-center justify-center w-full min-h-[60vh] p-8 text-center">
+      <div className="bg-card/40 dark:bg-black/40 backdrop-blur-xl rounded-3xl border border-border dark:border-white/10 p-10 max-w-lg w-full shadow-2xl flex flex-col items-center">
+        <div className="w-20 h-20 bg-red-500/10 dark:bg-red-500/20 rounded-full flex items-center justify-center mb-6 border border-red-500/20">
+          <AlertTriangle className="w-10 h-10 text-red-500" />
+        </div>
+        <h2 className="text-2xl font-bold text-foreground dark:text-white mb-3">
+          Something went wrong!
+        </h2>
+        <p className="text-muted-foreground dark:text-gray-400 mb-8 leading-relaxed">
+          We encountered an unexpected error while rendering this section. Our system has logged the issue.
+        </p>
+        <button
+          onClick={() => reset()}
+          className="flex items-center gap-2 px-6 py-3 bg-gradient-to-r from-purple-600 to-blue-600 hover:from-purple-700 hover:to-blue-700 text-white rounded-xl font-medium transition-all duration-300 hover:scale-105 active:scale-95 shadow-lg shadow-purple-500/25"
+        >
+          <RefreshCw className="w-4 h-4" />
+          Try Again
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/app/streaks/error.js
+++ b/app/streaks/error.js
@@ -1,0 +1,33 @@
+"use client";
+
+import { useEffect } from "react";
+import { AlertTriangle, RefreshCw } from "lucide-react";
+
+export default function Error({ error, reset }) {
+  useEffect(() => {
+    console.error("Route error:", error);
+  }, [error]);
+
+  return (
+    <div className="flex flex-col items-center justify-center w-full min-h-[60vh] p-8 text-center">
+      <div className="bg-card/40 dark:bg-black/40 backdrop-blur-xl rounded-3xl border border-border dark:border-white/10 p-10 max-w-lg w-full shadow-2xl flex flex-col items-center">
+        <div className="w-20 h-20 bg-red-500/10 dark:bg-red-500/20 rounded-full flex items-center justify-center mb-6 border border-red-500/20">
+          <AlertTriangle className="w-10 h-10 text-red-500" />
+        </div>
+        <h2 className="text-2xl font-bold text-foreground dark:text-white mb-3">
+          Something went wrong!
+        </h2>
+        <p className="text-muted-foreground dark:text-gray-400 mb-8 leading-relaxed">
+          We encountered an unexpected error while rendering this section. Our system has logged the issue.
+        </p>
+        <button
+          onClick={() => reset()}
+          className="flex items-center gap-2 px-6 py-3 bg-gradient-to-r from-purple-600 to-blue-600 hover:from-purple-700 hover:to-blue-700 text-white rounded-xl font-medium transition-all duration-300 hover:scale-105 active:scale-95 shadow-lg shadow-purple-500/25"
+        >
+          <RefreshCw className="w-4 h-4" />
+          Try Again
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/app/student/dashboard/error.js
+++ b/app/student/dashboard/error.js
@@ -1,0 +1,33 @@
+"use client";
+
+import { useEffect } from "react";
+import { AlertTriangle, RefreshCw } from "lucide-react";
+
+export default function Error({ error, reset }) {
+  useEffect(() => {
+    console.error("Route error:", error);
+  }, [error]);
+
+  return (
+    <div className="flex flex-col items-center justify-center w-full min-h-[60vh] p-8 text-center">
+      <div className="bg-card/40 dark:bg-black/40 backdrop-blur-xl rounded-3xl border border-border dark:border-white/10 p-10 max-w-lg w-full shadow-2xl flex flex-col items-center">
+        <div className="w-20 h-20 bg-red-500/10 dark:bg-red-500/20 rounded-full flex items-center justify-center mb-6 border border-red-500/20">
+          <AlertTriangle className="w-10 h-10 text-red-500" />
+        </div>
+        <h2 className="text-2xl font-bold text-foreground dark:text-white mb-3">
+          Something went wrong!
+        </h2>
+        <p className="text-muted-foreground dark:text-gray-400 mb-8 leading-relaxed">
+          We encountered an unexpected error while rendering this section. Our system has logged the issue.
+        </p>
+        <button
+          onClick={() => reset()}
+          className="flex items-center gap-2 px-6 py-3 bg-gradient-to-r from-purple-600 to-blue-600 hover:from-purple-700 hover:to-blue-700 text-white rounded-xl font-medium transition-all duration-300 hover:scale-105 active:scale-95 shadow-lg shadow-purple-500/25"
+        >
+          <RefreshCw className="w-4 h-4" />
+          Try Again
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/app/teacher/dashboard/error.js
+++ b/app/teacher/dashboard/error.js
@@ -1,0 +1,33 @@
+"use client";
+
+import { useEffect } from "react";
+import { AlertTriangle, RefreshCw } from "lucide-react";
+
+export default function Error({ error, reset }) {
+  useEffect(() => {
+    console.error("Route error:", error);
+  }, [error]);
+
+  return (
+    <div className="flex flex-col items-center justify-center w-full min-h-[60vh] p-8 text-center">
+      <div className="bg-card/40 dark:bg-black/40 backdrop-blur-xl rounded-3xl border border-border dark:border-white/10 p-10 max-w-lg w-full shadow-2xl flex flex-col items-center">
+        <div className="w-20 h-20 bg-red-500/10 dark:bg-red-500/20 rounded-full flex items-center justify-center mb-6 border border-red-500/20">
+          <AlertTriangle className="w-10 h-10 text-red-500" />
+        </div>
+        <h2 className="text-2xl font-bold text-foreground dark:text-white mb-3">
+          Something went wrong!
+        </h2>
+        <p className="text-muted-foreground dark:text-gray-400 mb-8 leading-relaxed">
+          We encountered an unexpected error while rendering this section. Our system has logged the issue.
+        </p>
+        <button
+          onClick={() => reset()}
+          className="flex items-center gap-2 px-6 py-3 bg-gradient-to-r from-purple-600 to-blue-600 hover:from-purple-700 hover:to-blue-700 text-white rounded-xl font-medium transition-all duration-300 hover:scale-105 active:scale-95 shadow-lg shadow-purple-500/25"
+        >
+          <RefreshCw className="w-4 h-4" />
+          Try Again
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/app/terms/error.js
+++ b/app/terms/error.js
@@ -1,0 +1,33 @@
+"use client";
+
+import { useEffect } from "react";
+import { AlertTriangle, RefreshCw } from "lucide-react";
+
+export default function Error({ error, reset }) {
+  useEffect(() => {
+    console.error("Route error:", error);
+  }, [error]);
+
+  return (
+    <div className="flex flex-col items-center justify-center w-full min-h-[60vh] p-8 text-center">
+      <div className="bg-card/40 dark:bg-black/40 backdrop-blur-xl rounded-3xl border border-border dark:border-white/10 p-10 max-w-lg w-full shadow-2xl flex flex-col items-center">
+        <div className="w-20 h-20 bg-red-500/10 dark:bg-red-500/20 rounded-full flex items-center justify-center mb-6 border border-red-500/20">
+          <AlertTriangle className="w-10 h-10 text-red-500" />
+        </div>
+        <h2 className="text-2xl font-bold text-foreground dark:text-white mb-3">
+          Something went wrong!
+        </h2>
+        <p className="text-muted-foreground dark:text-gray-400 mb-8 leading-relaxed">
+          We encountered an unexpected error while rendering this section. Our system has logged the issue.
+        </p>
+        <button
+          onClick={() => reset()}
+          className="flex items-center gap-2 px-6 py-3 bg-gradient-to-r from-purple-600 to-blue-600 hover:from-purple-700 hover:to-blue-700 text-white rounded-xl font-medium transition-all duration-300 hover:scale-105 active:scale-95 shadow-lg shadow-purple-500/25"
+        >
+          <RefreshCw className="w-4 h-4" />
+          Try Again
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/app/timetable/error.js
+++ b/app/timetable/error.js
@@ -1,0 +1,33 @@
+"use client";
+
+import { useEffect } from "react";
+import { AlertTriangle, RefreshCw } from "lucide-react";
+
+export default function Error({ error, reset }) {
+  useEffect(() => {
+    console.error("Route error:", error);
+  }, [error]);
+
+  return (
+    <div className="flex flex-col items-center justify-center w-full min-h-[60vh] p-8 text-center">
+      <div className="bg-card/40 dark:bg-black/40 backdrop-blur-xl rounded-3xl border border-border dark:border-white/10 p-10 max-w-lg w-full shadow-2xl flex flex-col items-center">
+        <div className="w-20 h-20 bg-red-500/10 dark:bg-red-500/20 rounded-full flex items-center justify-center mb-6 border border-red-500/20">
+          <AlertTriangle className="w-10 h-10 text-red-500" />
+        </div>
+        <h2 className="text-2xl font-bold text-foreground dark:text-white mb-3">
+          Something went wrong!
+        </h2>
+        <p className="text-muted-foreground dark:text-gray-400 mb-8 leading-relaxed">
+          We encountered an unexpected error while rendering this section. Our system has logged the issue.
+        </p>
+        <button
+          onClick={() => reset()}
+          className="flex items-center gap-2 px-6 py-3 bg-gradient-to-r from-purple-600 to-blue-600 hover:from-purple-700 hover:to-blue-700 text-white rounded-xl font-medium transition-all duration-300 hover:scale-105 active:scale-95 shadow-lg shadow-purple-500/25"
+        >
+          <RefreshCw className="w-4 h-4" />
+          Try Again
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/app/values/error.js
+++ b/app/values/error.js
@@ -1,0 +1,33 @@
+"use client";
+
+import { useEffect } from "react";
+import { AlertTriangle, RefreshCw } from "lucide-react";
+
+export default function Error({ error, reset }) {
+  useEffect(() => {
+    console.error("Route error:", error);
+  }, [error]);
+
+  return (
+    <div className="flex flex-col items-center justify-center w-full min-h-[60vh] p-8 text-center">
+      <div className="bg-card/40 dark:bg-black/40 backdrop-blur-xl rounded-3xl border border-border dark:border-white/10 p-10 max-w-lg w-full shadow-2xl flex flex-col items-center">
+        <div className="w-20 h-20 bg-red-500/10 dark:bg-red-500/20 rounded-full flex items-center justify-center mb-6 border border-red-500/20">
+          <AlertTriangle className="w-10 h-10 text-red-500" />
+        </div>
+        <h2 className="text-2xl font-bold text-foreground dark:text-white mb-3">
+          Something went wrong!
+        </h2>
+        <p className="text-muted-foreground dark:text-gray-400 mb-8 leading-relaxed">
+          We encountered an unexpected error while rendering this section. Our system has logged the issue.
+        </p>
+        <button
+          onClick={() => reset()}
+          className="flex items-center gap-2 px-6 py-3 bg-gradient-to-r from-purple-600 to-blue-600 hover:from-purple-700 hover:to-blue-700 text-white rounded-xl font-medium transition-all duration-300 hover:scale-105 active:scale-95 shadow-lg shadow-purple-500/25"
+        >
+          <RefreshCw className="w-4 h-4" />
+          Try Again
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/app/verify/error.js
+++ b/app/verify/error.js
@@ -1,0 +1,33 @@
+"use client";
+
+import { useEffect } from "react";
+import { AlertTriangle, RefreshCw } from "lucide-react";
+
+export default function Error({ error, reset }) {
+  useEffect(() => {
+    console.error("Route error:", error);
+  }, [error]);
+
+  return (
+    <div className="flex flex-col items-center justify-center w-full min-h-[60vh] p-8 text-center">
+      <div className="bg-card/40 dark:bg-black/40 backdrop-blur-xl rounded-3xl border border-border dark:border-white/10 p-10 max-w-lg w-full shadow-2xl flex flex-col items-center">
+        <div className="w-20 h-20 bg-red-500/10 dark:bg-red-500/20 rounded-full flex items-center justify-center mb-6 border border-red-500/20">
+          <AlertTriangle className="w-10 h-10 text-red-500" />
+        </div>
+        <h2 className="text-2xl font-bold text-foreground dark:text-white mb-3">
+          Something went wrong!
+        </h2>
+        <p className="text-muted-foreground dark:text-gray-400 mb-8 leading-relaxed">
+          We encountered an unexpected error while rendering this section. Our system has logged the issue.
+        </p>
+        <button
+          onClick={() => reset()}
+          className="flex items-center gap-2 px-6 py-3 bg-gradient-to-r from-purple-600 to-blue-600 hover:from-purple-700 hover:to-blue-700 text-white rounded-xl font-medium transition-all duration-300 hover:scale-105 active:scale-95 shadow-lg shadow-purple-500/25"
+        >
+          <RefreshCw className="w-4 h-4" />
+          Try Again
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/app/wellness/error.js
+++ b/app/wellness/error.js
@@ -1,0 +1,33 @@
+"use client";
+
+import { useEffect } from "react";
+import { AlertTriangle, RefreshCw } from "lucide-react";
+
+export default function Error({ error, reset }) {
+  useEffect(() => {
+    console.error("Route error:", error);
+  }, [error]);
+
+  return (
+    <div className="flex flex-col items-center justify-center w-full min-h-[60vh] p-8 text-center">
+      <div className="bg-card/40 dark:bg-black/40 backdrop-blur-xl rounded-3xl border border-border dark:border-white/10 p-10 max-w-lg w-full shadow-2xl flex flex-col items-center">
+        <div className="w-20 h-20 bg-red-500/10 dark:bg-red-500/20 rounded-full flex items-center justify-center mb-6 border border-red-500/20">
+          <AlertTriangle className="w-10 h-10 text-red-500" />
+        </div>
+        <h2 className="text-2xl font-bold text-foreground dark:text-white mb-3">
+          Something went wrong!
+        </h2>
+        <p className="text-muted-foreground dark:text-gray-400 mb-8 leading-relaxed">
+          We encountered an unexpected error while rendering this section. Our system has logged the issue.
+        </p>
+        <button
+          onClick={() => reset()}
+          className="flex items-center gap-2 px-6 py-3 bg-gradient-to-r from-purple-600 to-blue-600 hover:from-purple-700 hover:to-blue-700 text-white rounded-xl font-medium transition-all duration-300 hover:scale-105 active:scale-95 shadow-lg shadow-purple-500/25"
+        >
+          <RefreshCw className="w-4 h-4" />
+          Try Again
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/app/~offline/error.js
+++ b/app/~offline/error.js
@@ -1,0 +1,33 @@
+"use client";
+
+import { useEffect } from "react";
+import { AlertTriangle, RefreshCw } from "lucide-react";
+
+export default function Error({ error, reset }) {
+  useEffect(() => {
+    console.error("Route error:", error);
+  }, [error]);
+
+  return (
+    <div className="flex flex-col items-center justify-center w-full min-h-[60vh] p-8 text-center">
+      <div className="bg-card/40 dark:bg-black/40 backdrop-blur-xl rounded-3xl border border-border dark:border-white/10 p-10 max-w-lg w-full shadow-2xl flex flex-col items-center">
+        <div className="w-20 h-20 bg-red-500/10 dark:bg-red-500/20 rounded-full flex items-center justify-center mb-6 border border-red-500/20">
+          <AlertTriangle className="w-10 h-10 text-red-500" />
+        </div>
+        <h2 className="text-2xl font-bold text-foreground dark:text-white mb-3">
+          Something went wrong!
+        </h2>
+        <p className="text-muted-foreground dark:text-gray-400 mb-8 leading-relaxed">
+          We encountered an unexpected error while rendering this section. Our system has logged the issue.
+        </p>
+        <button
+          onClick={() => reset()}
+          className="flex items-center gap-2 px-6 py-3 bg-gradient-to-r from-purple-600 to-blue-600 hover:from-purple-700 hover:to-blue-700 text-white rounded-xl font-medium transition-all duration-300 hover:scale-105 active:scale-95 shadow-lg shadow-purple-500/25"
+        >
+          <RefreshCw className="w-4 h-4" />
+          Try Again
+        </button>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Description
This PR fixes an issue where unexpected errors inside nested routes were bubbling up to the root `error.js` boundary, causing the entire page—including global navigation and sidebars—to crash ungracefully. 

To solve this properly, beautifully styled, localized `error.js` boundaries have been added to 34 nested routes across the `app/` directory (e.g., `/dashboard`, `/auth`, `/courses`, etc.). Now, if a specific nested route or component throws an error, only that segment will display the localized error UI with a recovery mechanism, keeping the rest of the application fully functional.

Fixes #3200

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] My changes generate no new warnings
- [x] I have performed a self-review of my own code