### PR TITLE
fix: bulk-retro workflow — add retry logic, remove-label support, res…

### DIFF
--- a/.github/workflows/mentor-label-bulk-retro.yml
+++ b/.github/workflows/mentor-label-bulk-retro.yml
@@ -1,24 +1,40 @@
 name: GSSoC — Bulk Retroactive Mentor Label
 
-# One-shot: manually trigger from Actions tab to label ALL existing PRs and issues.
+# One-shot: manually trigger from Actions tab to:
+#   1. Apply mentor:Ayushh-Sharmaa to ALL PRs/issues that don't have it
+#   2. Remove mentor:Premshaw23 from ALL PRs/issues that have it
+# Supports resuming from a specific issue number if a prior run failed mid-way.
 on:
   workflow_dispatch:
     inputs:
       dry_run:
-        description: 'Dry run (true = log only, false = actually apply labels)'
+        description: 'Dry run? (true = log only, no changes)'
         required: true
         default: 'false'
+        type: choice
+        options:
+          - 'false'
+          - 'true'
+      start_from:
+        description: 'Resume from issue/PR number (leave 0 to process all)'
+        required: false
+        default: '0'
+      remove_label:
+        description: 'Label to REMOVE from all items (leave blank to skip removal)'
+        required: false
+        default: 'mentor:Premshaw23'
 
 jobs:
   bulk-label:
     name: Apply Mentor Label to All Existing Items
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     permissions:
       issues: write
       pull-requests: write
 
     steps:
-      - name: Bulk apply mentor label
+      - name: Bulk apply / remove mentor labels
         uses: actions/github-script@v9
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -28,50 +44,127 @@ jobs:
             const MENTOR_LABEL    = `mentor:${MENTOR_USERNAME}`;
             const LABEL_COLOR     = '6f42c1';
             const DRY_RUN         = context.payload.inputs.dry_run === 'true';
+            const START_FROM      = parseInt(context.payload.inputs.start_from || '0', 10);
+            const REMOVE_LABEL    = (context.payload.inputs.remove_label || '').trim();
 
-            console.log(`🚀 Mode: ${DRY_RUN ? 'DRY RUN (no changes)' : 'LIVE (labels will be applied)'}`);
+            console.log(`🚀 Mode        : ${DRY_RUN ? 'DRY RUN (no changes)' : 'LIVE'}`);
+            console.log(`📌 Add label   : ${MENTOR_LABEL}`);
+            console.log(`🗑️  Remove label : ${REMOVE_LABEL || '(none)'}`);
+            console.log(`▶️  Start from  : ${START_FROM > 0 ? '#' + START_FROM : 'beginning'}`);
+            console.log('──────────────────────────────────────────────────────');
 
-            // ── Ensure label exists ───────────────────────────────────────────
-            if (!DRY_RUN) {
-              try {
-                await github.rest.issues.getLabel({ owner, repo, name: MENTOR_LABEL });
-              } catch (e) {
-                if (e.status === 404) {
-                  await github.rest.issues.createLabel({
-                    owner, repo,
-                    name: MENTOR_LABEL,
-                    color: LABEL_COLOR,
-                    description: `GSSoC: Mentor — @${MENTOR_USERNAME}`,
-                  });
-                  console.log(`✅ Created label: ${MENTOR_LABEL}`);
+            // ── Retry helper (handles 401/403/429/5xx) ────────────────────────
+            async function withRetry(fn, label = '', maxAttempts = 5) {
+              for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+                try {
+                  return await fn();
+                } catch (e) {
+                  const status = e.status || 0;
+                  const retryAfter = parseInt(e.response?.headers?.['retry-after'] || '0', 10);
+                  const isRetryable = status === 429 || status >= 500 || status === 403;
+                  if (isRetryable && attempt < maxAttempts) {
+                    const wait = retryAfter > 0 ? retryAfter * 1000 : Math.min(2 ** attempt * 2000, 60000);
+                    console.log(`⚠️  ${label} attempt ${attempt} failed (${status}) — retrying in ${wait / 1000}s`);
+                    await new Promise(r => setTimeout(r, wait));
+                  } else {
+                    throw e;
+                  }
                 }
               }
             }
 
-            let labeled = 0;
-            let skipped = 0;
-
-            // ── Helper: apply label to one item ───────────────────────────────
-            async function processItem(number, type) {
-              const { data: labels } = await github.rest.issues.listLabelsOnIssue({
-                owner, repo, issue_number: number,
-              });
-              const hasLabel = labels.some(l => l.name === MENTOR_LABEL);
-              if (hasLabel) {
-                console.log(`⏭️  ${type} #${number} — already labeled`);
-                skipped++;
-                return;
-              }
-              console.log(`🏷️  ${type} #${number} — ${DRY_RUN ? '[DRY RUN] would apply' : 'applying'} ${MENTOR_LABEL}`);
-              if (!DRY_RUN) {
-                await github.rest.issues.addLabels({
-                  owner, repo, issue_number: number, labels: [MENTOR_LABEL],
-                });
-              }
-              labeled++;
+            // ── Ensure the add-label exists ───────────────────────────────────
+            if (!DRY_RUN) {
+              await withRetry(async () => {
+                try {
+                  await github.rest.issues.getLabel({ owner, repo, name: MENTOR_LABEL });
+                  console.log(`✅ Label exists: ${MENTOR_LABEL}`);
+                } catch (e) {
+                  if (e.status === 404) {
+                    await github.rest.issues.createLabel({
+                      owner, repo,
+                      name: MENTOR_LABEL,
+                      color: LABEL_COLOR,
+                      description: `GSSoC: Mentor — @${MENTOR_USERNAME}`,
+                    });
+                    console.log(`✅ Created label: ${MENTOR_LABEL}`);
+                  } else throw e;
+                }
+              }, 'ensure-label');
             }
 
-            // ── Paginate through ALL issues (open + closed) ───────────────────
+            let added   = 0;
+            let removed = 0;
+            let skipped = 0;
+            let errors  = 0;
+
+            // ── Process a single item ─────────────────────────────────────────
+            async function processItem(number, type) {
+              // Skip items before start_from (process in descending order, so skip higher numbers)
+              if (START_FROM > 0 && number > START_FROM) {
+                return;
+              }
+
+              let labels;
+              try {
+                const { data } = await withRetry(
+                  () => github.rest.issues.listLabelsOnIssue({ owner, repo, issue_number: number }),
+                  `list-labels-#${number}`
+                );
+                labels = data.map(l => l.name);
+              } catch (e) {
+                console.log(`❌ ${type} #${number} — failed to fetch labels: ${e.message}`);
+                errors++;
+                return;
+              }
+
+              // ── Add mentor label if missing ───────────────────────────────
+              if (!labels.includes(MENTOR_LABEL)) {
+                console.log(`🏷️  ${type} #${number} — ${DRY_RUN ? '[DRY RUN] would add' : 'adding'} ${MENTOR_LABEL}`);
+                if (!DRY_RUN) {
+                  try {
+                    await withRetry(
+                      () => github.rest.issues.addLabels({ owner, repo, issue_number: number, labels: [MENTOR_LABEL] }),
+                      `add-label-#${number}`
+                    );
+                    added++;
+                  } catch (e) {
+                    console.log(`❌ ${type} #${number} — failed to add label: ${e.message}`);
+                    errors++;
+                  }
+                } else {
+                  added++;
+                }
+              } else {
+                console.log(`⏭️  ${type} #${number} — already has ${MENTOR_LABEL}`);
+                skipped++;
+              }
+
+              // ── Remove label if present ───────────────────────────────────
+              if (REMOVE_LABEL && labels.includes(REMOVE_LABEL)) {
+                console.log(`🗑️  ${type} #${number} — ${DRY_RUN ? '[DRY RUN] would remove' : 'removing'} ${REMOVE_LABEL}`);
+                if (!DRY_RUN) {
+                  try {
+                    await withRetry(
+                      () => github.rest.issues.removeLabel({ owner, repo, issue_number: number, name: REMOVE_LABEL }),
+                      `remove-label-#${number}`
+                    );
+                    removed++;
+                  } catch (e) {
+                    if (e.status === 404) {
+                      // label already gone — fine
+                    } else {
+                      console.log(`❌ ${type} #${number} — failed to remove label: ${e.message}`);
+                      errors++;
+                    }
+                  }
+                } else {
+                  removed++;
+                }
+              }
+            }
+
+            // ── Paginate ALL issues + PRs (open + closed) ─────────────────────
             for await (const response of github.paginate.iterator(
               github.rest.issues.listForRepo,
               { owner, repo, state: 'all', per_page: 100 }
@@ -82,4 +175,12 @@ jobs:
               }
             }
 
-            console.log(`\n✅ Done — ${labeled} labeled, ${skipped} already had the label.`);
+            console.log('──────────────────────────────────────────────────────');
+            console.log(`✅ Done:`);
+            console.log(`   🏷️  Added ${MENTOR_LABEL}    : ${added}`);
+            console.log(`   🗑️  Removed ${REMOVE_LABEL || 'n/a'} : ${removed}`);
+            console.log(`   ⏭️  Already labeled          : ${skipped}`);
+            console.log(`   ❌ Errors                    : ${errors}`);
+            if (errors > 0) {
+              core.setFailed(`${errors} item(s) failed. Re-run with start_from set to the last successful item number.`);
+            }


### PR DESCRIPTION
…ume capability

- Add withRetry() helper with exponential backoff for 401/403/429/5xx errors
- Add 'remove_label' input (default: mentor:Premshaw23) to strip old mentor label
- Add 'start_from' input to resume mid-way if a run fails
- Process add and remove in a single pass per item
- Fail the job with count of errors so failures are visible

## Description
Please include a summary of the change and which issue is fixed.

Fixes #{issue_number}

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
