### PR TITLE
[Critical] Fix isMounted() ReferenceError crash in useAuth hook — closes #3273

### DIFF
--- a/hooks/useAuth.js
+++ b/hooks/useAuth.js
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect, useRef, useCallback } from "react";
+import { useIsMounted } from "@/hooks/useIsMounted";
 import { auth, db } from "@/lib/firebaseConfig";
 import { onAuthStateChanged, signOut as firebaseSignOut } from "firebase/auth";
 import { doc, onSnapshot } from "firebase/firestore";
@@ -124,6 +125,8 @@ export const useAuth = () => {
   const refreshManagerRef = useRef(null);
   const unsubscribeSnapshotRef = useRef(null);
   const firstSnapshotReceivedRef = useRef(false);
+
+  const isMounted = useIsMounted();
 
   const handleSessionExpired = useCallback(() => {
     if (!isMounted()) return;


### PR DESCRIPTION
## Description
Fixes `ReferenceError: isMounted is not defined` crashing the auth flow in `useAuth.js`. The `isMounted()` function was called in 4 places (session expiry handler, auth state listener, signOut error handler) but never imported or defined.

## Related Issue
Closes #3273

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made
- **`hooks/useAuth.js`**: Added `import { useIsMounted } from "@/hooks/useIsMounted"` to imports
- **`hooks/useAuth.js`**: Added `const isMounted = useIsMounted()` initialization inside the `useAuth` hook body (before `handleSessionExpired`)

## Testing
1. Trigger session expiry by exhausting token refresh retries (set `MAX_REFRESH_RETRIES = 1` temporarily)
2. Verify `handleSessionExpired` runs without throwing `ReferenceError`
3. Sign out while offline to trigger the error path in `signOut` — should show error message gracefully
4. Normal auth state changes (login/logout) should work without errors

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
