### PR TITLE
[Critical] Fix undefined state variables causing ReferenceError in StudentDashboard — closes #3274

### DIFF
--- a/components/StudentDashboard.js
+++ b/components/StudentDashboard.js
@@ -234,6 +234,8 @@ const StudentDashboard = () => {
 
   const [viewMode, setViewMode] = useState("heatmap");
   const [showComplaint, setShowComplaint] = useState(false);
+  const [skillPath, setSkillPath] = useState("standard");
+  const [showDiagnosticQuiz, setShowDiagnosticQuiz] = useState(false);
   const lastScheduleTickRef = useRef(getScheduleTickKey(new Date()));
 
   const attendanceStats = useMemo(() => {


### PR DESCRIPTION
## Description
Fixes `ReferenceError` crashes in `StudentDashboard.js` caused by two state variables (`skillPath` and `showDiagnosticQuiz`) being used in event handlers and JSX but never declared with `useState`.

## Related Issue
Closes #3274

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made
- **`components/StudentDashboard.js`**: Added `const [skillPath, setSkillPath] = useState("standard")`
- **`components/StudentDashboard.js`**: Added `const [showDiagnosticQuiz, setShowDiagnosticQuiz] = useState(false)`

## Testing
1. Open StudentDashboard — verify it renders without `ReferenceError` (previously crashed at line 380 reading `showDiagnosticQuiz`)
2. Click "Simulate Advanced Track" / "Booster Track" buttons — verify `handleEvaluateQuiz` sets state without error
3. Verify adaptive layout sections (Fast-Track Projects, Booster Modules) render conditionally based on `skillPath`

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
