### PR TITLE
[Critical] Fix stale closure in useKeyboardShortcuts — missing 4 callback dependencies — closes #3275

### DIFF
--- a/hooks/useKeyboardShortcuts.js
+++ b/hooks/useKeyboardShortcuts.js
@@ -61,7 +61,7 @@ export function useKeyboardShortcuts({
         onEscape?.();
       }
     },
-    [onSearch, onHelp, onEscape]
+    [onSearch, onHelp, onEscape, onTheme, onHome, onLeaderboard, onNotifications]
   );
 
   useEffect(() => {


### PR DESCRIPTION
## Description
Fixes stale closure bug in `useKeyboardShortcuts.js` where `onTheme`, `onHome`, `onLeaderboard`, and `onNotifications` callbacks were referenced inside the `useCallback` body but missing from the dependency array, causing keyboard shortcuts (Ctrl+T/H/L/N) to invoke outdated callback values.

## Related Issue
Closes #3275

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made
- **`hooks/useKeyboardShortcuts.js`**: Updated `useCallback` dependency array from `[onSearch, onHelp, onEscape]` to `[onSearch, onHelp, onEscape, onTheme, onHome, onLeaderboard, onNotifications]`

## Testing
1. Mount a component that passes `useKeyboardShortcuts` with dynamic callbacks
2. Press Ctrl+T (theme), Ctrl+H (home), Ctrl+L (leaderboard), Ctrl+N (notifications)
3. Verify each shortcut invokes the **latest** (not stale) callback
4. Verify existing shortcuts (Ctrl+K, Ctrl+/, Escape) still work correctly

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
