### PR TITLE
Replace pull_request_target with pull_request in contributor-guidelines workflow

### DIFF
--- a/.github/workflows/contributor-guidelines.yml
+++ b/.github/workflows/contributor-guidelines.yml
@@ -3,7 +3,7 @@ name: Contributor Guidelines Reminder
 on:
   issues:
     types: [opened]
-  pull_request_target:
+  pull_request:
     types: [opened]
 
 concurrency:
@@ -95,9 +95,14 @@ jobs:
             message += `Thanks for being a great contributor! 🎉`;
 
             // Post comment
-            await github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: issue_number,
-              body: message
-            });
+            // Wrap in try-catch for fork PRs where the token is read-only
+            try {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue_number,
+                body: message
+              });
+            } catch (commentErr) {
+              console.log('Skipping comment — read-only token (fork PR)');
+            }


### PR DESCRIPTION
## What this fixes

The `.github/workflows/contributor-guidelines.yml` workflow uses the `pull_request_target` trigger event. Unlike `pull_request`, this event runs in the context of the base repository (not the fork), giving the workflow access to a write-capable `GITHUB_TOKEN` with `issues: write` and `pull-requests: write` permissions. If a future contributor modifies this workflow to check out PR code or install dependencies from the fork branch, the base repos secrets would be exposed to the PR author — a documented GitHub Actions supply-chain attack vector.

## Root cause

Line 6 of the workflow specified `pull_request_target` instead of `pull_request`. The `pull_request_target` event intentionally runs in the base repos security context so workflows can access secrets when commenting on fork PRs. However, this workflow does not need to check out code, access secrets, or run any untrusted input. The only operation requiring write access is posting a comment, which works for same-repo PRs under the `pull_request` event and is unnecessary for fork PRs where the contributor guidelines are informational.

## What changed

- **`.github/workflows/contributor-guidelines.yml:6`** — Changed `pull_request_target` to `pull_request`
- **`.github/workflows/contributor-guidelines.yml:97-108`** — Wrapped the `issues.createComment` call in a try-catch so that fork PRs (where the `pull_request` event provides a read-only token) degrade gracefully instead of failing the workflow check

## How to verify

1. Open a new PR from a branch in the same repo (not a fork). The workflow triggers, composes the guidelines message, and posts it as a comment — same as before.
2. Open a new issue. The workflow triggers from the `issues: [opened]` event and posts the guidelines comment — same as before.
3. Open a new PR from a fork. The workflow triggers but the comment step silently skips (read-only token). The check passes instead of failing.

## Edge cases considered

- **Fork PRs** — Comment creation is wrapped in try-catch to prevent a failed check when the read-only token cannot write. The script still computes and logs the guideline data internally.
- **Issues** — Unaffected; the `issues: [opened]` trigger remains and the token always has write access for the base repos issues.
- **Future workflow modifications** — With `pull_request` instead of `pull_request_target`, any future step that tries to check out PR code or run scripts from the fork will receive a read-only token, preventing the most common `pull_request_target` exploitation pattern.

Closes #3265