### PR TITLE
fix: remove duplicate redisClient declaration in middleware

### DIFF
--- a/middleware.js
+++ b/middleware.js
@@ -37,8 +37,6 @@ const CLOCK_TOLERANCE_SECONDS = 60;
 const RATE_LIMIT_WINDOW_MS = 15 * 60 * 1000; // 15 minutes
 const RATE_LIMIT_MAX = 5;
 
-let redisClient;
-
 function getRedis() {
   if (!redisClient) {
     redisClient = new Redis({


### PR DESCRIPTION
Closes #3298 

# Summary
Removes the duplicate global `redisClient` declaration in `middleware.js` that was causing syntax and runtime conflicts in the request pipeline.

# Changes Made
- Deleted the redundant `let redisClient;` line in `middleware.js`.

# Testing
- Tested local middleware execution.
- Verified rate-limiting APIs load successfully without syntax errors.

# Checklist
- [x] Code follows project standards
- [x] Tested locally
- [x] No unrelated changes included
