### PR TITLE
fix: standardize build script in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "license": "MIT",
   "scripts": {
     "dev": "next dev",
-    "build": "node --experimental-global-webcrypto node_modules/next/dist/bin/next build",
+    "build": "next build",
     "start": "next start",
     "test": "vitest run",
     "test:watch": "vitest",


### PR DESCRIPTION
Closes #3297 

# Summary
Simplifies and standardizes the standard Next.js build command in `package.json`.

# Changes Made
- Updated `"build": "node --experimental-global-webcrypto node_modules/next/dist/bin/next build"` to `"build": "next build"`.

# Testing
- Ran `npm run build` locally and verified that the production build completes successfully.

# Checklist
- [x] Code follows project standards
- [x] Tested locally
- [x] No unrelated changes included
