### PR TITLE
Register attendance-warnings cron job in vercel.json

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -3,6 +3,10 @@
     {
       "path": "/api/cron/attendance-risk",
       "schedule": "0 2 * * *"
+    },
+    {
+      "path": "/api/cron/attendance-warnings",
+      "schedule": "30 2 * * *"
     }
   ]
 }


### PR DESCRIPTION
## What this fixes

The `vercel.json` crons array only contains an entry for `/api/cron/attendance-risk` (daily at 2 AM). The sibling route `/api/cron/attendance-warnings` — a 317-line implementation that evaluates student attendance against configurable thresholds, creates warning notifications, and sends emails via EmailJS — has no cron entry and therefore **never executes** on the Vercel scheduler. Students never receive low-attendance warnings despite the full implementation being present in the codebase.

## Root cause

`vercel.json:2-7` defined a single cron entry. The `app/api/cron/attendance-warnings/route.js` file exists and is importable (it can be called manually with a valid `CRON_SECRET` bearer token), but no automated schedule triggers it. The risk-detection pipeline is incomplete: `attendance-risk` computes risk scores, but the corresponding outreach step is missing.

## What changed

- **`vercel.json:7-10`** — Added a new cron entry for `/api/cron/attendance-warnings` scheduled at `30 2 * * *` (daily at 2:30 AM), 30 minutes after the risk assessment cron to avoid resource contention during the same maintenance window

## How to verify

1. Open `vercel.json` and confirm it now contains two cron entries
2. Verify the JSON is valid: `python3 -c "import json; json.load(open('vercel.json'))"`
3. After deployment to Vercel, check the Vercel dashboard under Cron Jobs — both `/api/cron/attendance-risk` and `/api/cron/attendance-warnings` should appear with their respective schedules
4. Wait until 2:30 AM UTC (or trigger manually with a CRON_SECRET bearer token) and confirm the `attendance_warnings` collection in MongoDB is populated

## Edge cases considered

- **Schedule offset** — Set 30 minutes after the risk cron so both jobs do not fire simultaneously and compete for database connections on the same serverless runtime
- **Manual invocation** — The route still requires a valid `CRON_SECRET` bearer token via `authorizeCronRequest`, so unauthorized calls are rejected regardless of the cron registration
- **No risk job dependency** — The two routes are independent; attendance-warnings queries attendance records directly and does not depend on risk scores, so sequential ordering is not required

Closes #3268