### PR TITLE
Fix: Broken Test Suite Pipeline (Jest & ESM Configuration)

### DIFF
--- a/components/__tests__/imagesRoute.test.js
+++ b/components/__tests__/imagesRoute.test.js
@@ -8,6 +8,7 @@ import { checkRateLimit } from "@/lib/rateLimit";
 import {
   extractImageFileFromFormData,
   fetchAndValidateImage,
+  getImageResponseHeaders,
   getUserImageFromDb,
   updateUserImageInDb,
   validateFaceDescriptor,

--- a/vitest.config.mjs
+++ b/vitest.config.mjs
@@ -16,6 +16,10 @@ export default defineConfig({
     environment: "jsdom",
     globals: true,
     setupFiles: ["./tests/setup.js"],
+    deps: {
+      interopDefault: true,
+      inline: ["bson", "mongodb", "undici"],
+    },
     coverage: {
       reporter: ["text", "json", "html"],
       exclude: [
@@ -37,3 +41,4 @@ export default defineConfig({
     },
   },
 });
+


### PR DESCRIPTION
Resolves #3270

**Changes Made**
- `vitest.config.mjs`: Added `deps.inline` for `bson`, `mongodb`, and `undici` to fix the `SyntaxError: Unexpected token 'export'` caused by ESM modules not being transformed correctly.
- `components/__tests__/imagesRoute.test.js`: Added the missing `getImageResponseHeaders` import that was being used in `vi.mock()` but never imported, fixing the `ReferenceError`.

**Impact**
The test suite now runs without ESM parse errors or reference errors out of the box.
