### PR TITLE
Fix empty catch silently swallowing Firebase Auth lookup failure in bulk import

### DIFF
--- a/app/api/institute/bulk-import/route.js
+++ b/app/api/institute/bulk-import/route.js
@@ -82,7 +82,16 @@ export async function POST(req) {
     try {
       getUsersResult = await admin.auth().getUsers(authIdentifiers);
       existingAuthUsers.push(...getUsersResult.users.map((u) => u.email));
-    } catch {}
+    } catch (authLookupErr) {
+      const errMsg = authLookupErr instanceof Error ? authLookupErr.message : String(authLookupErr);
+      console.error(
+        `[bulk-import] Firebase Auth lookup failed for ${authIdentifiers.length} emails: ${errMsg}`
+      );
+      throw new AppError(
+        `Failed to look up existing Auth users. Aborting import to prevent duplicate creation.`,
+        503
+      );
+    }
 
     // Batch phase 2: Create non-existing Firebase Auth users in bulk
     const usersToCreate = students.filter(


### PR DESCRIPTION
## What this fixes

In `app/api/institute/bulk-import/route.js:82-85`, the Firebase Auth bulk lookup at line 83 is wrapped in a bare `try/catch {}` that silently swallows every error. When the Auth API is unreachable, rate-limited, or returns an unexpected response, `getUsersResult` stays `undefined` (never assigned), `existingAuthUsers` remains empty, and the filter at line 88 marks ALL students as to create even if their emails already exist in Auth. The subsequent `createUsers` call then fails with email already exists errors for existing users, producing opaque import failures.

## Root cause

The empty `catch {}` at line 85 discards the error without any logging or abort. The `getUsersResult` variable declared at line 81 is never assigned when the `try` block throws, causing `existingAuthUsers` to remain an empty array. Downstream code in batch phase 2 at line 88-90 filters students based on the empty array and attempts to create Auth users for emails that already exist. The actual database result is inconsistent — the import reports failure counts that are misleading because they blame email conflicts rather than the unreachable Auth API.

## What changed

- **`app/api/institute/bulk-import/route.js:85-94`** — Replaced the empty `catch {}` with an error handler that logs the error message and the count of affected emails via `console.error`, then throws an `AppError` with status 503, aborting the import before it produces an inconsistent result

## How to verify

1. Simulate a Firebase Auth outage by making `admin.auth().getUsers()` throw (e.g., by providing invalid credentials or a malformed auth identifier)
2. Send a bulk import POST request with valid student data
3. Before the fix: the import proceeds, `createUsers` fails with email already exists, and the response contains misleading failure reasons
4. After the fix: the import aborts immediately with status 503 and a clear error message: Failed to look up existing Auth users. Aborting import to prevent duplicate creation.
5. Check server logs for the `[bulk-import] Firebase Auth lookup failed for N emails:` entry with the actual error details

## Edge cases considered

- **Transient Auth API failure** — The import is aborted with 503 rather than silently continuing. The caller can retry with the idempotency key when Auth is available again.
- **Partial results from getUsers** — If `getUsers` resolves but with partial data (e.g., some identifiers not found), that path is unaffected and handled normally by the existing filter logic.
- **Rate-limited Auth API** — The error message and status code indicate to the caller that they should back off and retry rather than blaming individual student records.

Closes #3269