### PR TITLE
fix: revoke Blob object URL after CSV export in exportRiskToCSV to prevent memory leak

### DIFF
--- a/utils/exportToCSV.js
+++ b/utils/exportToCSV.js
@@ -29,4 +29,5 @@ export const exportRiskToCSV = (data) => {
   document.body.appendChild(link);
   link.click();
   document.body.removeChild(link);
+  URL.revokeObjectURL(url); //  Release Blob from memory immediately
 };


### PR DESCRIPTION
Release Blob from memory immediately after download.

## Description

Fixes a memory leak in utils/exportToCSV.js where URL.createObjectURL() was called but URL.revokeObjectURL() was never called after the download was triggered. The same bug was previously fixed in utils/exportUtils.js but this second CSV export utility was missed in that fix.

Fixes #3314 

## Type of Change
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:
- [ x] My code follows the style guidelines of this project
- [ x] I have performed a self-review of my own code
- [ x] I have commented my code, particularly in hard-to-understand areas
- [ x] My changes generate no new warnings
