### PR TITLE
fix: replace require('crypto') with ESM import in lib/quiz-session-manager.js to prevent server-side crash

### DIFF
--- a/lib/quiz-session-manager.js
+++ b/lib/quiz-session-manager.js
@@ -13,18 +13,21 @@
  * Generate a secure random session ID for quiz session.
  * @returns {string} Secure random session ID
  */
+// AFTER (fixed)
+import { randomBytes } from "crypto"; //  top-level ESM import — works on server
+
 export function generateSessionId() {
-  const array = new Uint8Array(32);
-  if (typeof window !== "undefined" && window.crypto) {
-    window.crypto.getRandomValues(array);
-  } else {
-    // Fallback for server-side usage
-    const crypto = require("crypto");
-    return crypto.randomBytes(32).toString("hex");
+  // globalThis.crypto is available in both browser (Web Crypto API)
+  // and Node.js >= 19. For older Node versions, fall back to the
+  // 'crypto' built-in which is always available server-side.
+  if (typeof globalThis.crypto?.getRandomValues === "function") {
+    const array = new Uint8Array(32);
+    globalThis.crypto.getRandomValues(array);
+    return Array.from(array, (byte) => byte.toString(16).padStart(2, "0")).join("");
   }
-  return Array.from(array, (byte) => byte.toString(16).padStart(2, "0")).join(
-    ""
-  );
+
+  // Server-side fallback for Node < 19 using the built-in crypto module 
+  return randomBytes(32).toString("hex");
 }
 
 /**


### PR DESCRIPTION
## Description

Fixes a ReferenceError: require is not defined crash in lib/quiz-session-manager.js.

Fixes #3320 

## Type of Change
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:
- [ x] My code follows the style guidelines of this project
- [ x] I have performed a self-review of my own code
- [ x] I have commented my code, particularly in hard-to-understand areas
- [ x] My changes generate no new warnings
