### PR TITLE
fix(cron): detect EmailJS HTTP failures

### DIFF
--- a/app/api/cron/attendance-warnings/route.js
+++ b/app/api/cron/attendance-warnings/route.js
@@ -66,7 +66,7 @@ async function sendWarningEmails(emailsToSend) {
 
   const sendEmail = async (emailData) => {
     try {
-      await fetch("https://api.emailjs.com/api/v1.0/email/send", {
+      const response = await fetch("https://api.emailjs.com/api/v1.0/email/send", {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
@@ -78,8 +78,26 @@ async function sendWarningEmails(emailsToSend) {
           template_params: emailData,
         }),
       });
+
+      if (!response.ok) {
+        let responseBody = "";
+        try {
+          responseBody = await response.text();
+        } catch {
+          // Ignore body parse failures and log status-based diagnostics.
+        }
+
+        console.error(
+          `[attendance-warnings] EmailJS request failed for ${emailData.to_email} with status ${response.status} ${response.statusText}${
+            responseBody ? `: ${responseBody}` : ""
+          }`
+        );
+      }
     } catch (error) {
-      console.error(`Failed to send email to ${emailData.to_email}:`, error);
+      console.error(
+        `[attendance-warnings] Failed to send email to ${emailData.to_email}:`,
+        error
+      );
     }
   };
 


### PR DESCRIPTION
## Description

Fixes #3323

The attendance warning cron job previously only handled network/runtime exceptions when sending emails through EmailJS.

HTTP error responses such as 401, 429, 500, and 503 were silently treated as successful deliveries because the EmailJS response status was never validated.

### Changes Made

* Capture and validate the EmailJS HTTP response.
* Check `response.ok` before treating a request as successful.
* Log HTTP status and status text for failed requests.
* Log response body when available for easier debugging.
* Preserve existing batch processing behavior using `Promise.allSettled()`.
* Continue processing remaining emails even if individual email deliveries fail.

### Result

EmailJS HTTP failures are now detected and logged instead of being silently ignored.

## Type of Change

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] This change requires a documentation update

## Checklist

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my own code
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] My changes generate no new warnings
