### PR TITLE
fix(auth): correct misleading email verification toast

### DIFF
--- a/app/auth/page.js
+++ b/app/auth/page.js
@@ -99,7 +99,9 @@ function AuthPageContent() {
       }
 
       if (result.needsVerification) {
-        toast.success("Verification email sent! Please check your inbox.");
+        toast.error(
+          "Your email is not verified. Please verify your email to continue."
+        );
         setShowRoleSelection(true);
         router.push("/verify");
       } else if (result.needsProfile) {

--- a/components/NoticeCard.jsx
+++ b/components/NoticeCard.jsx
@@ -199,8 +199,8 @@ const createPdfDownload = (notice) => {
 
   // ── FIX FOR ISSUE #2007: Safe text extraction and fallback ──
   const rawContent = notice.content || notice.text;
-  const safeContent = (typeof rawContent === "string" && rawContent.trim().length > 0) 
-    ? rawContent 
+  const safeContent = (typeof rawContent === "string" && rawContent.trim().length > 0)
+    ? rawContent
     : "No text content provided for this notice.";
   // ────────────────────────────────────────────────────────────
 
@@ -329,23 +329,23 @@ const NoticeCard = ({
   }, [notice]);
 
   const handleCopyLink = useCallback(async () => {
-  const noticeUrl =
-    typeof window !== "undefined"
-      ? `${window.location.origin}/notices/${notice.id}`
-      : "";
+    const noticeUrl =
+      typeof window !== "undefined"
+        ? `${window.location.origin}/notices/${notice.id}`
+        : "";
 
-  try {
-    await navigator.clipboard.writeText(noticeUrl);
+    try {
+      await navigator.clipboard.writeText(noticeUrl);
 
-    setCopyFeedback(true);
+      setCopyFeedback(true);
 
-    setTimeout(() => {
-      setCopyFeedback(false);
-    }, 2000);
-  } catch (err) {
-    console.error("Failed to copy notice link", err);
-  }
-}, [notice]);
+      setTimeout(() => {
+        setCopyFeedback(false);
+      }, 2000);
+    } catch (err) {
+      console.error("Failed to copy notice link", err);
+    }
+  }, [notice]);
 
   const handleShareNotice = useCallback(async () => {
     const noticeUrl =
@@ -444,8 +444,8 @@ const NoticeCard = ({
             whileHover={{ scale: 1.05 }}
             whileTap={{ scale: 0.95 }}
             className={`inline-flex items-center gap-2 rounded-3xl border px-4 py-2 text-sm font-semibold transition active:scale-95 ${isRead
-                ? "border-slate-700 bg-slate-900 text-slate-300 hover:border-slate-500"
-                : "border-indigo-500/40 bg-indigo-500/10 text-indigo-200 hover:bg-indigo-500/20"
+              ? "border-slate-700 bg-slate-900 text-slate-300 hover:border-slate-500"
+              : "border-indigo-500/40 bg-indigo-500/10 text-indigo-200 hover:bg-indigo-500/20"
               }`}
             aria-label={isRead ? "Mark notice unread" : "Mark notice read"}
           >


### PR DESCRIPTION
## Description

This PR fixes a misleading email verification notification shown during the login flow for users with unverified email addresses.

Previously, when an unverified user attempted to log in, the application displayed a success toast stating:

> "Verification email sent! Please check your inbox."

However, no verification email was actually sent during login. The message incorrectly implied successful email delivery and could confuse users.

### Changes Made

* Updated the toast notification shown when an unverified user attempts to log in.
* Replaced the misleading success message with a notification that accurately informs users that email verification is required.
* Preserved the redirect to the `/verify` page, where users can resend a verification email if needed.
* Improved the user experience by ensuring notifications reflect the actual authentication flow.

Fixes #3140

## Type of Change

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] This change requires a documentation update

## Checklist:

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my own code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [x] My changes generate no new warnings
