### PR TITLE
docs: update branch references from main to master in GSSoC contributor guide

### DIFF
--- a/GSSoc_Contributor.md
+++ b/GSSoc_Contributor.md
@@ -141,16 +141,16 @@ Fetch latest updates:
 git fetch upstream
 ```
 
-Switch to main branch:
+Switch to master branch:
 
 ```bash
-git checkout main
+git checkout master
 ```
 
 Merge latest changes:
 
 ```bash
-git merge upstream/main
+git merge upstream/master
 ```
 
 Return to your branch:
@@ -162,7 +162,7 @@ git checkout docs/add-gssoc-guide
 Rebase if necessary:
 
 ```bash
-git rebase main
+git rebase master
 ```
 
 ---
@@ -186,7 +186,7 @@ git push origin docs/add-gssoc-guide
 3. Select:
 
    * Base Repository: Premshaw23/Learnova
-   * Base Branch: main
+   * Base Branch: master
    * Head Repository: your fork
    * Compare Branch: your feature branch
 
@@ -240,9 +240,9 @@ Regularly sync your fork:
 
 ```bash
 git fetch upstream
-git checkout main
-git merge upstream/main
-git push origin main
+git checkout master
+git merge upstream/master
+git push origin master
 ```
 
 ---


### PR DESCRIPTION
## Description

Updated the GSSoC Contributor Guide to replace outdated references to the `main` branch with the repository's actual default branch, `master`.

The synchronization and rebasing commands in the documentation have been corrected to ensure contributors can follow the guide without encountering branch-related errors.

Fixes #3387

## Type of Change

* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [x] This change requires a documentation update

## Checklist:

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my own code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [x] My changes generate no new warnings
