### PR TITLE
fix: add 'use client' directive to interactive components to fix build errors

### DIFF
--- a/components/LearningStreakDashboard.jsx
+++ b/components/LearningStreakDashboard.jsx
@@ -1,3 +1,6 @@
+"use client";
+
+
 import React, { useState } from 'react';
 
 const MOCK_ANALYTICS_DATA = {

--- a/components/SyllabusAnalytics.jsx
+++ b/components/SyllabusAnalytics.jsx
@@ -1,3 +1,5 @@
+"use client";
+
 import React, { useState } from 'react';
 
 const MOCK_SYLLABUS_TRACKS = {


### PR DESCRIPTION
## Description
This pull request fixes a Next.js build error by adding the missing use client directive to both the `LearningStreakDashboard` and `SyllabusAnalytics` components. 

Fixes #3390 

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings