### PR TITLE
feat: add NoticeForm component with audience targeting for notice creation (fixes #2184)

### DIFF
--- a/app/notices/page.js
+++ b/app/notices/page.js
@@ -3,7 +3,7 @@
 import { useEffect } from "react";
 import { useRouter } from "next/navigation";
 import { useAuth } from "@/hooks/useAuth";
-import SmartNoticeBoard from "@/components/NoticeBoard";
+import SmartNoticeBoard from "@/components/SmartNoticeBoard";
 
 const Notice = () => {
   const { user, loading: authLoading } = useAuth();

--- a/components/NoticeForm.jsx
+++ b/components/NoticeForm.jsx
@@ -1,0 +1,292 @@
+"use client";
+
+/**
+ * NoticeForm.jsx
+ * 
+ * Modal form for creating a new notice with audience targeting.
+ * Part of feat #2184 — Notice Board upgrades.
+ */
+
+import { useState, useCallback } from "react";
+import { motion, AnimatePresence } from "framer-motion";
+import { X, Loader2 } from "lucide-react";
+import toast from "react-hot-toast";
+
+const ROLES = ["student", "teacher", "institute", "admin", "staff"];
+const CATEGORIES = ["academic", "administrative", "financial", "general", "technical"];
+const PRIORITIES = ["low", "medium", "high"];
+
+export default function NoticeForm({ onClose, onSuccess }) {
+  const [title, setTitle] = useState("");
+  const [content, setContent] = useState("");
+  const [category, setCategory] = useState("general");
+  const [priority, setPriority] = useState("medium");
+  const [isPinned, setIsPinned] = useState(false);
+  const [tags, setTags] = useState("");
+  const [audienceMode, setAudienceMode] = useState("all");
+  const [selectedRoles, setSelectedRoles] = useState([]);
+  const [submitting, setSubmitting] = useState(false);
+
+  const toggleRole = (role) => {
+    setSelectedRoles((prev) =>
+      prev.includes(role) ? prev.filter((r) => r !== role) : [...prev, role]
+    );
+  };
+
+  const buildTargetAudience = () => {
+    if (audienceMode === "all") return ROLES;
+    return selectedRoles.length > 0 ? selectedRoles : ROLES;
+  };
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+
+    if (!title.trim() || !content.trim()) {
+      toast.error("Title and content are required.");
+      return;
+    }
+
+    if (audienceMode === "roles" && selectedRoles.length === 0) {
+      toast.error("Please select at least one role.");
+      return;
+    }
+
+    setSubmitting(true);
+    try {
+      const tagArray = tags
+        .split(",")
+        .map((t) => t.trim())
+        .filter(Boolean);
+
+      const body = {
+        title: title.trim(),
+        content: content.trim(),
+        category,
+        priority,
+        isPinned,
+        tags: tagArray,
+        targetAudience: buildTargetAudience(),
+      };
+
+      const res = await fetch("/api/notices", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      });
+
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        throw new Error(data?.message || "Failed to publish notice.");
+      }
+
+      toast.success("Notice published! 🎉");
+      onSuccess?.();
+      onClose();
+    } catch (err) {
+      toast.error(err.message || "Something went wrong.");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/60 backdrop-blur-sm">
+      <motion.div
+        initial={{ opacity: 0, scale: 0.95, y: 20 }}
+        animate={{ opacity: 1, scale: 1, y: 0 }}
+        exit={{ opacity: 0, scale: 0.95, y: 20 }}
+        transition={{ duration: 0.25 }}
+        className="relative w-full max-w-2xl max-h-[90vh] overflow-y-auto rounded-3xl border border-slate-700 bg-slate-900 shadow-2xl"
+      >
+        {/* Header */}
+        <div className="sticky top-0 z-10 flex items-center justify-between border-b border-slate-800 bg-slate-900 px-6 py-4">
+          <h2 className="text-xl font-bold text-white">Create Notice</h2>
+          <button
+            onClick={onClose}
+            className="rounded-xl p-2 text-slate-400 transition hover:bg-slate-800 hover:text-white"
+            aria-label="Close"
+          >
+            <X className="h-5 w-5" />
+          </button>
+        </div>
+
+        <form onSubmit={handleSubmit} className="space-y-6 p-6">
+          {/* Title */}
+          <div>
+            <label className="mb-1.5 block text-sm font-semibold text-slate-300">
+              Title <span className="text-red-400">*</span>
+            </label>
+            <input
+              type="text"
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              placeholder="Notice title…"
+              className="w-full rounded-xl border border-slate-700 bg-slate-800 px-4 py-3 text-white placeholder-slate-500 outline-none focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500"
+              required
+            />
+          </div>
+
+          {/* Content */}
+          <div>
+            <label className="mb-1.5 block text-sm font-semibold text-slate-300">
+              Content <span className="text-red-400">*</span>
+            </label>
+            <textarea
+              value={content}
+              onChange={(e) => setContent(e.target.value)}
+              placeholder="Write your notice here…"
+              rows={5}
+              className="w-full rounded-xl border border-slate-700 bg-slate-800 px-4 py-3 text-white placeholder-slate-500 outline-none focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 resize-none"
+              required
+            />
+          </div>
+
+          {/* Category / Priority */}
+          <div className="grid grid-cols-2 gap-4">
+            <div>
+              <label className="mb-1.5 block text-sm font-semibold text-slate-300">
+                Category
+              </label>
+              <select
+                value={category}
+                onChange={(e) => setCategory(e.target.value)}
+                className="w-full rounded-xl border border-slate-700 bg-slate-800 px-4 py-3 text-white outline-none focus:border-indigo-500"
+              >
+                {CATEGORIES.map((c) => (
+                  <option key={c} value={c}>
+                    {c.charAt(0).toUpperCase() + c.slice(1)}
+                  </option>
+                ))}
+              </select>
+            </div>
+            <div>
+              <label className="mb-1.5 block text-sm font-semibold text-slate-300">
+                Priority
+              </label>
+              <select
+                value={priority}
+                onChange={(e) => setPriority(e.target.value)}
+                className="w-full rounded-xl border border-slate-700 bg-slate-800 px-4 py-3 text-white outline-none focus:border-indigo-500"
+              >
+                {PRIORITIES.map((p) => (
+                  <option key={p} value={p}>
+                    {p.charAt(0).toUpperCase() + p.slice(1)}
+                  </option>
+                ))}
+              </select>
+            </div>
+          </div>
+
+          {/* Tags */}
+          <div>
+            <label className="mb-1.5 block text-sm font-semibold text-slate-300">
+              Tags{" "}
+              <span className="text-xs font-normal text-slate-500">
+                (comma separated)
+              </span>
+            </label>
+            <input
+              type="text"
+              value={tags}
+              onChange={(e) => setTags(e.target.value)}
+              placeholder="e.g. exam, fee, holiday"
+              className="w-full rounded-xl border border-slate-700 bg-slate-800 px-4 py-3 text-white placeholder-slate-500 outline-none focus:border-indigo-500"
+            />
+          </div>
+
+          {/* Pin toggle */}
+          <label className="flex cursor-pointer items-center gap-3">
+            <div
+              onClick={() => setIsPinned((p) => !p)}
+              className={`relative h-6 w-11 rounded-full transition-colors ${
+                isPinned ? "bg-indigo-500" : "bg-slate-700"
+              }`}
+            >
+              <span
+                className={`absolute top-0.5 left-0.5 h-5 w-5 rounded-full bg-white shadow transition-transform ${
+                  isPinned ? "translate-x-5" : "translate-x-0"
+                }`}
+              />
+            </div>
+            <span className="text-sm font-medium text-slate-300">
+              Pin this notice
+            </span>
+          </label>
+
+          {/* Audience Targeting */}
+          <div className="rounded-2xl border border-slate-700 bg-slate-800/50 p-4 space-y-3">
+            <p className="text-sm font-semibold text-slate-300">
+              Target Audience
+            </p>
+            <div className="flex gap-3">
+              {["all", "roles"].map((mode) => (
+                <button
+                  key={mode}
+                  type="button"
+                  onClick={() => setAudienceMode(mode)}
+                  className={`rounded-xl px-4 py-2 text-sm font-semibold transition ${
+                    audienceMode === mode
+                      ? "bg-indigo-500 text-white"
+                      : "bg-slate-700 text-slate-300 hover:bg-slate-600"
+                  }`}
+                >
+                  {mode === "all" ? "Everyone" : "By Role"}
+                </button>
+              ))}
+            </div>
+
+            <AnimatePresence>
+              {audienceMode === "roles" && (
+                <motion.div
+                  initial={{ opacity: 0, height: 0 }}
+                  animate={{ opacity: 1, height: "auto" }}
+                  exit={{ opacity: 0, height: 0 }}
+                  className="flex flex-wrap gap-2 overflow-hidden"
+                >
+                  {ROLES.map((role) => (
+                    <button
+                      key={role}
+                      type="button"
+                      onClick={() => toggleRole(role)}
+                      className={`rounded-full px-3 py-1.5 text-xs font-semibold capitalize transition ${
+                        selectedRoles.includes(role)
+                          ? "bg-indigo-500/80 text-white border border-indigo-400"
+                          : "bg-slate-700 text-slate-300 border border-slate-600 hover:bg-slate-600"
+                      }`}
+                    >
+                      {role}
+                    </button>
+                  ))}
+                  {selectedRoles.length === 0 && (
+                    <p className="text-xs text-amber-400 mt-1 w-full">
+                      Select at least one role.
+                    </p>
+                  )}
+                </motion.div>
+              )}
+            </AnimatePresence>
+          </div>
+
+          {/* Submit */}
+          <div className="flex justify-end gap-3 pt-2">
+            <button
+              type="button"
+              onClick={onClose}
+              className="rounded-xl border border-slate-700 bg-slate-800 px-6 py-3 text-sm font-semibold text-slate-300 transition hover:bg-slate-700"
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              disabled={submitting}
+              className="flex items-center gap-2 rounded-xl bg-gradient-to-r from-indigo-500 to-purple-600 px-6 py-3 text-sm font-bold text-white shadow-lg transition hover:from-indigo-600 hover:to-purple-700 disabled:opacity-60"
+            >
+              {submitting && <Loader2 className="h-4 w-4 animate-spin" />}
+              {submitting ? "Publishing…" : "Publish Notice"}
+            </button>
+          </div>
+        </form>
+      </motion.div>
+    </div>
+  );
+}

--- a/components/SmartNoticeBoard.jsx
+++ b/components/SmartNoticeBoard.jsx
@@ -1,0 +1,497 @@
+"use client";
+
+import { useState, useEffect, useMemo, useCallback } from "react";
+import { motion, AnimatePresence } from "framer-motion";
+import toast from "react-hot-toast";
+
+import { useAuth } from "@/hooks/useAuth";
+import { useNotices } from "@/contexts/FirestoreContext";
+import { db } from "@/lib/firebaseConfig";
+import { doc, updateDoc } from "firebase/firestore";
+import { Navbar } from "./Navbar";
+import NoticeSearch from "./NoticeSearch";
+import NoticeFilters from "./NoticeFilters";
+import NoticeCard from "./NoticeCard";
+import EmptyNoticeState from "./EmptyNoticeState";
+import NoticeSkeleton from "./NoticeSkeleton";
+import NoticeForm from "./NoticeForm";
+
+const CATEGORIES = [
+  { id: "all", label: "All Notices" },
+  { id: "academic", label: "Academic" },
+  { id: "administrative", label: "Administrative" },
+  { id: "financial", label: "Financial" },
+  { id: "general", label: "General" },
+  { id: "technical", label: "Technical" },
+];
+
+const SmartNoticeBoard = () => {
+  const { user, userProfile, loading: authLoading } = useAuth();
+
+  // ── Consume the shared pooled subscription from FirestoreContext ──────────
+  // No local onSnapshot — notices arrive from the global singleton listener.
+  const { notices: rawNotices, loading: noticesLoading, error: noticesError } = useNotices();
+
+  // feat #2184: show create form for teachers/admins/staff
+  const [showCreateForm, setShowCreateForm] = useState(false);
+  const canCreateNotice = ["teacher", "admin", "staff"].includes(userProfile?.role);
+
+  const [searchQuery, setSearchQuery] = useState("");
+  const [selectedCategory, setSelectedCategory] = useState("all");
+  const [selectedPriority, setSelectedPriority] = useState("all");
+  const [selectedTags, setSelectedTags] = useState([]);
+  const [dateRange, setDateRange] = useState("all");
+  const [sortOrder, setSortOrder] = useState("newest");
+  const [showOnlyUnread, setShowOnlyUnread] = useState(false);
+  const [currentPage, setCurrentPage] = useState(1);
+
+  const itemsPerPage = 5;
+
+  const [readNotices, setReadNotices] = useState(new Set());
+  const [activeTab, setActiveTab] = useState("notices");
+  const [activity] = useState([]);
+
+  const userId = user?.uid || user?.id || "anonymous";
+
+  // Normalise createdAt to a JS Date so downstream components can safely call
+  // getRelativeTime() regardless of whether it arrived as a Firestore Timestamp
+  // or was already converted by firestorePool's snapshot mapper.
+  const notices = useMemo(
+    () =>
+      rawNotices.map((n) => ({
+        ...n,
+        createdAt:
+          n.createdAt instanceof Date
+            ? n.createdAt
+            : n.createdAt?.toDate
+            ? n.createdAt.toDate()
+            : new Date(n.createdAt || Date.now()),
+      })),
+    [rawNotices]
+  );
+
+  // Derived activity
+  const derivedActivity = useMemo(() => {
+    if (activity?.length > 0) return activity;
+    return (notices || []).slice(0, 5).map((notice, idx) => ({
+      id: notice?.id || idx,
+      title: notice?.title || "Untitled",
+      timestamp: notice?.createdAt || new Date(),
+      user: notice?.author || "System",
+      type: notice?.isPinned ? "pin" : notice?.priority === "high" ? "urgent" : "create",
+    }));
+  }, [activity, notices]);
+
+  const loading = authLoading || noticesLoading;
+
+  // Show toast once if the pool reports an error
+  useEffect(() => {
+    if (noticesError) toast.error("Failed to load notices");
+  }, [noticesError]);
+
+  // Load read notices from user profile or local storage fallback
+  useEffect(() => {
+    if (!userId || userId === "anonymous") return;
+    if (userProfile && Array.isArray(userProfile.readNotices)) {
+      setReadNotices(new Set(userProfile.readNotices));
+    } else {
+      try {
+        const saved = localStorage.getItem(`readNotices_${userId}`);
+        if (saved) {
+          const parsed = JSON.parse(saved);
+          if (Array.isArray(parsed)) setReadNotices(new Set(parsed));
+        }
+      } catch (err) {
+        console.error("Failed to load read notices locally:", err);
+      }
+    }
+  }, [userId, userProfile]);
+
+  // Save read state
+  const saveReadState = useCallback(
+    async (state) => {
+      const stateArray = [...state];
+      try {
+        localStorage.setItem(`readNotices_${userId}`, JSON.stringify(stateArray));
+      } catch (err) {
+        console.error("Failed to save read state locally:", err);
+      }
+      if (user && userId !== "anonymous") {
+        try {
+          const userRef = doc(db, "users", userId);
+          await updateDoc(userRef, { readNotices: stateArray });
+        } catch (err) {
+          console.error("Failed to sync read state to Firestore:", err);
+        }
+      }
+    },
+    [userId, user]
+  );
+
+  const markAsRead = useCallback(
+    (noticeId) => {
+      setReadNotices((current) => {
+        const next = new Set(current);
+        next.add(noticeId);
+        saveReadState(next);
+        return next;
+      });
+    },
+    [saveReadState]
+  );
+
+  const markAsUnread = useCallback(
+    (noticeId) => {
+      setReadNotices((current) => {
+        const next = new Set(current);
+        next.delete(noticeId);
+        saveReadState(next);
+        return next;
+      });
+    },
+    [saveReadState]
+  );
+
+  const getRelativeTime = useCallback((date) => {
+    const now = new Date();
+    const diff = now.getTime() - new Date(date).getTime();
+    const minutes = Math.floor(diff / 60000);
+    if (minutes < 1) return "Just now";
+    if (minutes < 60) return `${minutes}m ago`;
+    const hours = Math.floor(minutes / 60);
+    if (hours < 24) return `${hours}h ago`;
+    const days = Math.floor(hours / 24);
+    if (days < 7) return `${days}d ago`;
+    return new Date(date).toLocaleDateString();
+  }, []);
+
+  const availableTags = useMemo(() => {
+    const tags = notices.flatMap((notice) => notice?.tags || []);
+    return [...new Set(tags)];
+  }, [notices]);
+
+  const searchOptions = useMemo(() => {
+    return notices.map((notice) => notice?.title || "");
+  }, [notices]);
+
+  const activeFilterCount = useMemo(() => {
+    let count = 0;
+    if (selectedCategory !== "all") count++;
+    if (selectedPriority !== "all") count++;
+    if (selectedTags.length > 0) count++;
+    if (dateRange !== "all") count++;
+    if (showOnlyUnread) count++;
+    return count;
+  }, [selectedCategory, selectedPriority, selectedTags, dateRange, showOnlyUnread]);
+
+  useEffect(() => {
+    setCurrentPage(1);
+  }, [searchQuery, selectedCategory, selectedPriority, selectedTags, dateRange, showOnlyUnread, sortOrder]);
+
+  const filteredNotices = useMemo(() => {
+    const queryText = searchQuery.trim().toLowerCase();
+    const now = Date.now();
+
+    return notices
+      .filter((notice) => {
+        const haystack = `
+          ${notice?.title || ""}
+          ${notice?.content || ""}
+          ${notice?.category || ""}
+          ${(notice?.tags || []).join(" ")}
+        `.toLowerCase();
+
+        if (queryText && !haystack.includes(queryText)) return false;
+        if (selectedCategory !== "all" && notice?.category !== selectedCategory) return false;
+        if (selectedPriority !== "all" && notice?.priority !== selectedPriority) return false;
+        if (selectedTags.length > 0 && !selectedTags.every((tag) => notice?.tags?.includes(tag))) return false;
+        if (showOnlyUnread && readNotices.has(notice.id)) return false;
+
+        const noticeTime = new Date(notice?.createdAt).getTime();
+        if (dateRange === "today") return now - noticeTime <= 24 * 60 * 60 * 1000;
+        if (dateRange === "7d") return now - noticeTime <= 7 * 24 * 60 * 60 * 1000;
+        if (dateRange === "30d") return now - noticeTime <= 30 * 24 * 60 * 60 * 1000;
+        return true;
+      })
+      .sort((a, b) => {
+        if (a.isPinned !== b.isPinned) return a.isPinned ? -1 : 1;
+        if (sortOrder === "oldest") {
+          return new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime();
+        }
+        return new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime();
+      });
+  }, [notices, searchQuery, selectedCategory, selectedPriority, selectedTags, dateRange, sortOrder, showOnlyUnread, readNotices]);
+
+  const totalPages = Math.ceil(filteredNotices.length / itemsPerPage);
+  const safeCurrentPage = currentPage > totalPages && totalPages > 0 ? totalPages : currentPage;
+  const indexOfLastItem = safeCurrentPage * itemsPerPage;
+  const indexOfFirstItem = indexOfLastItem - itemsPerPage;
+  const paginatedNotices = filteredNotices.slice(indexOfFirstItem, indexOfLastItem);
+
+  const unreadCount = useMemo(() => {
+    return notices.filter((notice) => !readNotices.has(notice.id)).length;
+  }, [notices, readNotices]);
+
+  const handleClearFilters = useCallback(() => {
+    setSearchQuery("");
+    setSelectedCategory("all");
+    setSelectedPriority("all");
+    setSelectedTags([]);
+    setDateRange("all");
+    setSortOrder("newest");
+    setShowOnlyUnread(false);
+    setCurrentPage(1);
+  }, []);
+
+  const handleTagToggle = useCallback((tag) => {
+    setSelectedTags((current) =>
+      current.includes(tag) ? current.filter((item) => item !== tag) : [...current, tag]
+    );
+  }, []);
+
+  const handleSuggestionSelect = useCallback((suggestion) => {
+    setSearchQuery(suggestion);
+  }, []);
+
+  if (loading) {
+    return (
+      <div className="min-h-screen bg-slate-950 text-white">
+        <Navbar />
+        <div className="mx-auto max-w-7xl px-4 py-8">
+          <div className="rounded-3xl border border-slate-800 bg-slate-900/60 p-6">
+            <NoticeSkeleton count={4} />
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-slate-950 text-white">
+      <Navbar />
+
+      {/* Notice creation modal */}
+      <AnimatePresence>
+        {showCreateForm && (
+          <NoticeForm
+            onClose={() => setShowCreateForm(false)}
+            onSuccess={() => setShowCreateForm(false)}
+          />
+        )}
+      </AnimatePresence>
+
+      <div className="mx-auto max-w-7xl px-4 py-8">
+        {/* Header */}
+        <div className="mb-8 rounded-3xl border border-slate-800 bg-slate-900/60 p-6">
+          <div className="flex flex-col gap-6 lg:flex-row lg:items-center lg:justify-between">
+            <div>
+              <p className="mb-2 text-sm uppercase tracking-[0.3em] text-indigo-300">
+                Notice Center
+              </p>
+              <h1 className="text-4xl font-bold">Smart Notice Board</h1>
+              <p className="mt-3 text-slate-400">
+                Search, filter, and manage notices in real-time.
+              </p>
+
+              {/* feat #2184: Create Notice button for teachers/admins */}
+              {canCreateNotice && (
+                <button
+                  onClick={() => setShowCreateForm(true)}
+                  className="mt-4 flex items-center gap-2 rounded-xl bg-gradient-to-r from-indigo-500 to-purple-600 px-5 py-2.5 text-sm font-bold text-white shadow-lg hover:from-indigo-600 hover:to-purple-700 transition"
+                >
+                  + Create Notice
+                </button>
+              )}
+            </div>
+
+            {/* Stats */}
+            <div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
+              {[
+                { label: "Total", value: notices.length, color: "text-white" },
+                { label: "Unread", value: unreadCount, color: "text-emerald-400" },
+                { label: "Pinned", value: notices.filter((n) => n.isPinned).length, color: "text-yellow-400" },
+                { label: "High", value: notices.filter((n) => n.priority === "high").length, color: "text-red-400" },
+              ].map((stat) => (
+                <div key={stat.label} className="rounded-2xl border border-slate-700 bg-slate-800/70 p-4 text-center">
+                  <p className={`text-3xl font-bold ${stat.color}`}>{stat.value}</p>
+                  <p className="mt-2 text-xs uppercase tracking-widest text-slate-400">{stat.label}</p>
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+
+        {/* Tab Selection */}
+        <div className="mb-6 flex justify-start">
+          <div className="flex space-x-2 bg-slate-900/80 p-1.5 rounded-2xl border border-slate-800">
+            <button
+              onClick={() => setActiveTab("notices")}
+              className={`px-4 py-2 rounded-xl text-sm font-semibold transition-all duration-300 ${
+                activeTab === "notices"
+                  ? "bg-gradient-to-r from-indigo-500 to-purple-600 text-white shadow-lg"
+                  : "text-slate-400 hover:text-white"
+              }`}
+            >
+              Active Notices
+            </button>
+            <button
+              onClick={() => setActiveTab("overview")}
+              className={`px-4 py-2 rounded-xl text-sm font-semibold transition-all duration-300 ${
+                activeTab === "overview"
+                  ? "bg-gradient-to-r from-indigo-500 to-purple-600 text-white shadow-lg"
+                  : "text-slate-400 hover:text-white"
+              }`}
+            >
+              Activity Feed Overview
+            </button>
+          </div>
+        </div>
+
+        {/* Main Content */}
+        {activeTab === "overview" ? (
+          <div className="bg-slate-900/60 border border-slate-800 rounded-3xl p-6 space-y-6">
+            <div className="flex items-center justify-between">
+              <h2 className="text-2xl font-bold text-white">Recent Notice Activity</h2>
+              <span className="text-xs text-indigo-300 uppercase tracking-widest font-semibold bg-indigo-500/10 border border-indigo-500/20 px-3 py-1 rounded-full">
+                Live Feed
+              </span>
+            </div>
+
+            {derivedActivity?.length > 0 ? (
+              <div className="space-y-4">
+                {derivedActivity.map((item, index) => (
+                  <div
+                    key={item?.id || index}
+                    className="flex items-start justify-between bg-slate-800/40 rounded-2xl p-4 border border-slate-700/50"
+                  >
+                    <div>
+                      <p className="text-white font-medium">{item?.title}</p>
+                      <p className="text-slate-400 text-xs mt-1">
+                        By <span className="text-slate-300 font-semibold">{item?.user}</span>
+                        {" • "}
+                        {getRelativeTime(item?.timestamp)}
+                      </p>
+                    </div>
+                    <span className="text-xs px-2.5 py-1 rounded-full font-semibold uppercase tracking-wider bg-blue-500/10 text-blue-300 border border-blue-500/20">
+                      {item?.type}
+                    </span>
+                  </div>
+                ))}
+              </div>
+            ) : (
+              <div className="text-center py-16 bg-slate-950/40 rounded-2xl border border-dashed border-slate-800">
+                <p className="text-slate-500 text-base">No recent activity available</p>
+                <p className="text-slate-600 text-xs mt-1">
+                  Check back later for system logs and notice actions.
+                </p>
+              </div>
+            )}
+          </div>
+        ) : (
+          <div className="grid gap-6 xl:grid-cols-[340px_1fr]">
+            {/* Sidebar */}
+            <aside className="space-y-6">
+              <NoticeSearch
+                value={searchQuery}
+                onSearchChange={setSearchQuery}
+                onClearFilters={handleClearFilters}
+                resultsCount={filteredNotices.length}
+                activeFilterCount={activeFilterCount}
+                suggestions={searchOptions}
+                onSuggestionSelect={handleSuggestionSelect}
+              />
+              <NoticeFilters
+                categories={CATEGORIES}
+                selectedCategory={selectedCategory}
+                onCategoryChange={setSelectedCategory}
+                selectedPriority={selectedPriority}
+                onPriorityChange={setSelectedPriority}
+                availableTags={availableTags}
+                selectedTags={selectedTags}
+                onTagToggle={handleTagToggle}
+                selectedDateRange={dateRange}
+                onDateRangeChange={setDateRange}
+                sortOrder={sortOrder}
+                onSortOrderChange={setSortOrder}
+                showOnlyUnread={showOnlyUnread}
+                onToggleUnread={() => setShowOnlyUnread((prev) => !prev)}
+              />
+            </aside>
+
+            {/* Notices */}
+            <main>
+              {filteredNotices.length === 0 ? (
+                <EmptyNoticeState query={searchQuery} onResetFilters={handleClearFilters} />
+              ) : (
+                <>
+                  <motion.div layout className="grid gap-5 lg:grid-cols-2">
+                    <AnimatePresence>
+                      {paginatedNotices.map((notice) => {
+                        const isRead = readNotices.has(notice.id);
+                        return (
+                          <motion.div
+                            key={notice.id}
+                            layout
+                            initial={{ opacity: 0, y: 20 }}
+                            animate={{ opacity: 1, y: 0 }}
+                            exit={{ opacity: 0, scale: 0.95 }}
+                            transition={{ duration: 0.3 }}
+                          >
+                            <NoticeCard
+                              notice={notice}
+                              isRead={isRead}
+                              onToggleRead={() =>
+                                isRead ? markAsUnread(notice.id) : markAsRead(notice.id)
+                              }
+                              searchQuery={searchQuery}
+                              getRelativeTime={getRelativeTime}
+                            />
+                          </motion.div>
+                        );
+                      })}
+                    </AnimatePresence>
+                  </motion.div>
+
+                  {/* Pagination */}
+                  {totalPages > 1 && (
+                    <div className="mt-8 flex items-center justify-between border-t border-slate-800 pt-6">
+                      <p className="text-sm text-slate-400">
+                        Showing{" "}
+                        <span className="font-semibold text-white">{indexOfFirstItem + 1}</span>
+                        {" to "}
+                        <span className="font-semibold text-white">
+                          {Math.min(indexOfLastItem, filteredNotices.length)}
+                        </span>
+                        {" of "}
+                        <span className="font-semibold text-white">{filteredNotices.length}</span>
+                        {" notices"}
+                      </p>
+                      <div className="flex gap-3">
+                        <button
+                          onClick={() => setCurrentPage((p) => Math.max(p - 1, 1))}
+                          disabled={safeCurrentPage === 1}
+                          className="rounded-xl border border-slate-700 bg-slate-800/50 px-4 py-2 text-sm font-medium transition-all hover:bg-slate-800 disabled:opacity-40"
+                        >
+                          Previous
+                        </button>
+                        <button
+                          onClick={() => setCurrentPage((p) => Math.min(p + 1, totalPages))}
+                          disabled={safeCurrentPage === totalPages}
+                          className="rounded-xl border border-slate-700 bg-slate-800/50 px-4 py-2 text-sm font-medium transition-all hover:bg-slate-800 disabled:opacity-40"
+                        >
+                          Next
+                        </button>
+                      </div>
+                    </div>
+                  )}
+                </>
+              )}
+            </main>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default SmartNoticeBoard;


### PR DESCRIPTION
## Description
Adds a modal form for teachers and admins to create notices directly
from the Notice Board UI, with role-based audience targeting.

Fixes #2184

## Changes Made
- Added `components/NoticeForm.jsx` — modal form with title, content,
  category, priority, tags, pin toggle, and audience selector
  (Everyone / By Role with individual role chips)
- Added `components/SmartNoticeBoard.jsx` — updated notice board with
  `canCreateNotice` check so only teachers/admins/staff see the
  "+ Create Notice" button, wires open/close state for the modal
- Updated `app/notices/page.js` — import path updated to point to
  new SmartNoticeBoard component

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings