### PR TITLE
feat: add rich media attachments (PDF, images, links) to notices (fixes #2184)

### DIFF
--- a/app/api/notices/upload/route.js
+++ b/app/api/notices/upload/route.js
@@ -1,0 +1,62 @@
+import { NextResponse } from "next/server";
+import { put } from "@vercel/blob";
+import { requireRole } from "@/lib/rbac";
+import { withErrorHandler } from "@/lib/error-handler";
+import { AppError } from "@/lib/errors";
+
+export const runtime = "nodejs";
+
+const MAX_FILE_BYTES = 10 * 1024 * 1024; // 10 MB
+const ALLOWED_TYPES = [
+  "image/jpeg",
+  "image/png",
+  "image/gif",
+  "image/webp",
+  "application/pdf",
+];
+
+/**
+ * POST /api/notices/upload
+ *
+ * Accepts a single file (multipart/form-data, field name "file").
+ * Uploads it to Vercel Blob and returns the public URL.
+ * Only teachers, admins, and staff may upload.
+ *
+ * feat #2184 — Rich media attachments for notices
+ */
+async function uploadAttachment(request) {
+  const allowedRoles = ["teacher", "admin", "staff"];
+  await requireRole(request, allowedRoles);
+
+  const formData = await request.formData();
+  const file = formData.get("file");
+
+  if (!file || typeof file === "string") {
+    throw new AppError("No file provided.", 400);
+  }
+
+  if (!ALLOWED_TYPES.includes(file.type)) {
+    throw new AppError(
+      "Invalid file type. Only images and PDFs are allowed.",
+      415
+    );
+  }
+
+  if (file.size > MAX_FILE_BYTES) {
+    throw new AppError("File exceeds the 10 MB limit.", 413);
+  }
+
+  // Sanitise filename — strip path traversal characters
+  const safeName = file.name
+    .replace(/[^a-zA-Z0-9._-]/g, "_")
+    .slice(0, 128);
+
+  const blob = await put(`notices/${Date.now()}_${safeName}`, file, {
+    access: "public",
+    contentType: file.type,
+  });
+
+  return NextResponse.json({ url: blob.url });
+}
+
+export const POST = withErrorHandler(uploadAttachment);

--- a/components/NoticeCard.jsx
+++ b/components/NoticeCard.jsx
@@ -547,6 +547,57 @@ const NoticeCard = ({
         ))}
       </motion.div>
 
+      {/* Attachments — feat #2184: rich media support */}
+      {notice.attachments?.length > 0 && (
+        <div className="mt-5 space-y-3">
+          <p className="text-xs uppercase tracking-widest text-slate-500 font-semibold">
+            Attachments
+          </p>
+          {notice.attachments.map((att, i) => (
+            <div key={i}>
+              {att.type === "link" ? (
+                
+                  href={att.url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="flex items-center gap-2 text-sm text-sky-400 hover:underline break-all"
+                >
+                  🔗 {att.name}
+                </a>
+              ) : att.type?.startsWith("image/") ? (
+                
+                  href={att.url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  <img
+                    src={att.url}
+                    alt={att.name}
+                    className="rounded-xl max-h-48 w-full object-cover border border-slate-700 hover:opacity-90 transition"
+                  />
+                </a>
+              ) : att.type === "application/pdf" ? (
+                <div className="rounded-xl overflow-hidden border border-slate-700">
+                  <iframe
+                    src={att.url}
+                    title={att.name}
+                    className="w-full h-48"
+                  />
+                  
+                    href={att.url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="flex items-center gap-2 bg-slate-800 px-3 py-2 text-xs text-slate-300 hover:bg-slate-700 transition"
+                  >
+                    📄 {att.name} — Open PDF
+                  </a>
+                </div>
+              ) : null}
+            </div>
+          ))}
+        </div>
+      )}
+
       <motion.div
         initial={{ opacity: 0 }}
         animate={{ opacity: 1 }}

--- a/lib/validations/notices.js
+++ b/lib/validations/notices.js
@@ -21,6 +21,21 @@ export const createNoticeSchema = z.object({
     .min(1, "Target audience is required")
     .max(50)
     .optional(),
+
+  // feat #2184: rich media attachments (PDFs, images, links)
+  // Files are uploaded via POST /api/notices/upload to Vercel Blob
+  // and the returned URL is stored here alongside metadata.
+  attachments: z
+    .array(
+      z.object({
+        name: z.string().min(1),
+        type: z.string().min(1), // MIME type or "link"
+        size: z.number().min(0), // bytes, 0 for links
+        url: z.string().url(),
+      })
+    )
+    .max(3, "Maximum 3 attachments allowed")
+    .default([]),
 });
 
 export const updateNoticeSchema = createNoticeSchema.partial();


### PR DESCRIPTION
## Description
Adds rich media attachment support to the Notice Board —
teachers and admins can now attach PDFs, images, and links
to any notice, stored via Vercel Blob.

Fixes #2184

## Changes Made
- Added `app/api/notices/upload/route.js` — new API endpoint that
  accepts multipart file uploads (images + PDFs, max 10 MB each),
  validates file type and size, uploads to Vercel Blob, returns
  public URL. Only teachers/admins/staff can upload.
- Updated `lib/validations/notices.js` — added `attachments` array
  field to createNoticeSchema (max 3 attachments, each with
  name/type/size/url validated by Zod). updateNoticeSchema inherits
  the field automatically via .partial()
- Updated `components/NoticeCard.jsx` — renders attachments inline:
  images as thumbnails, PDFs as inline iframe with open link,
  URLs as clickable links with 🔗 icon

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings