### PR TITLE
fix: replace inline require('crypto') with top-level ESM import

### DIFF
--- a/lib/progress-encryption.js
+++ b/lib/progress-encryption.js
@@ -14,6 +14,9 @@
  * In production, key must be securely managed (e.g., AWS KMS, HashiCorp Vault)
  * @returns {string} Base64-encoded encryption key
  */
+
+import { randomBytes, createCipheriv, createDecipheriv } from "crypto";
+
 export function getEncryptionKey() {
   const key = process.env.LEARNING_DATA_ENCRYPTION_KEY;
 
@@ -43,17 +46,17 @@ export function getEncryptionKey() {
  */
 export function encryptProgressData(data) {
   try {
-    const crypto = require("crypto");
+    //const crypto = require("crypto");
     const key = Buffer.from(getEncryptionKey(), "base64");
 
     // Convert data to JSON string
     const jsonStr = JSON.stringify(data);
 
     // Generate random IV for this encryption
-    const iv = crypto.randomBytes(16);
+    const iv = randomBytes(16);
 
     // Create cipher
-    const cipher = crypto.createCipheriv("aes-256-cbc", key, iv);
+    const cipher = createCipheriv("aes-256-cbc", key, iv);
 
     // Encrypt
     let encrypted = cipher.update(jsonStr, "utf8", "hex");
@@ -76,7 +79,7 @@ export function encryptProgressData(data) {
  */
 export function decryptProgressData(encryptedData) {
   try {
-    const crypto = require("crypto");
+    //const crypto = require("crypto");
     const key = Buffer.from(getEncryptionKey(), "base64");
 
     // Decode from base64
@@ -91,7 +94,7 @@ export function decryptProgressData(encryptedData) {
     const iv = Buffer.from(ivHex, "hex");
 
     // Create decipher
-    const decipher = crypto.createDecipheriv("aes-256-cbc", key, iv);
+    const decipher = createDecipheriv("aes-256-cbc", key, iv);
 
     // Decrypt
     let decrypted = decipher.update(encryptedHex, "hex", "utf8");


### PR DESCRIPTION
## Description
Fixes a ReferenceError: require is not defined crash in lib/progress-encryption.js that silently breaks all student learning data encryption and decryption.
Both encryptProgressData() and decryptProgressData() called require("crypto") inline inside their function bodies.

Fixes #3402 

## Type of Change
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:
- [ x] My code follows the style guidelines of this project
- [ x] I have performed a self-review of my own code
- [ x] I have commented my code, particularly in hard-to-understand areas
- [ x] My changes generate no new warnings
