### PR TITLE
fix: validateCsrfOriginAndReferer() can throw 403 when CSRF_TRUSTED_ORIGIN / request.nextUrl.origin is missing

### DIFF
--- a/components/ClientLayout.js
+++ b/components/ClientLayout.js
@@ -143,8 +143,17 @@ export default function ClientLayout({ children }) {
             const requestHeaders = new Headers(
               requestInput?.headers || init.headers || {}
             );
-            if (!requestHeaders.has("x-csrf-token")) {
-              requestHeaders.set("X-CSRF-Token", csrfToken);
+            const existingToken =
+              requestHeaders.get("x-csrf-token") ||
+              requestHeaders.get("x-xsrf-token") ||
+              requestHeaders.get("x-csrftoken");
+
+            if (!existingToken) {
+              requestHeaders.set("x-csrf-token", csrfToken);
+            } else {
+              if (!requestHeaders.has("x-csrf-token")) {
+                requestHeaders.set("x-csrf-token", existingToken);
+              }
             }
 
             if (requestInput) {

--- a/docs/API.md
+++ b/docs/API.md
@@ -95,6 +95,18 @@ Returns a CSRF token for form submissions.
 
 **Auth required:** No
 
+**Response `200`**
+```json
+{
+  "csrfToken": "a1b2c3d4..."
+}
+```
+
+#### CSRF Protection Header
+For unsafe cookie-authenticated requests (e.g., `POST`, `PUT`, `PATCH`, `DELETE`) to `/api/*` routes, the CSRF token must be passed in a header.
+- **Canonical Header:** `x-csrf-token` (case-insensitive)
+- **Supported Fallbacks (case-insensitive):** `x-xsrf-token`, `x-csrftoken`
+
 ---
 
 ### `POST /api/auth/set-role`

--- a/lib/__tests__/csrf.test.js
+++ b/lib/__tests__/csrf.test.js
@@ -1,0 +1,131 @@
+import { describe, expect, test } from "vitest";
+import {
+  generateCsrfToken,
+  getCsrfHeaderValue,
+  validateCsrfRequest,
+  CSRF_HEADER_NAME,
+} from "../csrf";
+
+describe("CSRF Helpers", () => {
+  describe("generateCsrfToken", () => {
+    test("generates a random hexadecimal string of correct length", () => {
+      const token1 = generateCsrfToken();
+      const token2 = generateCsrfToken();
+      expect(token1).toHaveLength(64); // 32 bytes to hex
+      expect(token2).toHaveLength(64);
+      expect(token1).not.toBe(token2);
+    });
+  });
+
+  describe("getCsrfHeaderValue", () => {
+    test("handles null or undefined headers", () => {
+      expect(getCsrfHeaderValue(null)).toBeNull();
+      expect(getCsrfHeaderValue(undefined)).toBeNull();
+    });
+
+    test("reads from Fetch Headers object case-insensitively", () => {
+      const headers1 = new Headers();
+      headers1.set("x-csrf-token", "token-a");
+      expect(getCsrfHeaderValue(headers1)).toBe("token-a");
+
+      const headers2 = new Headers();
+      headers2.set("X-CSRF-Token", "token-b");
+      expect(getCsrfHeaderValue(headers2)).toBe("token-b");
+
+      const headers3 = new Headers();
+      headers3.set("X-XSRF-TOKEN", "token-c");
+      expect(getCsrfHeaderValue(headers3)).toBe("token-c");
+
+      const headers4 = new Headers();
+      headers4.set("X-CSRFToken", "token-d");
+      expect(getCsrfHeaderValue(headers4)).toBe("token-d");
+    });
+
+    test("reads from plain object headers case-insensitively", () => {
+      expect(getCsrfHeaderValue({ "x-csrf-token": "token-1" })).toBe("token-1");
+      expect(getCsrfHeaderValue({ "X-CSRF-Token": "token-2" })).toBe("token-2");
+      expect(getCsrfHeaderValue({ "X-XSRF-TOKEN": "token-3" })).toBe("token-3");
+      expect(getCsrfHeaderValue({ "X-CSRFToken": "token-4" })).toBe("token-4");
+    });
+  });
+
+  describe("validateCsrfRequest", () => {
+    const mockCookieStore = (value) => ({
+      get: (name) => {
+        if (name === "csrfToken") return { value };
+        return null;
+      },
+    });
+
+    test("ignores safe HTTP methods", () => {
+      const req = {
+        method: "GET",
+        headers: new Headers(),
+        cookies: mockCookieStore(null),
+      };
+      // Should not throw even with missing token/cookies
+      expect(() => validateCsrfRequest(req)).not.toThrow();
+    });
+
+    test("succeeds with matching cookie and canonical header", () => {
+      const req = {
+        method: "POST",
+        headers: new Headers({ "x-csrf-token": "valid-token" }),
+        cookies: mockCookieStore("valid-token"),
+      };
+      expect(() => validateCsrfRequest(req)).not.toThrow();
+    });
+
+    test("succeeds with matching cookie and fallback header name", () => {
+      const req = {
+        method: "POST",
+        headers: new Headers({ "X-XSRF-TOKEN": "valid-token" }),
+        cookies: mockCookieStore("valid-token"),
+      };
+      expect(() => validateCsrfRequest(req)).not.toThrow();
+
+      const req2 = {
+        method: "PUT",
+        headers: new Headers({ "X-CSRFToken": "valid-token" }),
+        cookies: mockCookieStore("valid-token"),
+      };
+      expect(() => validateCsrfRequest(req2)).not.toThrow();
+    });
+
+    test("normalizes tokens with quoting and whitespaces", () => {
+      const req = {
+        method: "POST",
+        headers: new Headers({ "x-csrf-token": ' "valid-token" ' }),
+        cookies: mockCookieStore("valid-token"),
+      };
+      expect(() => validateCsrfRequest(req)).not.toThrow();
+    });
+
+    test("throws when CSRF cookie is missing", () => {
+      const req = {
+        method: "POST",
+        headers: new Headers({ "x-csrf-token": "valid-token" }),
+        cookies: mockCookieStore(null),
+      };
+      expect(() => validateCsrfRequest(req)).toThrow("Forbidden: missing CSRF cookie");
+    });
+
+    test("throws when CSRF header is missing", () => {
+      const req = {
+        method: "POST",
+        headers: new Headers(),
+        cookies: mockCookieStore("valid-token"),
+      };
+      expect(() => validateCsrfRequest(req)).toThrow("Forbidden: missing CSRF header (x-csrf-token)");
+    });
+
+    test("throws when tokens mismatch", () => {
+      const req = {
+        method: "POST",
+        headers: new Headers({ "x-csrf-token": "token-xyz" }),
+        cookies: mockCookieStore("token-abc"),
+      };
+      expect(() => validateCsrfRequest(req)).toThrow("Forbidden: invalid CSRF token (mismatch)");
+    });
+  });
+});

--- a/lib/__tests__/csrf.test.js
+++ b/lib/__tests__/csrf.test.js
@@ -1,8 +1,9 @@
-import { describe, expect, test } from "vitest";
+import { describe, expect, test, afterEach } from "vitest";
 import {
   generateCsrfToken,
   getCsrfHeaderValue,
   validateCsrfRequest,
+  validateCsrfOriginAndReferer,
   CSRF_HEADER_NAME,
 } from "../csrf";
 
@@ -126,6 +127,108 @@ describe("CSRF Helpers", () => {
         cookies: mockCookieStore("token-abc"),
       };
       expect(() => validateCsrfRequest(req)).toThrow("Forbidden: invalid CSRF token (mismatch)");
+    });
+  });
+
+  describe("validateCsrfOriginAndReferer (Origin & Referer validation)", () => {
+    const originalEnv = process.env.CSRF_TRUSTED_ORIGIN;
+
+    afterEach(() => {
+      if (originalEnv === undefined) {
+        delete process.env.CSRF_TRUSTED_ORIGIN;
+      } else {
+        process.env.CSRF_TRUSTED_ORIGIN = originalEnv;
+      }
+    });
+
+    test("skips for safe methods", () => {
+      const req = { method: "GET" };
+      expect(() => validateCsrfOriginAndReferer(req)).not.toThrow();
+    });
+
+    test("succeeds when request.nextUrl.origin matches origin header", () => {
+      const req = {
+        method: "POST",
+        nextUrl: { origin: "https://example.com" },
+        headers: new Headers({ origin: "https://example.com" }),
+      };
+      expect(() => validateCsrfOriginAndReferer(req)).not.toThrow();
+    });
+
+    test("succeeds when process.env.CSRF_TRUSTED_ORIGIN matches origin header", () => {
+      process.env.CSRF_TRUSTED_ORIGIN = "https://trusted.com";
+      const req = {
+        method: "POST",
+        headers: new Headers({ origin: "https://trusted.com" }),
+      };
+      expect(() => validateCsrfOriginAndReferer(req)).not.toThrow();
+    });
+
+    test("succeeds when x-forwarded-host and proto match origin header (fallback)", () => {
+      delete process.env.CSRF_TRUSTED_ORIGIN;
+      const req = {
+        method: "POST",
+        headers: new Headers({
+          origin: "https://forwarded.com",
+          "x-forwarded-proto": "https",
+          "x-forwarded-host": "forwarded.com",
+        }),
+      };
+      expect(() => validateCsrfOriginAndReferer(req)).not.toThrow();
+    });
+
+    test("succeeds when host matches origin header (fallback)", () => {
+      delete process.env.CSRF_TRUSTED_ORIGIN;
+      const req = {
+        method: "POST",
+        headers: new Headers({
+          origin: "http://myhost.com",
+          host: "myhost.com",
+        }),
+        url: "http://myhost.com/api/test",
+      };
+      expect(() => validateCsrfOriginAndReferer(req)).not.toThrow();
+    });
+
+    test("succeeds when request.url parsed origin matches origin header (fallback)", () => {
+      delete process.env.CSRF_TRUSTED_ORIGIN;
+      const req = {
+        method: "POST",
+        headers: new Headers({
+          origin: "https://urlorigin.com",
+        }),
+        url: "https://urlorigin.com/api/test",
+      };
+      expect(() => validateCsrfOriginAndReferer(req)).not.toThrow();
+    });
+
+    test("succeeds with referer fallback", () => {
+      const req = {
+        method: "POST",
+        nextUrl: { origin: "https://example.com" },
+        headers: new Headers({
+          referer: "https://example.com/some/path",
+        }),
+      };
+      expect(() => validateCsrfOriginAndReferer(req)).not.toThrow();
+    });
+
+    test("fails when origin header does not match", () => {
+      const req = {
+        method: "POST",
+        nextUrl: { origin: "https://example.com" },
+        headers: new Headers({ origin: "https://malicious.com" }),
+      };
+      expect(() => validateCsrfOriginAndReferer(req)).toThrow("Forbidden: invalid Origin/Referer");
+    });
+
+    test("fails when referer host does not match and origin is missing", () => {
+      const req = {
+        method: "POST",
+        nextUrl: { origin: "https://example.com" },
+        headers: new Headers({ referer: "https://malicious.com/path" }),
+      };
+      expect(() => validateCsrfOriginAndReferer(req)).toThrow("Forbidden: invalid Origin/Referer");
     });
   });
 });

--- a/lib/apiClient.js
+++ b/lib/apiClient.js
@@ -70,10 +70,14 @@ export async function apiFetch(url, options = {}) {
 
       const csrfToken = getClientCsrfToken();
       if (csrfToken && shouldAttachCsrfToken(url, method)) {
-        requestHeaders["X-CSRF-Token"] =
-          requestHeaders["X-CSRF-Token"] ||
+        const existingToken =
           requestHeaders["x-csrf-token"] ||
-          csrfToken;
+          requestHeaders["X-CSRF-Token"] ||
+          requestHeaders["x-xsrf-token"] ||
+          requestHeaders["X-XSRF-TOKEN"] ||
+          requestHeaders["x-csrftoken"] ||
+          requestHeaders["X-CSRFToken"];
+        requestHeaders["x-csrf-token"] = existingToken || csrfToken;
       }
 
       if (

--- a/lib/csrf.js
+++ b/lib/csrf.js
@@ -1,5 +1,5 @@
 const CSRF_COOKIE_NAME = "csrfToken";
-const CSRF_HEADER_NAME = "x-csrf-token";
+export const CSRF_HEADER_NAME = "x-csrf-token";
 const SAFE_METHODS = new Set(["GET", "HEAD", "OPTIONS"]);
 
 function getCryptoSource() {
@@ -100,34 +100,32 @@ export function shouldAttachCsrfToken(url, method) {
 export function getCsrfHeaderValue(requestHeaders) {
   if (!requestHeaders) return null;
 
+  const targetHeaders = ["x-csrf-token", "x-xsrf-token", "x-csrftoken"];
+
   // Fast path for standard Fetch Headers.
   if (typeof requestHeaders.get === "function") {
-    const direct = requestHeaders.get(CSRF_HEADER_NAME);
-    if (direct) return direct;
+    for (const headerName of targetHeaders) {
+      const direct = requestHeaders.get(headerName);
+      if (direct) return direct;
+    }
 
     // Some runtimes/proxies may normalize header names differently or callers may
     // not pass a true Headers instance. Scan all entries case-insensitively.
     if (typeof requestHeaders.entries === "function") {
       for (const [name, value] of requestHeaders.entries()) {
-        if (String(name).toLowerCase() === CSRF_HEADER_NAME.toLowerCase()) {
+        if (targetHeaders.includes(String(name).toLowerCase())) {
           return value;
         }
       }
     }
-
-    // Try a common variant.
-    const variant =
-      requestHeaders.get("X-CSRF-TOKEN") || requestHeaders.get("X-CSRF-Token");
-    if (variant) return variant;
 
     return null;
   }
 
   // Fallback: plain object headers.
   if (typeof requestHeaders === "object") {
-    const target = CSRF_HEADER_NAME.toLowerCase();
     for (const [key, value] of Object.entries(requestHeaders)) {
-      if (key.toLowerCase() === target) {
+      if (targetHeaders.includes(key.toLowerCase())) {
         return value;
       }
     }

--- a/lib/csrf.js
+++ b/lib/csrf.js
@@ -135,10 +135,40 @@ export function getCsrfHeaderValue(requestHeaders) {
 }
 
 function getTrustedAppOrigin(request) {
-  // Best effort: middleware request has nextUrl.origin.
-  // If unavailable (non-standard runtimes), callers should set
-  // CSRF_TRUSTED_ORIGIN.
-  return request?.nextUrl?.origin || process.env.CSRF_TRUSTED_ORIGIN || null;
+  if (request?.nextUrl?.origin) {
+    return request.nextUrl.origin;
+  }
+  if (process.env.CSRF_TRUSTED_ORIGIN) {
+    return process.env.CSRF_TRUSTED_ORIGIN;
+  }
+
+  // Fallback: derive from request headers or request.url
+  if (request) {
+    const headers = request.headers;
+    if (headers) {
+      const proto =
+        (headers.get("x-forwarded-proto")?.split(",")[0]?.trim()) ||
+        (request.url && request.url.startsWith("https:") ? "https" : "http");
+      const host =
+        (headers.get("x-forwarded-host")?.split(",")[0]?.trim()) ||
+        headers.get("host");
+
+      if (host) {
+        return `${proto}://${host}`;
+      }
+    }
+
+    if (request.url) {
+      try {
+        const parsed = new URL(request.url);
+        return parsed.origin;
+      } catch {
+        // ignore parsing errors
+      }
+    }
+  }
+
+  return null;
 }
 
 function getHeaderOrigin(requestHeaders) {

--- a/worker/index.js
+++ b/worker/index.js
@@ -88,9 +88,18 @@ async function swFetchWithCsrf(url, options = {}) {
   const headers = new Headers(options.headers || {});
 
   if (isUnsafeMethod(method) && isSameOriginApiUrl(url)) {
-    if (!headers.has("x-csrf-token") && !headers.has("X-CSRF-Token")) {
+    const existingToken =
+      headers.get("x-csrf-token") ||
+      headers.get("x-xsrf-token") ||
+      headers.get("x-csrftoken");
+
+    if (!existingToken) {
       const token = await getCsrfToken();
-      if (token) headers.set("X-CSRF-Token", token);
+      if (token) headers.set("x-csrf-token", token);
+    } else {
+      if (!headers.has("x-csrf-token")) {
+        headers.set("x-csrf-token", existingToken);
+      }
     }
   }
 


### PR DESCRIPTION
closes #3371