### PR TITLE
fix: Navbar Login/Sign Up buttons do not navigate to login page

### DIFF
--- a/app/auth/page.js
+++ b/app/auth/page.js
@@ -34,10 +34,11 @@ export default function AuthPage() {
 function AuthPageContent() {
   const searchParams = useSearchParams();
   const mode = searchParams.get("mode");
+  const isDirect = searchParams.get("direct") === "true";
 
-  const [showRoleSelection, setShowRoleSelection] = useState(true);
+  const [showRoleSelection, setShowRoleSelection] = useState(!isDirect);
   const [isLogin, setIsLogin] = useState(mode !== "signup");
-  const [selectedRole, setSelectedRole] = useState("");
+  const [selectedRole, setSelectedRole] = useState(isDirect ? USER_ROLES.STUDENT : "");
 
   const [isLoading, setIsLoading] = useState(false);
   const [showForgotPassword, setShowForgotPassword] = useState(false);

--- a/components/Navbar.js
+++ b/components/Navbar.js
@@ -294,7 +294,7 @@ export function Navbar() {
                       size="default"
                       className="relative h-9 rounded-xl border border-indigo-500/30 bg-gradient-to-r from-indigo-600 to-violet-600 px-5 text-sm font-semibold text-white shadow-md shadow-indigo-600/25 transition-all duration-200 hover:from-indigo-500 hover:to-violet-500"
                     >
-                      <Link href="/auth">
+                      <Link href="/auth?direct=true">
                         <span className="flex items-center gap-1.5">
                           Login <Sparkles className="h-3.5 w-3.5 text-indigo-200" />
                         </span>
@@ -312,7 +312,7 @@ export function Navbar() {
                       size="default"
                       className="relative h-9 rounded-xl border border-indigo-500/30 bg-gradient-to-r from-indigo-600 to-violet-600 px-5 text-sm font-semibold text-white shadow-md shadow-indigo-600/25 transition-all duration-200 hover:from-indigo-500 hover:to-violet-500"
                     >
-                      <Link href="/auth?mode=signup">
+                      <Link href="/auth?mode=signup&direct=true">
                         <span className="flex items-center gap-1.5">
                           Sign Up <Sparkles className="h-3.5 w-3.5 text-indigo-200" />
                         </span>


### PR DESCRIPTION
## Description

In `app/auth/page.js`, `showRoleSelection` was hardcoded to `useState(true)`,
meaning the role selection screen **always** appeared regardless of how the user
reached `/auth`. This caused the navbar **Login** and **Sign Up** buttons to
behave identically to clicking a role card — always dropping the user into role
selection first — instead of going directly to the login form.
 
---
### `components/Navbar.js`
 
- Login button now navigates to `/auth?direct=true` instead of `/auth`
- Sign Up button now navigates to `/auth?mode=signup&direct=true` instead of `/auth?mode=signup`
- The `direct=true` query param signals that the user came from the navbar and wants to skip role selection
### `app/auth/page.js`
 
- Read the new param:
  ```js
  const isDirect = searchParams.get("direct") === "true"
  ```
- `showRoleSelection` now initializes as `useState(!isDirect)` — `false` when
  coming from the navbar, `true` when coming from a role card
- `selectedRole` now initializes as `useState(isDirect ? USER_ROLES.STUDENT : "")`
  — defaults to **Student** when skipping selection, since the form requires a
  role to submit. The user can still switch roles via the role badge inside the form
---
 
## Behavior After Fix
 
| Entry point | Role selection shown | Default role |
|---|---|---|
| Navbar Login / Sign Up | No — goes straight to form | Student (changeable) |
| Role card click | Yes — as before | Whichever card was clicked |

Fixes #3425 

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
