### PR TITLE
fix(middleware): add timeout to Google Identity Toolkit fetch

### DIFF
--- a/middleware.js
+++ b/middleware.js
@@ -333,6 +333,7 @@ async function verifyIdToken(token) {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ idToken: token }),
+        signal: AbortSignal.timeout(5000),
       }
     );
 


### PR DESCRIPTION
This pull request introduces a small improvement to the `verifyIdToken` function in `middleware.js`. The change adds a 5-second timeout to the network request for verifying ID tokens, which helps prevent the request from hanging indefinitely.

Closes #2783 