### PR TITLE
Fix Firebase initialization to prevent duplicate app errors

### DIFF
--- a/lib/firebase-admin.js
+++ b/lib/firebase-admin.js
@@ -5,7 +5,8 @@ let initializationError = null;
 
 export const initializeFirebase = () => {
   // Already initialized
-  if (firebaseInitialized && admin.apps.length) {
+  if (admin.apps.length > 0) {
+    firebaseInitialized = true;
     return;
   }
 


### PR DESCRIPTION
## Description

This pull request makes a minor adjustment to the Firebase initialization logic to ensure the `firebaseInitialized` flag is set correctly when Firebase apps are already present.

* Updated the condition in `initializeFirebase` (in `lib/firebase-admin.js`) to set `firebaseInitialized = true` if any Firebase apps are already initialized.…errors


Fixes #2784
