### PR TITLE
fix(saga): throw error when failing to record pending operation

### DIFF
--- a/lib/transactionCoordinator.js
+++ b/lib/transactionCoordinator.js
@@ -70,6 +70,7 @@ async function recordPendingOperation({
         error: err.message,
       }
     );
+    throw err;
   }
 }
 


### PR DESCRIPTION
This pull request introduces a small but important change to the `recordPendingOperation` function in `lib/transactionCoordinator.js`. Now, if an error occurs, the function will re-throw the error after logging it, ensuring that error handling is properly propagated to the caller.


Closes #2785