### PR TITLE
fix: guard useIdleTimeout against unauthenticated guests

### DIFF
--- a/hooks/useIdleTimeout.js
+++ b/hooks/useIdleTimeout.js
@@ -6,7 +6,7 @@ const IDLE_TIMEOUT = 15 * 60 * 1000;
 const WARNING_BEFORE = 2 * 60 * 1000;
 
 export function useIdleTimeout() {
-  const { signOut } = useAuth();
+  const { signOut, isAuthenticated } = useAuth();
   const signOutRef = useRef(signOut);
   useEffect(() => {
     signOutRef.current = signOut;
@@ -19,15 +19,14 @@ export function useIdleTimeout() {
   const clearTimers = () => {
     if (logoutTimer.current) clearTimeout(logoutTimer.current);
     if (warningTimer.current) clearTimeout(warningTimer.current);
-  };
-
-  const resetTimers = () => {
-    clearTimers();
-
     if (warningToastId.current) {
       toast.dismiss(warningToastId.current);
       warningToastId.current = null;
     }
+  };
+
+  const resetTimers = () => {
+    clearTimers();
 
     warningTimer.current = setTimeout(() => {
       warningToastId.current = toast(
@@ -37,12 +36,16 @@ export function useIdleTimeout() {
     }, IDLE_TIMEOUT - WARNING_BEFORE);
 
     logoutTimer.current = setTimeout(async () => {
-      toast.dismiss(warningToastId.current);
       await signOutRef.current();
     }, IDLE_TIMEOUT);
   };
 
   useEffect(() => {
+    if (!isAuthenticated) {
+      clearTimers();
+      return;
+    }
+
     const events = ["mousemove", "keydown", "click", "touchstart", "scroll"];
 
     const throttledReset = () => {
@@ -63,14 +66,7 @@ export function useIdleTimeout() {
     return () => {
       clearTimers();
       if (throttleTimer.current) clearTimeout(throttleTimer.current);
-      // Dismiss the warning toast if it is still visible when the component unmounts.
-      // react-hot-toast keeps a global store that outlives any single component, so
-      // without this the "You will be logged out" message persists across navigation.
-      if (warningToastId.current) {
-        toast.dismiss(warningToastId.current);
-        warningToastId.current = null;
-      }
       events.forEach((e) => window.removeEventListener(e, throttledReset));
     };
-  }, []);
+  }, [isAuthenticated]);
 }


### PR DESCRIPTION
The hook was unconditionally starting idle timers and showing 'You will be logged out' toast warnings for ALL users, including guests on the homepage and /auth page who were never logged in.

### Changes:
- Destructure isAuthenticated from useAuth() in useIdleTimeout
- Bail out early in the useEffect when user is not authenticated, calling clearTimers() to clean up any leftover state
- Move the warning toast dismiss into clearTimers() so a single call handles full cleanup (timers + visible toast)
- Add isAuthenticated to the useEffect dependency array so the hook re-evaluates when auth state changes (e.g. on sign-out)

Fixes: unauthenticated users receiving idle-logout warnings

## Description
The useIdleTimeout hook was unconditionally starting idle timers and showing "You will be logged out" toast warnings for all users, including unauthenticated guests browsing the homepage or /auth page who were never logged in. After 13 minutes of inactivity, guests would see the idle warning toast, and after 15 minutes the app would attempt to execute the signOut workflow unnecessarily.

This PR adds an authentication guard so the idle detection logic only activates for verified, logged-in users. If a user signs out mid-session, the effect re-runs, cleans up all active timers, and dismisses any visible warning toast.

Fixes #3525 

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
