### PR TITLE
fix: Remove duplicate CalendarSection import in productivity page

### DIFF
--- a/app/productivity/page.js
+++ b/app/productivity/page.js
@@ -36,7 +36,6 @@ import ProductivityTrendsSection from "@/components/productivity/ProductivityTre
 import { apiFetch } from "@/lib/apiClient";
 import { TaskSection } from "@/components/productivity/TaskSection";
 import { CalendarSection } from "@/components/productivity/CalendarSection";
-import { CalendarSection } from "@/components/productivity/CalendarSection";
 import { AgendaListSection } from "@/components/productivity/AgendaListSection";
 import { safeLocalStorageSet, safeLocalStorageGet } from "@/lib/storage";
 const MODES = {
@@ -250,7 +249,8 @@ const AcademicEligibilityCard = ({ isDark }) => {
         <button
           onClick={handleCheck}
           className="w-full rounded-xl bg-cyan-500 hover:bg-cyan-400 transition-colors px-3 py-1.5 text-sm font-semibold text-slate-900"
-         aria-label="Action button">
+          aria-label="Action button"
+        >
           Check Eligibility
         </button>
 


### PR DESCRIPTION
## Description

Cleaned up redundant import statements in the productivity main page file. This removes duplicate imports that increase code noise and can trigger linting warnings or build issues in CI pipelines.

Fixes #[issue_number]

## What Changed

### Import Cleanup
- Remove duplicate CalendarSection import statement from app/productivity/page.js
- Keeps only one import statement for CalendarSection component
- Improves code cleanliness and codebase maintainability

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] No existing functionality is broken
- [x] Import statements are properly organized
- [x] No linting warnings introduced

## Files Changed
- `app/productivity/page.js` - Removed duplicate CalendarSection import (line 39)

## Testing Notes
- Verified no functionality is affected by the import removal
- Duplicate import was not being used
- CalendarSection component still properly imported once at line 38

