### PR TITLE
docs: update branch name references from main to master in GSSoC contributor guide

### DIFF
--- a/docs/GSSoc_Contributor.md
+++ b/docs/GSSoc_Contributor.md
@@ -111,8 +111,15 @@ Before committing:
 
 Stage files:
 
+-To add all the files which is changed
+
 ```bash
 git add .
+```
+-To add only selected files
+
+```bash
+git add filename-one, filename-two
 ```
 
 Commit with a meaningful message:

--- a/docs/GSSoc_Contributor.md
+++ b/docs/GSSoc_Contributor.md
@@ -122,6 +122,8 @@ git add .
 git add filename-one, filename-two
 ```
 
+
+
 Commit with a meaningful message:
 
 ```bash


### PR DESCRIPTION
## Description

Updated the GSSoC Contributor Guide to replace outdated references to the `main` branch with the repository's actual default branch, `master`.

The documentation now reflects the correct Git workflow for contributors by updating commands used for syncing, merging, and rebasing with the upstream repository. This helps prevent confusion and ensures contributors can follow the guide without encountering branch-related errors.

Fixes #3387

## Type of Change

* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [x] This change requires a documentation update

## Checklist:

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my own code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [x] My changes generate no new warnings
