### PR TITLE
Upgrade IndexedDB version and add compound index

### DIFF
--- a/services/offlineSyncQueue.js
+++ b/services/offlineSyncQueue.js
@@ -7,8 +7,8 @@ const STORE_NAME = "attendance_queue";
  * Initializes the IndexedDB for offline attendance storage.
  */
 export async function initOfflineDB() {
-  return openDB(DB_NAME, 1, {
-    upgrade(db) {
+  return openDB(DB_NAME, 2, {
+    upgrade(db, oldVersion) {
       if (!db.objectStoreNames.contains(STORE_NAME)) {
         const store = db.createObjectStore(STORE_NAME, {
           keyPath: "id",
@@ -16,6 +16,11 @@ export async function initOfflineDB() {
         });
         store.createIndex("status", "status", { unique: false });
         store.createIndex("timestamp", "timestamp", { unique: false });
+        store.createIndex("userId_date", ["userId", "date"], { unique: false });
+      } else if (oldVersion < 2) {
+        // Existing store — add the compound index that was missing before v2
+        const tx = db.transaction(STORE_NAME, "readwrite");
+        tx.store.createIndex("userId_date", ["userId", "date"], { unique: false });
       }
     },
   });
@@ -23,11 +28,32 @@ export async function initOfflineDB() {
 
 /**
  * Adds an attendance record to the offline IndexedDB queue.
+ * If a pending record for the same userId + date already exists, the
+ * existing record's ID is returned and no duplicate is inserted.
  * @param {Object} record - The attendance data (userId, studentName, etc.)
  */
 export async function queueOfflineAttendance(record) {
   try {
     const db = await initOfflineDB();
+
+    // Deduplication: check for an existing pending record with the same
+    // userId and date before inserting to avoid double-syncing.
+    if (record.userId && record.date) {
+      const tx = db.transaction(STORE_NAME, "readonly");
+      const existing = await tx.store
+        .index("userId_date")
+        .getAll(IDBKeyRange.only([record.userId, record.date]));
+      await tx.done;
+
+      const pendingDuplicate = existing.find((r) => r.status === "pending");
+      if (pendingDuplicate) {
+        console.log(
+          `[Offline Sync] Duplicate skipped — record already queued with ID: ${pendingDuplicate.id}`
+        );
+        return pendingDuplicate.id;
+      }
+    }
+
     const id = await db.add(STORE_NAME, {
       ...record,
       status: "pending",


### PR DESCRIPTION
closes issue #3568 

initOfflineDB — bumped DB version 1 → 2, added a compound multi-entry index` "userId_date"` on `["userId", "date"]`. The upgrade callback handles both fresh installs (creates the index in the new store) and existing v1 databases (adds the missing index via the oldVersion < 2 branch).
`queueOfflineAttendance `— before inserting, opens a readonly transaction, queries the new userId_date index with `IDBKeyRange.only([record.userId, record.date])`, and if any result has` status === "pending",` returns its ID early without inserting. The insert only happens when no pending duplicate exists.