### PR TITLE
fix(security): Normalize confidence score before persistence in attendance record

### DIFF
--- a/app/api/attendance/record/route.js
+++ b/app/api/attendance/record/route.js
@@ -53,7 +53,7 @@ export const POST = withErrorHandler(
           userId,
           studentName,
           email,
-          confidenceScore,
+          confidenceScore: normalizedConfidence,
           normalizedDate,
         },
         token


### PR DESCRIPTION
## What type of PR is this?

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [ ] 🎨 UI/UX improvement
- [ ] ⚡ Performance improvement
- [x] 🔒 Security fix

## Description

This PR addresses a security vulnerability (CWE-840) related to a business logic flaw in `app/api/attendance/record/route.js`. The application was correctly calculating a `normalizedConfidence` score (0-1 range) for consistency across the database and dashboards, but was inadvertently passing the original, unnormalized `confidenceScore` (0-100 range) to the `AttendanceService.recordAttendance` function. 

This inconsistency could lead to data integrity issues in the database and downstream systems that expect a normalized value. The fix ensures that the calculated `normalizedConfidence` is now correctly used when recording attendance, aligning with the intended data consistency requirements.

## Related Issues

Closes #3624

## Changes Made

- Modified `app/api/attendance/record/route.js` to pass the `normalizedConfidence` (0-1 range) instead of the raw `confidenceScore` (0-100 range) to the `AttendanceService.recordAttendance` function.

## Testing

How did you test these changes?
- [x] Tested locally
- [ ] Tested on mobile
- [ ] Tested different user roles
- [ ] All roles tested

The changes were validated to ensure that the `normalizedConfidence` value is correctly passed and used for persistence. Internal validation processes confirmed that the fix prevents the storage of inconsistent, unnormalized confidence scores, thus resolving the data integrity issue.

## Screenshots (if applicable, else dont include)

N/A

## Checklist

- [x] No hardcoded secrets or credentials
- [x] `.env.local` is not committed
- [x] Code follows project style
- [x] Changes are documented
- [x] Build passes locally (`npm run build`)
- [x] No console errors/warnings