### PR TITLE
fix: add fallback color handling

### DIFF
--- a/components/AttendanceInsights.js
+++ b/components/AttendanceInsights.js
@@ -20,9 +20,12 @@ const InsightCard = ({ icon: Icon, label, value, color }) => {
       "from-purple-500/10 to-purple-600/5 border-purple-500/20 text-purple-400",
   };
 
+  const selectedColorStyle =
+  colorStyles[color] ?? colorStyles.orange;
+
   return (
     <div
-      className={`bg-gradient-to-br ${colorStyles[color]} rounded-xl border p-4 flex items-center gap-3`}
+      className={`bg-gradient-to-br ${selectedColorStyle} rounded-xl border p-4 flex items-center gap-3`}
     >
       <div className="flex items-center justify-center w-10 h-10 rounded-lg bg-white/5 shrink-0">
         <Icon className="w-5 h-5" />
@@ -40,22 +43,22 @@ const InsightCard = ({ icon: Icon, label, value, color }) => {
 const AttendanceInsights = ({ recentActivity }) => {
   const safeRecords = Array.isArray(recentActivity) ? recentActivity : [];
 
-  const currentStreak = useMemo(
-    () => calculateCurrentStreak(safeRecords),
-    [safeRecords]
-  );
-
-  const longestStreak = useMemo(
-    () => calculateLongestStreak(safeRecords),
-    [safeRecords]
-  );
-
-  const consistency = useMemo(
-    () => calculateConsistency(safeRecords),
-    [safeRecords]
-  );
-
-  const badge = useMemo(() => getBadge(consistency), [consistency]);
+  const {
+  currentStreak,
+  longestStreak,
+  consistency,
+  badge,
+  } = useMemo(() => {
+    const currentStreak = calculateCurrentStreak(safeRecords);
+    const longestStreak = calculateLongestStreak(safeRecords);
+    const consistency = calculateConsistency(safeRecords);
+    
+    return {
+    currentStreak,
+    longestStreak,
+    consistency,
+    badge: getBadge(consistency),
+  };}, [safeRecords]);
 
   return (
     <div className="bg-black/40 backdrop-blur-xl rounded-[2rem] border border-white/10 p-6 shadow-2xl">

--- a/components/AttendanceInsights.js
+++ b/components/AttendanceInsights.js
@@ -43,22 +43,22 @@ const InsightCard = ({ icon: Icon, label, value, color }) => {
 const AttendanceInsights = ({ recentActivity }) => {
   const safeRecords = Array.isArray(recentActivity) ? recentActivity : [];
 
-  const {
-  currentStreak,
-  longestStreak,
-  consistency,
-  badge,
-  } = useMemo(() => {
-    const currentStreak = calculateCurrentStreak(safeRecords);
-    const longestStreak = calculateLongestStreak(safeRecords);
-    const consistency = calculateConsistency(safeRecords);
-    
-    return {
-    currentStreak,
-    longestStreak,
-    consistency,
-    badge: getBadge(consistency),
-  };}, [safeRecords]);
+  const currentStreak = useMemo(
+    () => calculateCurrentStreak(safeRecords),
+    [safeRecords]
+  );
+
+  const longestStreak = useMemo(
+    () => calculateLongestStreak(safeRecords),
+    [safeRecords]
+  );
+
+  const consistency = useMemo(
+    () => calculateConsistency(safeRecords),
+    [safeRecords]
+  );
+
+  const badge = useMemo(() => getBadge(consistency), [consistency]);
 
   return (
     <div className="bg-black/40 backdrop-blur-xl rounded-[2rem] border border-white/10 p-6 shadow-2xl">


### PR DESCRIPTION
##Description

Currently, the component directly accesses colorStyles[color]. If an unsupported color value is passed, the lookup returns undefined, resulting in incomplete Tailwind class names and broken styling. This change introduces a safe default style to ensure the component always renders with valid styling.

Changes Made-:

- Added a fallback color style using the existing orange theme.
- Prevents invalid or missing color props from generating incomplete class names.
- Preserves the current appearance for all supported color values.

Closes #3630 


## Type of Change

[X] Bug fix (non-breaking change which fixes an issue)
[ ] New feature (non-breaking change which adds functionality)
[ ] Breaking change
[ ] Documentation update
[X] Code refactor

## Checklist
[X] My code follows the code style of this project.
[X] I have performed a self-review of my own code.
[X] My changes generate no new warnings.
[X] Existing functionality remains unchanged.