### PR TITLE
[Backend] Fix privilege escalation — enforce admin role on session termination

### DIFF
--- a/app/api/admin/sessions/terminate/route.js
+++ b/app/api/admin/sessions/terminate/route.js
@@ -1,13 +1,13 @@
 import { NextResponse } from "next/server";
 import { withErrorHandler, parseJSON } from "@/lib/error-handler";
-import { requireAuth } from "@/lib/rbac";
+import { requireAdmin } from "@/lib/rbac";
 import { terminateAllUserSessions } from "@/lib/sessionManager";
 
 export const dynamic = "force-dynamic";
 
 export const POST = withErrorHandler(async (request) => {
   // Only admins can forcibly terminate sessions for other users
-  await requireAuth(request);
+  await requireAdmin(request);
 
   const body = await parseJSON(request);
   const { targetUserId } = body;


### PR DESCRIPTION
## Description

The admin session termination endpoint (\POST /api/admin/sessions/terminate\) was using \equireAuth()\ which only verifies the user is logged in — **any** authenticated user (student, teacher, etc.) could forcibly terminate any other user's sessions.

## Fix

Replaced \equireAuth()\ with \equireAdmin()\ to enforce that only users with the \dmin\ role can terminate sessions.

### Changes in \pp/api/admin/sessions/terminate/route.js\
- \import { requireAuth }\ → \import { requireAdmin }\
- \wait requireAuth(request)\ → \wait requireAdmin(request)\

## Impact

This was a **privilege escalation vulnerability** (CWE-285). A non-admin user could terminate admin sessions or DoS any user by repeatedly terminating their sessions.

Fixes #3674