### PR TITLE
[Security] Restrict Firestore user profile reads to owner and teachers

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -16,10 +16,10 @@ service cloud.firestore {
     }
 
     // Users Collection
-    // Anyone authenticated can read user profiles, but users can only edit their own profile
-    // Only teachers/admins can create new teacher profiles (handled via Cloud Functions usually, so blocked here)
+    // Users can read their own profile; teachers can read all profiles for class management
+    // Users can only edit their own profile
     match /users/{userId} {
-      allow read: if isAuthenticated();
+      allow read: if isAuthenticated() && (request.auth.uid == userId || isTeacher());
       allow write: if isAuthenticated() && request.auth.uid == userId;
     }
 


### PR DESCRIPTION
## Description

The Firestore security rules allowed **any authenticated user** to read all user profiles. The read rule only checked \isAuthenticated()\, meaning a student could enumerate teachers, admins, and other students' personal data.

## Fix

Changed the read rule on \/users/{userId}\ from:
\\\
allow read: if isAuthenticated();
\\\
to:
\\\
allow read: if isAuthenticated() && (request.auth.uid == userId || isTeacher());
\\\

This ensures:
- Users can always read their **own** profile
- **Teachers** can read any user's profile (needed for class management)
- **Students cannot** read other students' profiles

Fixes #3673