### PR TITLE
[UI] Fix StreakTracker crash — JSX milestone message moved into return statement

### DIFF
--- a/components/ui/StreakTracker.jsx
+++ b/components/ui/StreakTracker.jsx
@@ -85,11 +85,6 @@ export default function StreakTracker({ className }) {
   streak < 30 ? 30 :
   streak < 100 ? 100 :
   null;
-  {nextMilestone && (
-  <span className="text-[10px] opacity-70">
-    {nextMilestone - streak} days to {nextMilestone}-day milestone
-  </span>
-)}
 
   return (
     <div
@@ -122,6 +117,11 @@ export default function StreakTracker({ className }) {
   {badge && (
     <span className="text-[10px] font-medium">
       {badge}
+    </span>
+  )}
+  {nextMilestone && (
+    <span className="text-[10px] opacity-70">
+      {nextMilestone - streak} days to {nextMilestone}-day milestone
     </span>
   )}
 </div>


### PR DESCRIPTION
## Description

The StreakTracker component had JSX code (a milestone countdown message) sitting **outside** the component's `return` statement, wrapped in bare `{...}` which JavaScript interprets as a block statement — causing a syntax error that crashes the entire component.

## Fix

- Removed the orphaned JSX block from outside the return statement
- Added the milestone message inside the `<div className="flex flex-col">` within the return, after the badge display

## Before

The following was placed outside the `return` statement, causing a syntax crash:
```jsx
{nextMilestone && (
  <span className="text-[10px] opacity-70">
    {nextMilestone - streak} days to {nextMilestone}-day milestone
  </span>
)}
```

## After

The milestone message renders correctly inside the component's JSX tree.

Fixes #3672
