### PR TITLE
feat: Calendar integration for individual class schedules

### DIFF
--- a/components/TeacherDashboardComponent.js
+++ b/components/TeacherDashboardComponent.js
@@ -63,6 +63,10 @@ import {
   Zap,
   Loader2,
   XCircle,
+  FileText,
+  Clock,
+  MapPin,
+  CalendarPlus,
 } from "lucide-react";
 import ExportDropdown from "@/components/ui/ExportDropdown";
 import { exportToCSV } from "@/utils/exportUtils";
@@ -1201,6 +1205,72 @@ const TeacherDashboard = () => {
     </div>
   );
 
+  const handleExportSingleClass = (cls, day) => {
+    let icsString = [
+      "BEGIN:VCALENDAR",
+      "VERSION:2.0",
+      "PRODID:-//Learnova//Teacher Schedule//EN",
+      "CALSCALE:GREGORIAN",
+      "METHOD:PUBLISH",
+    ].join("\r\n") + "\r\n";
+
+    const [startStr, endStr] = (cls.time || "").split("-");
+    if (!startStr || !endStr) return;
+
+    // Helper to get next weekday date
+    const getNextWeekdayDate = (dayName, timeStr) => {
+      const weekdays = { Sunday: 0, Monday: 1, Tuesday: 2, Wednesday: 3, Thursday: 4, Friday: 5, Saturday: 6 };
+      const targetDay = weekdays[dayName];
+      const now = new Date();
+      const currentDay = now.getDay();
+      let daysToAdd = targetDay - currentDay;
+      if (daysToAdd < 0) daysToAdd += 7;
+      const targetDate = new Date();
+      targetDate.setDate(now.getDate() + daysToAdd);
+      const [hours, minutes] = timeStr.split(":").map(Number);
+      targetDate.setHours(hours || 9, minutes || 0, 0, 0);
+      return targetDate;
+    };
+
+    const formatDateToICS = (date) => {
+      const yyyy = date.getFullYear();
+      const mm = String(date.getMonth() + 1).padStart(2, "0");
+      const dd = String(date.getDate()).padStart(2, "0");
+      const hh = String(date.getHours()).padStart(2, "0");
+      const min = String(date.getMinutes()).padStart(2, "0");
+      const ss = "00";
+      return `${yyyy}${mm}${dd}T${hh}${min}${ss}`;
+    };
+
+    const startDate = getNextWeekdayDate(day, startStr.trim());
+    const endDate = getNextWeekdayDate(day, endStr.trim());
+    const byDayMap = { Sunday: "SU", Monday: "MO", Tuesday: "TU", Wednesday: "WE", Thursday: "TH", Friday: "FR", Saturday: "SA" };
+
+    icsString += [
+      "BEGIN:VEVENT",
+      `UID:class-${day}-${Date.now()}@learnova`,
+      `DTSTAMP:${formatDateToICS(new Date())}`,
+      `SUMMARY:${cls.subject}`,
+      `DESCRIPTION:Room: ${cls.room}`,
+      `LOCATION:${cls.room}`,
+      `DTSTART:${formatDateToICS(startDate)}`,
+      `DTEND:${formatDateToICS(endDate)}`,
+      `RRULE:FREQ=WEEKLY;BYDAY=${byDayMap[day]}`,
+      "END:VEVENT",
+    ].join("\r\n") + "\r\n";
+    icsString += "END:VCALENDAR";
+
+    const blob = new Blob([icsString], { type: "text/calendar;charset=utf-8;" });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement("a");
+    link.href = url;
+    link.setAttribute("download", `${(cls.subject || "Class").replace(/\s+/g, '_')}_schedule.ics`);
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    toast.success(`Exported ${cls.subject} to .ics!`);
+  };
+
   const renderSchedule = () => (
     <div className="space-y-8">
       <div className="text-center">
@@ -1222,9 +1292,18 @@ const TeacherDashboard = () => {
               {classes.map((cls, index) => (
                 <div
                   key={index}
-                  className="bg-gray-800/50 rounded-lg p-3 border border-gray-700/50"
+                  className="bg-gray-800/50 rounded-lg p-3 border border-gray-700/50 relative group"
                 >
-                  <div className="text-sm font-medium text-foreground dark:text-white">
+                  <div className="absolute top-2 right-2 opacity-0 group-hover:opacity-100 transition-opacity">
+                    <button 
+                      onClick={() => handleExportSingleClass(cls, day)}
+                      className="p-1 rounded bg-black/40 text-gray-400 hover:text-green-400 transition-colors"
+                      title="Add to Calendar"
+                    >
+                      <CalendarPlus className="w-3 h-3" />
+                    </button>
+                  </div>
+                  <div className="text-sm font-medium text-foreground dark:text-white pr-5">
                     {cls.subject}
                   </div>
                   <div className="text-xs text-muted-foreground dark:text-gray-400">

--- a/components/Timetable.js
+++ b/components/Timetable.js
@@ -560,6 +560,55 @@ export default function Timetable({ role = "student" }) {
     toast.success(`Successfully exported ${eventCount} classes to .ics!`);
   };
 
+  const handleExportSingleClass = (cls, day) => {
+    let icsString =
+      [
+        "BEGIN:VCALENDAR",
+        "VERSION:2.0",
+        "PRODID:-//Learnova//Student Timetable Scheduler//EN",
+        "CALSCALE:GREGORIAN",
+        "METHOD:PUBLISH",
+      ].join("\r\n") + "\r\n";
+
+    const [startStr, endStr] = cls.time.split("-");
+    if (!startStr || !endStr) return;
+
+    const startDate = getNextWeekdayDate(day, startStr.trim());
+    const endDate = getNextWeekdayDate(day, endStr.trim());
+
+    const startICS = formatDateToICS(startDate);
+    const endICS = formatDateToICS(endDate);
+    const byDay = byDayMap[day];
+
+    icsString +=
+      [
+        "BEGIN:VEVENT",
+        `UID:class-${day}-${Date.now()}@learnova`,
+        `DTSTAMP:${formatDateToICS(new Date())}`,
+        `SUMMARY:${cls.subject}`,
+        `DESCRIPTION:Instructor: ${cls.teacher}\\nRoom: ${cls.room}`,
+        `LOCATION:${cls.room}`,
+        `DTSTART:${startICS}`,
+        `DTEND:${endICS}`,
+        `RRULE:FREQ=WEEKLY;BYDAY=${byDay}`,
+        "END:VEVENT",
+      ].join("\r\n") + "\r\n";
+
+    icsString += "END:VCALENDAR";
+
+    const blob = new Blob([icsString], {
+      type: "text/calendar;charset=utf-8;",
+    });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement("a");
+    link.href = url;
+    link.setAttribute("download", `${cls.subject.replace(/\s+/g, '_')}_class.ics`);
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    toast.success(`Successfully exported ${cls.subject} to .ics!`);
+  };
+
   const classes = timetableData[selectedDay] || [];
 
   return (
@@ -710,6 +759,16 @@ export default function Timetable({ role = "student" }) {
 
                     {/* Visual action controls on the card */}
                     <div className="flex items-center space-x-1.5 opacity-80 sm:opacity-0 group-hover:opacity-100 transition-opacity duration-200">
+                      <button
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          handleExportSingleClass(cls, selectedDay);
+                        }}
+                        className="p-1.5 rounded-lg bg-white/5 text-white/50 hover:text-green-400 hover:bg-white/10 hover:border-green-500/20 border border-transparent transition-all"
+                        title="Add to Calendar"
+                      >
+                        <CalendarPlus className="w-3 h-3" />
+                      </button>
                       <button
                         onClick={(e) => {
                           e.stopPropagation();


### PR DESCRIPTION
## Description
This PR addresses issue #3690 by introducing an "Add to Calendar" button for individual classes. While the universal calendar sync modal was previously added to the timetable, this new feature implements a direct and simple way to export single class events. Users can now hover over any scheduled class in both the Student Timetable and the Teacher Dashboard to reveal a button that instantly downloads a `.ics` file specifically for that class. This makes it effortless to integrate specific upcoming classes directly into external calendar apps like Google Calendar, Apple Calendar, or Outlook.

Fixes #3690

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
