### PR TITLE
fix: remove duplicate NextIntlClientProvider import in layout.js

### DIFF
--- a/app/layout.js
+++ b/app/layout.js
@@ -42,8 +42,6 @@ import ErrorBoundary from "@/components/ErrorBoundary";
 // ─── Context providers (all wrapped inside AllProviders) ─────────────────────
 // AllProviders composes: ThemeProvider → AuthProvider → FirestoreProvider → NotificationProvider
 import AllProviders from "./providers/AllProviders";
-import { NextIntlClientProvider } from "next-intl";
-import { getMessages } from "next-intl/server";
 
 // ─── SEO metadata & structured data ─────────────────────────────────────────
 import { siteStructuredData } from "@/lib/seo/siteStructuredData";


### PR DESCRIPTION
Fixes #3717

Problem
NextIntlClientProvider and getMessages from next-intl were imported twice in app/layout.js, causing a duplicate identifier compilation error.

Changes
Removed duplicate import { NextIntlClientProvider } from "next-intl"

Removed duplicate import { getMessages } from "next-intl/server"

Testing
Dev server compiles successfully without errors

No functional changes — layout behaviour is identical