### PR TITLE
Fix role selection card alignment on large screens

### DIFF
--- a/components/RoleSelection.js
+++ b/components/RoleSelection.js
@@ -77,7 +77,7 @@ export default function RoleSelection({ onRoleSelect }) {
       </div>
 
       {/* Role cards */}
-      <div ref={containerRef} onKeyDown={handleKeyDown} className="relative z-10 mb-10 grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
+      <div ref={containerRef} onKeyDown={handleKeyDown} className="relative z-10 mb-10 grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-5">
         {Object.entries(ROLE_CONFIG).map(([role, config]) => {
           const glow =
             ROLE_GLOW[role] ??


### PR DESCRIPTION
## 📝 Pull Request Description

### Related Issue

Closes #3721 

### Summary

This PR fixes the alignment of role selection cards on large screens.

Previously, the role selection section displayed 5 role cards in a 4-column grid (`lg:grid-cols-4`), causing the last card ("Parent") to wrap onto a new row and resulting in an unbalanced layout.

### Changes Made

* Updated the role selection grid layout from:

  * `lg:grid-cols-4`
  * to `lg:grid-cols-5`
* Ensured all five role cards are displayed in a single row on large screens.
* Improved visual consistency and user experience during role selection.

### Before

* Four cards displayed in the first row.
* One card wrapped to a second row.

### After

* All five role cards are aligned evenly in a single row on large screens.

### Type of Change

* [x] 🐛 Bug fix (non-breaking change which fixes an issue)
* [ ] ✨ New project addition
* [ ] 🚀 New feature or UI/UX enhancement
* [ ] ♻️ Code refactoring / clean-up
* [ ] 📝 Documentation update

### Checklist

* [x] Code follows the project's style guidelines
* [x] Changes have been tested locally
* [x] No unrelated files were modified
* [x] Existing functionality remains unaffected

UNDER GSSOC'26
