### PR TITLE
fix(attendance): add unique constraint and handle race conditions #3725

### DIFF
--- a/app/api/attendance/sync/route.js
+++ b/app/api/attendance/sync/route.js
@@ -229,26 +229,36 @@ async function handleSync(request) {
           execute: async (ctx) => {
             if (ctx._alreadyProcessed) return;
             const mongoDB = await connectDb();
-            // $set is inherently field-level in MongoDB — only the listed fields are
-            // touched; no risk of clobbering unrelated fields on a concurrent write.
-            await mongoDB.collection("attendance").updateOne(
-              { userId: decodedToken.uid, date: recordDate },
-              {
-                $set: {
-                  userId: decodedToken.uid,
-                  studentName: serverIdentity.studentName,
-                  email: serverIdentity.email,
-                  instituteId,
-                  timestamp: new Date(record.queuedAt),
-                  date: recordDate,
-                  status: "present",
-                  confidenceScore: normalizedConfidence,
-                  offlineSynced: true,
-                  queuedAt: new Date(record.queuedAt),
+            try {
+              // $set is inherently field-level in MongoDB — only the listed fields are
+              // touched; no risk of clobbering unrelated fields on a concurrent write.
+              await mongoDB.collection("attendance").updateOne(
+                { userId: decodedToken.uid, date: recordDate },
+                {
+                  $set: {
+                    userId: decodedToken.uid,
+                    studentName: serverIdentity.studentName,
+                    email: serverIdentity.email,
+                    instituteId,
+                    timestamp: new Date(record.queuedAt),
+                    date: recordDate,
+                    status: "present",
+                    confidenceScore: normalizedConfidence,
+                    offlineSynced: true,
+                    queuedAt: new Date(record.queuedAt),
+                  },
                 },
-              },
-              { upsert: true }
-            );
+                { upsert: true }
+              );
+            } catch (err) {
+              // E11000 = duplicate key — another concurrent request already wrote
+              // this record. Mark as processed so we don't fail the whole batch.
+              if (err?.code === 11000) {
+                ctx._alreadyProcessed = true;
+                return;
+              }
+              throw err;
+            }
           },
           compensate: async () => {
             const mongoDB = await connectDb();

--- a/lib/mongodb.js
+++ b/lib/mongodb.js
@@ -101,6 +101,13 @@ async function ensureIndexes(db) {
         { status: 1, createdAt: 1 },
         { background: true }
       ),
+      // Prevent duplicate attendance records for the same user on the same date.
+      // This is the database-level guard against race conditions when multiple
+      // concurrent requests try to mark attendance for the same student.
+      db.collection("attendance").createIndex(
+        { userId: 1, date: 1 },
+        { unique: true, background: true }
+      ),
     ]);
   } catch {
     // Index creation is best-effort

--- a/lib/services/attendanceService.js
+++ b/lib/services/attendanceService.js
@@ -62,9 +62,15 @@ export class AttendanceService {
       email ||
       "unknown@learnova.edu";
 
+    // Build a deterministic idempotency key from the attendance target + date.
+    // This lets the saga's pending_operations check catch duplicate requests
+    // even when they arrive concurrently from different API calls.
+    const idempotencyKey = `attendance:${targetUid}:${normalizedDate}`;
+
     const sagaResult = await executeSaga({
       operationType: "attendance_record",
       uid: decodedToken.uid,
+      idempotencyKey,
       steps: [
         {
           name: "write_attendance",
@@ -111,23 +117,34 @@ export class AttendanceService {
           execute: async (ctx) => {
             if (ctx._alreadyRecorded) return;
             const mongoDB = await connectDb();
-            await mongoDB.collection("attendance").updateOne(
-              { userId, date: normalizedDate },
-              {
-                $set: {
-                  userId,
-                  studentName: resolvedName,
-                  email: resolvedEmail,
-                  instituteId,
-                  timestamp: new Date(),
-                  date: normalizedDate,
-                  status: "present",
-                  confidenceScore: normalizedConfidence,
-                  offlineSynced: false,
+            try {
+              await mongoDB.collection("attendance").updateOne(
+                { userId, date: normalizedDate },
+                {
+                  $set: {
+                    userId,
+                    studentName: resolvedName,
+                    email: resolvedEmail,
+                    instituteId,
+                    timestamp: new Date(),
+                    date: normalizedDate,
+                    status: "present",
+                    confidenceScore: normalizedConfidence,
+                    offlineSynced: false,
+                  },
                 },
-              },
-              { upsert: true }
-            );
+                { upsert: true }
+              );
+            } catch (err) {
+              // E11000 = duplicate key error — another concurrent request already
+              // wrote this attendance record. Treat it as already recorded rather
+              // than failing the entire saga.
+              if (err?.code === 11000) {
+                ctx._alreadyRecorded = true;
+                return;
+              }
+              throw err;
+            }
           },
           compensate: async (ctx) => {
             if (ctx._alreadyRecorded) return;


### PR DESCRIPTION
## Description

This PR fixes the critical race condition in the attendance system that caused data corruption when multiple students marked attendance simultaneously.

### Changes Made

**`lib/mongodb.js`**
- Added unique index on `{userId, date}` in the `attendance` collection
- This is the database-level guard that prevents duplicate records even when concurrent requests bypass application-level checks

**`lib/services/attendanceService.js`**
- Added deterministic `idempotencyKey` (`attendance:{userId}:{date}`) passed to the saga
- This enables the saga's `pending_operations` check to catch duplicate requests
- Added E11000 duplicate key error handling in the MongoDB write step
- When a duplicate key error occurs, the request is treated as idempotent success rather than failing

**`app/api/attendance/sync/route.js`**
- Added E11000 duplicate key error handling in the MongoDB write step
- Handles the race condition where two concurrent sync requests try to write the same attendance record

### How It Works

The fix uses a three-layer defense against race conditions:

| Layer | Mechanism | Scope |
|-------|-----------|-------|
| 1 | Firestore document ID `{userId}_{date}` | Prevents duplicate Firestore records |
| 2 | Saga idempotency key | Catches duplicate requests before they reach the database |
| 3 | MongoDB unique index `{userId, date}` | Database-level guarantee against duplicates |

### Before vs After

| Scenario | Before | After |
|----------|--------|-------|
| Two concurrent requests for same user+date | Possible duplicate MongoDB records | Second request returns success (idempotent) |
| Offline sync batch with duplicates | In-memory Set dedup only | MongoDB unique index + E11000 handling |
| Saga retry after network timeout | Creates new idempotency key each time | Deterministic key ensures dedup works |

### Testing

- [ ] Mark attendance for same student twice simultaneously
- [ ] Verify offline sync handles duplicate records in batch
- [ ] Check MongoDB has no duplicate entries for same user+date
- [ ] Verify XP is only awarded once for duplicate requests

Fixes #3725
