### PR TITLE
fix(sync): resolve fatal TypeError due to incorrect logger import

### DIFF
--- a/utils/offlineSyncValidator.js
+++ b/utils/offlineSyncValidator.js
@@ -4,9 +4,7 @@
  * Prevents cheating through modified local data
  */
 
-import { createLogger } from "./logger";
-
-const logger = createLogger("offline-sync");
+import logger from "./logger";
 
 /**
  * Validates offline progress synchronization data


### PR DESCRIPTION
### Description
This pull request addresses a critical execution bug within the `utils/offlineSyncValidator.js` module. Previously, the file attempted to perform a named import `createLogger` from `utils/logger.js`, which only provided a default export. This mismatched import caused an immediate `TypeError: (0 , _logger.createLogger) is not a function` when the validator was loaded, entirely crashing the application process and rendering the fraud validation features for offline synchronization unusable.

### Changes Made
- Refactored `utils/offlineSyncValidator.js` to correctly import the default configured `winston` logger instance (`import logger from "./logger"`).
- Removed the broken `createLogger("offline-sync")` initialization call.

### Impact
This fix resolves the fatal crash, enabling the safe integration of `OfflineSyncValidator` across the codebase. With this bug resolved, the system can successfully leverage the offline sync fraud checks (e.g., massive XP gains, impossible progress jumps, timestamp tampering) to maintain platform integrity during offline data syncs.

### Related Issue
Resolves #3776 

@Premshaw23 please check this
