### PR TITLE
Feat: Emergency Broadcast Alert System via Notice Board

### DIFF
--- a/components/ClientLayout.js
+++ b/components/ClientLayout.js
@@ -9,6 +9,7 @@ import { normalizeStreakCount } from "@/lib/streakUtils";
 import ErrorBoundary from "@/components/ErrorBoundary";
 import ShortcutsModal from "@/components/ShortcutsModal";
 import SearchModal from "@/components/SearchModal";
+import EmergencyBanner from "@/components/EmergencyBanner";
 import { useAuth } from "@/hooks/useAuth";
 import { db } from "@/lib/firebaseConfig";
 import { doc, runTransaction } from "firebase/firestore";
@@ -374,6 +375,7 @@ export default function ClientLayout({ children }) {
 
   return (
     <>
+      <EmergencyBanner />
       {children}
 
       <InstallPWA />

--- a/components/EmergencyBanner.jsx
+++ b/components/EmergencyBanner.jsx
@@ -1,0 +1,78 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { useNotices } from "@/contexts/FirestoreContext";
+import { AlertTriangle, X } from "lucide-react";
+import { useAuth } from "@/hooks/useAuth";
+import { motion, AnimatePresence } from "framer-motion";
+
+export default function EmergencyBanner() {
+  const { notices, loading } = useNotices();
+  const { user } = useAuth();
+  const [acknowledgedIds, setAcknowledgedIds] = useState(new Set());
+
+  useEffect(() => {
+    if (!user?.uid) return;
+    try {
+      const saved = localStorage.getItem(`emergencyAck_${user.uid}`);
+      if (saved) {
+        setAcknowledgedIds(new Set(JSON.parse(saved)));
+      }
+    } catch (err) {
+      console.error("Failed to load acknowledged emergency notices", err);
+    }
+  }, [user]);
+
+  const handleAcknowledge = (id) => {
+    setAcknowledgedIds((prev) => {
+      const next = new Set(prev);
+      next.add(id);
+      try {
+        localStorage.setItem(`emergencyAck_${user?.uid || "anon"}`, JSON.stringify([...next]));
+      } catch (err) {}
+      return next;
+    });
+  };
+
+  if (loading || !notices) return null;
+
+  const emergencyNotices = notices.filter(
+    (n) => n.priority === "emergency" && !acknowledgedIds.has(n.id)
+  );
+
+  if (emergencyNotices.length === 0) return null;
+
+  return (
+    <div className="fixed top-0 left-0 right-0 z-[100] flex flex-col items-center w-full shadow-2xl">
+      <AnimatePresence>
+        {emergencyNotices.map((notice) => (
+          <motion.div
+            key={notice.id}
+            initial={{ opacity: 0, y: -50 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={{ opacity: 0, y: -50 }}
+            className="w-full bg-red-600 border-b border-red-700 p-3 sm:p-4 flex flex-col sm:flex-row items-start sm:items-center justify-between gap-3"
+          >
+            <div className="flex items-center gap-3 text-white flex-1 min-w-0">
+              <AlertTriangle className="h-6 w-6 flex-shrink-0 animate-pulse text-yellow-300" />
+              <div className="flex-1 min-w-0">
+                <p className="font-bold text-sm sm:text-base leading-tight truncate">
+                  EMERGENCY ALERT: {notice.title}
+                </p>
+                <p className="text-xs sm:text-sm text-red-100 truncate mt-0.5">
+                  {notice.content}
+                </p>
+              </div>
+            </div>
+            <button
+              onClick={() => handleAcknowledge(notice.id)}
+              className="bg-white/20 hover:bg-white/30 text-white border border-white/30 rounded-lg px-4 py-1.5 text-sm font-semibold transition-colors flex-shrink-0"
+            >
+              Acknowledge
+            </button>
+          </motion.div>
+        ))}
+      </AnimatePresence>
+    </div>
+  );
+}

--- a/components/NoticeFilters.jsx
+++ b/components/NoticeFilters.jsx
@@ -27,6 +27,7 @@ const PRIORITY_OPTIONS = [
   { id: "high", label: "High" },
   { id: "medium", label: "Medium" },
   { id: "low", label: "Low" },
+  { id: "emergency", label: "Emergency" },
 ];
 
 // Animated button component for consistency

--- a/components/NoticeForm.jsx
+++ b/components/NoticeForm.jsx
@@ -14,7 +14,7 @@ import toast from "react-hot-toast";
 
 const ROLES = ["student", "teacher", "institute", "admin", "staff"];
 const CATEGORIES = ["academic", "administrative", "financial", "general", "technical"];
-const PRIORITIES = ["low", "medium", "high"];
+const PRIORITIES = ["low", "medium", "high", "emergency"];
 
 export default function NoticeForm({ onClose, onSuccess }) {
   const [title, setTitle] = useState("");

--- a/pr_desc_3742.md
+++ b/pr_desc_3742.md
@@ -1,0 +1,11 @@
+### Is your feature request related to a problem? Please describe.
+I'm always frustrated when critical, time-sensitive alerts (like severe weather closures, campus security threats, or emergency evacuations) are buried in the standard Notice Board alongside routine announcements, delaying awareness for students and parents. (Resolves #3742)
+
+### Describe the solution you'd like
+I have added an "Emergency" priority level to the Notice Board system. When a notice is published with this priority, a persistent, non-dismissible red banner (`EmergencyBanner`) will instantly appear at the top of every dashboard across the Learnova platform, pushing immediate awareness to all targeted users. This banner persists until the user explicitly clicks the 'Acknowledge' button.
+
+### Describe alternatives you've considered
+I considered integrating an external SMS system for emergency broadcasts, but that fractures communication and reduces engagement on Learnova. By creating the `EmergencyBanner` component that leverages the existing real-time `FirestoreContext` stream, we achieve instantaneous web alerts natively within the app.
+
+### Additional Context
+By checking for unacknowledged 'emergency' notices centrally in `ClientLayout`, we guarantee that users see the alert immediately regardless of what dashboard or page they are currently browsing. Local storage is used safely to maintain the acknowledgment state per user session.

--- a/pr_desc_3743.md
+++ b/pr_desc_3743.md
@@ -1,0 +1,11 @@
+### Is your feature request related to a problem? Please describe.
+I'm always frustrated when students attempt to spoof the face recognition attendance system by showing a photograph or playing a video of themselves on their phones in front of the camera, leading to inaccurate attendance records and fraudulent check-ins. (Resolves #3743)
+
+### Describe the solution you'd like
+I have integrated an enhanced Liveness Detection check directly into the Face API.js flow. While blinking detection using Eye Aspect Ratio (EAR) was previously added, this update randomizes the challenge between a "Blink" challenge and a "Smile" challenge (using the `face.expressions` API). This minor randomized action verifies that a live person is in front of the camera before logging attendance.
+
+### Describe alternatives you've considered
+An alternative was requiring teachers to audit the automated attendance manually to catch spoofing attempts, or strictly using depth-sensing algorithms (which aren't universally supported on all student devices). The randomized expression/blink challenge works natively on any 2D camera through face-api.js.
+
+### Additional Context
+Spoofing is a critical vulnerability for any automated attendance system. Integrating this robust randomized liveness check ensures the integrity of the attendance data reported to the Parent and Institute dashboards.


### PR DESCRIPTION
### Is your feature request related to a problem? Please describe.
I'm always frustrated when critical, time-sensitive alerts (like severe weather closures, campus security threats, or emergency evacuations) are buried in the standard Notice Board alongside routine announcements, delaying awareness for students and parents. (Resolves #3742)

### Describe the solution you'd like
I have added an "Emergency" priority level to the Notice Board system. When a notice is published with this priority, a persistent, non-dismissible red banner (`EmergencyBanner`) will instantly appear at the top of every dashboard across the Learnova platform, pushing immediate awareness to all targeted users. This banner persists until the user explicitly clicks the 'Acknowledge' button.

### Describe alternatives you've considered
I considered integrating an external SMS system for emergency broadcasts, but that fractures communication and reduces engagement on Learnova. By creating the `EmergencyBanner` component that leverages the existing real-time `FirestoreContext` stream, we achieve instantaneous web alerts natively within the app.

### Additional Context
By checking for unacknowledged 'emergency' notices centrally in `ClientLayout`, we guarantee that users see the alert immediately regardless of what dashboard or page they are currently browsing. Local storage is used safely to maintain the acknowledgment state per user session.
