### PR TITLE
fix: remove duplicate ShortcutsModal instance from layout (#3186)

### DIFF
--- a/app/layout.js
+++ b/app/layout.js
@@ -50,7 +50,6 @@ import { siteStructuredData } from "@/lib/seo/siteStructuredData";
 
 // 🎯 FIX: Explicitly loading overlays
 import CommandPaletteWrapper from "@/components/CommandPaletteWrapper";
-import ShortcutsModal from "@/components/ShortcutsModal";
 
 // Validate environment variables at startup (server-side only).
 // ─── Environment validation (server-side only, runs once at startup) ─────────
@@ -370,8 +369,6 @@ export default async function RootLayout({ children }) {
             />
 
             <CommandPaletteWrapper />
-            {/* 🚀 ADDED: System Shortcuts Modal integration layer */}
-            <ShortcutsModal />
           </Suspense>
         </AllProviders>
         </NextIntlClientProvider>


### PR DESCRIPTION
Fixes #3186