### PR TITLE
Fix syncAttendanceQueue method calls

### DIFF
--- a/lib/syncService.js
+++ b/lib/syncService.js
@@ -4,6 +4,7 @@ import {
   removePendingAction,
 } from "@/db/offlineStore";
 import { logger } from "@/lib/logger";
+import { auth } from "@/lib/firebaseConfig";
 
 // ---------------------------------------------------------------------------
 // CONFLICT RESOLUTION ENGINE (Version Vectoring / Last-Write-Wins)
@@ -118,11 +119,13 @@ export async function syncSingleRecord(record, token) {
 export async function syncAttendanceQueue() {
   if (typeof window === "undefined") return;
   if (!navigator.onLine) return;
-  const records = await getOutboxRecords();
+
+  // Fix: was calling undefined getOutboxRecords() — use getPendingActions() from offlineStore
+  const records = await getPendingActions();
   if (records.length === 0) return;
 
   try {
-    const auth = getAuth();
+    // Fix: was calling undefined getAuth() — use the exported auth instance from firebaseConfig
     let tokenStr = "";
     if (auth && auth.currentUser) {
       tokenStr = await auth.currentUser.getIdToken();
@@ -139,10 +142,11 @@ export async function syncAttendanceQueue() {
     );
 
     // Clean up successfully synced records
+    // Fix: was calling undefined removeFromOutbox() — use removePendingAction() from offlineStore
     let syncedCount = 0;
     for (let i = 0; i < results.length; i++) {
       if (results[i]) {
-        await removeFromOutbox(records[i].id);
+        await removePendingAction(records[i].id);
         syncedCount++;
       }
     }


### PR DESCRIPTION
Updated syncAttendanceQueue to use correct methods for fetching pending actions and removing synced records.
Fixes #3732 