### PR TITLE
fix: implement fail-closed session validation when Redis is unavailable

### DIFF
--- a/lib/sessionManager.js
+++ b/lib/sessionManager.js
@@ -1,16 +1,31 @@
 import { getRedis } from "./redis";
 import { randomUUID } from "crypto";
+import { logger } from "./logger";
 
-// Returns true if session management should be bypassed
-function shouldBypass() {
+// Returns true if Redis credentials are not configured
+function isRedisConfigured() {
   return (
-    !process.env.UPSTASH_REDIS_REST_URL || !process.env.UPSTASH_REDIS_REST_TOKEN
+    process.env.UPSTASH_REDIS_REST_URL && process.env.UPSTASH_REDIS_REST_TOKEN
   );
 }
 
+// When true, allows session bypass if Redis is unavailable (fail-open).
+// Default: false (fail-closed — reject requests when Redis is down).
+function shouldBypassOnFailure() {
+  return process.env.SESSION_BYPASS_ON_FAILURE === "true";
+}
+
 export async function createSession(userId, metadata = {}) {
+  if (!isRedisConfigured()) {
+    if (shouldBypassOnFailure()) {
+      logger.warn("Session bypass: Redis not configured", { userId });
+      return "local-bypass-session";
+    }
+    logger.error("Session creation blocked: Redis not configured", { userId });
+    throw new Error("Session management unavailable");
+  }
+
   const redis = getRedis();
-  if (shouldBypass()) return "local-bypass-session";
 
   // Terminate concurrent sessions (prevent concurrent login)
   const existingSessions = await redis.smembers(`user:sessions:${userId}`);
@@ -38,7 +53,16 @@ export async function createSession(userId, metadata = {}) {
 }
 
 export async function validateSession(sessionId) {
-  if (shouldBypass() || sessionId === "local-bypass-session") return true;
+  if (!isRedisConfigured()) {
+    if (shouldBypassOnFailure() || sessionId === "local-bypass-session") {
+      return true;
+    }
+    logger.warn("Session validation failed: Redis not configured", {
+      sessionId,
+    });
+    return false;
+  }
+
   const redis = getRedis();
 
   const exists = await redis.exists(`session:${sessionId}`);
@@ -46,7 +70,7 @@ export async function validateSession(sessionId) {
 }
 
 export async function terminateSession(sessionId) {
-  if (shouldBypass() || sessionId === "local-bypass-session") return;
+  if (!isRedisConfigured() || sessionId === "local-bypass-session") return;
   const redis = getRedis();
 
   const sessionData = await redis.get(`session:${sessionId}`);
@@ -63,7 +87,7 @@ export async function terminateSession(sessionId) {
 }
 
 export async function terminateAllUserSessions(userId) {
-  if (shouldBypass()) return;
+  if (!isRedisConfigured()) return;
   const redis = getRedis();
 
   const existingSessions = await redis.smembers(`user:sessions:${userId}`);

--- a/middleware.js
+++ b/middleware.js
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import * as jose from "jose";
 import { getRedis } from "@/lib/redis";
 import { validateCsrfOriginAndReferer, validateCsrfRequest } from "@/lib/csrf";
+import { logger } from "@/lib/logger";
 
 const FIREBASE_PROJECT_ID = process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID;
 const FIREBASE_AUTH_DOMAIN = process.env.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN;
@@ -561,9 +562,33 @@ export async function middleware(request) {
               { status: 401 }
             );
           }
+        } else {
+          // Redis unavailable
+          if (process.env.SESSION_BYPASS_ON_FAILURE === "true") {
+            logger.warn("Session bypass: Redis unavailable", { sessionId });
+          } else {
+            logger.error("Session validation blocked: Redis unavailable", {
+              sessionId,
+            });
+            return NextResponse.json(
+              { error: "Session management temporarily unavailable" },
+              { status: 503 }
+            );
+          }
         }
       } catch {
-        // Redis unavailable — continue without session validation
+        // Redis connection error
+        if (process.env.SESSION_BYPASS_ON_FAILURE === "true") {
+          logger.warn("Session bypass: Redis connection error", { sessionId });
+        } else {
+          logger.error("Session validation blocked: Redis connection error", {
+            sessionId,
+          });
+          return NextResponse.json(
+            { error: "Session management temporarily unavailable" },
+            { status: 503 }
+          );
+        }
       }
     }
   }


### PR DESCRIPTION
## Summary

When Redis is unavailable, the session manager and middleware silently bypass all session validation (fail-open). This allows expired, revoked, or stolen tokens to remain valid during Redis outages, creating a significant security vulnerability.

## Changes

- **`lib/sessionManager.js`**:
  - Renamed `shouldBypass()` to `isRedisConfigured()` for clarity
  - Added `shouldBypassOnFailure()` to check `SESSION_BYPASS_ON_FAILURE` env var
  - Default behavior is now fail-closed (reject requests when Redis is down)
  - Added structured logging for all session bypass/block events

- **`middleware.js`**:
  - Updated session validation to handle Redis failures explicitly
  - Returns 503 Service Unavailable when Redis is down (default behavior)
  - Logs warning when `SESSION_BYPASS_ON_FAILURE=true` is set

## Configuration

| Environment Variable | Default | Description |
|---------------------|---------|-------------|
| `SESSION_BYPASS_ON_FAILURE` | `false` | When `true`, preserves legacy bypass behavior. When `false`, rejects requests if Redis is unavailable. |

## Behavior

| Scenario | `SESSION_BYPASS_ON_FAILURE=false` (default) | `SESSION_BYPASS_ON_FAILURE=true` |
|----------|---------------------------------------------|----------------------------------|
| Redis configured & healthy | Normal session validation | Normal session validation |
| Redis configured but unavailable | 503 Service Unavailable | Bypass with warning log |
| Redis not configured | Session creation blocked | Bypass with warning log |

## Impact

- **Default (fail-closed)**: Requests are rejected with 503 when Redis is unavailable, preventing token reuse attacks
- **Opt-in (fail-open)**: Set `SESSION_BYPASS_ON_FAILURE=true` to preserve legacy behavior for environments where availability is prioritized over security
- All bypass events are logged for monitoring and alerting

## Testing

Session-related tests pass. The changes are backward-compatible when `SESSION_BYPASS_ON_FAILURE=true` is set.

Fixes #3830
