### PR TITLE
fix: change rate limiter to fail-closed on errors

### DIFF
--- a/lib/rateLimit.js
+++ b/lib/rateLimit.js
@@ -200,6 +200,10 @@ function isValidPublicIp(ip) {
 // ============================================================================
 /**
  * Optional Wrapper for easy injection into standard API routes.
+ *
+ * When the rate limiter encounters an unexpected error:
+ * - Default (fail-closed): Returns 503 Service Unavailable
+ * - Opt-in (fail-open): Set RATE_LIMIT_FAIL_OPEN=true to let requests through
  */
 export const rateLimitMiddleware = async (req, res, next) => {
   try {
@@ -220,7 +224,18 @@ export const rateLimitMiddleware = async (req, res, next) => {
     next();
   } catch (error) {
     logger.error('[RateLimiter Middleware Error]', error);
-    // Fail open: let the request through if the entire limiter crashes
-    next();
+
+    if (process.env.RATE_LIMIT_FAIL_OPEN === 'true') {
+      // Fail open: let the request through if the entire limiter crashes
+      // Only use this in development or when availability is critical
+      logger.warn('[RateLimiter] Fail-open mode enabled, allowing request');
+      next();
+    } else {
+      // Fail closed: reject the request if rate limiting cannot be enforced
+      res.status(503).json({
+        error: 'Service Unavailable',
+        message: 'Rate limiting service is temporarily unavailable. Please try again later.',
+      });
+    }
   }
 };


### PR DESCRIPTION
## Summary

The `rateLimitMiddleware` in `lib/rateLimit.js` had fail-open behavior — when the entire limiter crashed, it called `next()` and let requests through without any rate limiting. This allowed brute force attacks during rate limiter failures.

## Changes

- **`lib/rateLimit.js`**:
  - Default behavior is now fail-closed (returns 503 Service Unavailable on errors)
  - Added `RATE_LIMIT_FAIL_OPEN` environment variable for opt-in fail-open behavior
  - Added structured logging for fail-open/fail-closed decisions

## Configuration

| Environment Variable | Default | Description |
|---------------------|---------|-------------|
| `RATE_LIMIT_FAIL_OPEN` | `false` | When `true`, preserves legacy fail-open behavior. When `false`, rejects requests if rate limiter crashes. |

## Behavior

| Scenario | `RATE_LIMIT_FAIL_OPEN=false` (default) | `RATE_LIMIT_FAIL_OPEN=true` |
|----------|----------------------------------------|------------------------------|
| Rate limiter healthy | Normal rate limiting | Normal rate limiting |
| Rate limiter crashes | 503 Service Unavailable | Request allowed through |

## Impact

- **Default (fail-closed)**: Requests are rejected with 503 when the rate limiter crashes, preventing brute force attacks
- **Opt-in (fail-open)**: Set `RATE_LIMIT_FAIL_OPEN=true` to preserve legacy behavior for environments where availability is critical
- All fail-open/fail-closed decisions are logged for monitoring

## Testing

All lib and middleware tests pass (156 + 14 tests).

Fixes #3831
