### PR TITLE
fix: remove BOM from package.json to fix CI failures

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "name": "learnova",
   "version": "1.0.0",
   "description": "AI-Powered Smart Student Engagement & Attendance Platform",


### PR DESCRIPTION
## Summary

The `package.json` file contained a UTF-8 BOM (Byte Order Mark) at the beginning, causing `npm ci` to fail with a JSON parse error in CI. This was blocking all CI checks on PR #3837.

## Changes

- **`package.json`**:
  - Removed UTF-8 BOM (`EF BB BF`) from the beginning of the file
  - File is now valid JSON and can be parsed by npm

## Impact

- All CI checks (build, test, verify) were failing due to this BOM character
- After this fix, CI can properly install dependencies and run checks
- This unblocks PR #3837 (rate limiter fail-closed fix)

## Testing

- Verified `package.json` is valid JSON after the fix
- Verified npm dependencies can be installed

Fixes #3831
