### PR TITLE
fix: remove duplicate ShortcutsModal instance from layout (#3186)

### DIFF
--- a/app/layout.js
+++ b/app/layout.js
@@ -50,7 +50,6 @@ import { siteStructuredData } from "@/lib/seo/siteStructuredData";
 
 // 🎯 FIX: Explicitly loading overlays
 import CommandPaletteWrapper from "@/components/CommandPaletteWrapper";
-import ShortcutsModal from "@/components/ShortcutsModal";
 
 // Validate environment variables at startup (server-side only).
 // ─── Environment validation (server-side only, runs once at startup) ─────────
@@ -370,8 +369,6 @@ export default async function RootLayout({ children }) {
             />
 
             <CommandPaletteWrapper />
-            {/* 🚀 ADDED: System Shortcuts Modal integration layer */}
-            <ShortcutsModal />
           </Suspense>
         </AllProviders>
         </NextIntlClientProvider>


### PR DESCRIPTION
## Description
The root layout was rendering ShortcutsModal **twice** — once directly in layout.js and once inside ClientLayout.js. This caused stacked modals, duplicate event listeners, and broken dismissal behavior.

## Changes Made
- Removed the duplicate \ShortcutsModal\ import from layout.js (line 54)
- Removed the duplicate \ShortcutsModal\ JSX usage from the root layout JSX (lines 370-373)
- \CommandPaletteWrapper\ already handles its own internal state — the extra \ShortcutsModal\ was redundant since \ClientLayout.js\ already renders it

## Impact
- Fixes stacked modal overlays when pressing keyboard shortcuts
- Eliminates duplicate DOM rendering overhead
- Single event listener for modal interactions
- Proper modal dismissal behavior restored

Fixes #3186