### PR TITLE
fix(#3674): use requireAdmin instead of requireAuth in admin session terminate route

### DIFF
--- a/app/api/admin/sessions/terminate/route.js
+++ b/app/api/admin/sessions/terminate/route.js
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 import { withErrorHandler, parseJSON } from "@/lib/error-handler";
-import { requireAuth } from "@/lib/rbac";
+import { requireAdmin } from "@/lib/rbac";
 import { terminateAllUserSessions } from "@/lib/sessionManager";
 import { logAuditEvent } from "@/lib/auditLogger";
 
@@ -8,7 +8,7 @@ export const dynamic = "force-dynamic";
 
 export const POST = withErrorHandler(async (request) => {
   // Only admins can forcibly terminate sessions for other users
-  const decodedToken = await requireAuth(request);
+  const { payload: decodedToken } = await requireAdmin(request);
 
   const body = await parseJSON(request);
   const { targetUserId } = body;


### PR DESCRIPTION
## Description

The admin session termination endpoint \pp/api/admin/sessions/terminate/route.js\ was using \equireAuth()\ which only checks that the user is authenticated — not that they have the \dmin\ role. This meant any authenticated user could potentially terminate other users' sessions.

## Related Issue

Fixes #3674

## Changes

- Changed import from \equireAuth\ to \equireAdmin\
- Updated usage to destructure \{ payload: decodedToken }\ since \equireAdmin\ returns \{ payload, profile }\ instead of the raw payload

Now only users with the \dmin\ role can terminate sessions for other users, matching the comment that was already in the code.