### PR TITLE
fix(#3786): add resource.id constraint to Firestore user document security rules

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -19,8 +19,8 @@ service cloud.firestore {
     // Users can read their own profile; teachers can read all profiles for class management
     // Users can only edit their own profile
     match /users/{userId} {
-      allow read: if isAuthenticated() && (request.auth.uid == userId || isTeacher());
-      allow write: if isAuthenticated() && request.auth.uid == userId;
+      allow read: if isAuthenticated() && request.auth.uid == resource.id && (request.auth.uid == userId || isTeacher());
+      allow write: if isAuthenticated() && request.auth.uid == resource.id && request.auth.uid == userId;
     }
 
     // Courses Collection


### PR DESCRIPTION
## Description

Added \equest.auth.uid == resource.id\ constraint to both read and write rules for user documents in \irestore.rules\. This ensures the actual document ID being accessed matches the authenticated user's UID, preventing access when the path wildcard and resource ID are inconsistent.

## Related Issue

Fixes #3786

## Changes

- Read rule: \equest.auth.uid == resource.id\ added alongside existing checks
- Write rule: \equest.auth.uid == resource.id\ added alongside existing checks