### PR TITLE
fix(#3787): add loading skeleton states for key routes to prevent blank screens

### DIFF
--- a/app/StudyAI/loading.jsx
+++ b/app/StudyAI/loading.jsx
@@ -1,0 +1,31 @@
+"use client";
+import React from "react";
+import Skeleton from "@/components/ui/Skeleton";
+
+export default function StudyAILoading() {
+  return (
+    <div className="min-h-screen bg-gradient-to-b from-gray-950 via-gray-900 to-gray-950 p-6 space-y-6">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-4">
+          <Skeleton className="h-10 w-10 rounded-xl bg-slate-800/80" />
+          <div className="space-y-2">
+            <Skeleton className="h-6 w-40 bg-slate-800/80" />
+            <Skeleton className="h-4 w-64 bg-slate-800/50" />
+          </div>
+        </div>
+        <Skeleton className="h-10 w-28 bg-slate-800/60 rounded-xl" />
+      </div>
+      <div className="grid grid-cols-1 lg:grid-cols-4 gap-6">
+        <div className="lg:col-span-1 space-y-3">
+          {Array.from({ length: 4 }).map((_, i) => (
+            <Skeleton key={i} className="h-16 w-full bg-slate-800/60 rounded-xl" />
+          ))}
+        </div>
+        <div className="lg:col-span-3 space-y-4">
+          <Skeleton className="h-64 w-full bg-slate-800/70 rounded-2xl" />
+          <Skeleton className="h-32 w-full bg-slate-800/50 rounded-2xl" />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/activity/loading.jsx
+++ b/app/activity/loading.jsx
@@ -1,0 +1,26 @@
+"use client";
+import React from "react";
+import Skeleton from "@/components/ui/Skeleton";
+
+export default function ActivityLoading() {
+  return (
+    <div className="min-h-screen bg-gradient-to-b from-gray-950 via-gray-900 to-gray-950 p-6 space-y-6">
+      <div className="flex items-center justify-between">
+        <Skeleton className="h-8 w-40 bg-slate-800/80" />
+        <Skeleton className="h-10 w-28 bg-slate-800/60 rounded-xl" />
+      </div>
+      <div className="space-y-4">
+        {Array.from({ length: 6 }).map((_, i) => (
+          <div key={i} className="flex items-center gap-4 bg-black/40 backdrop-blur-xl border border-white/10 rounded-2xl p-4">
+            <Skeleton className="w-10 h-10 rounded-full bg-slate-800/80 shrink-0" />
+            <div className="flex-1 space-y-2">
+              <Skeleton className="h-4 w-3/4 bg-slate-800/80" />
+              <Skeleton className="h-3 w-1/2 bg-slate-800/50" />
+            </div>
+            <Skeleton className="h-8 w-20 bg-slate-800/60 rounded-lg" />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/app/leaderboards/loading.jsx
+++ b/app/leaderboards/loading.jsx
@@ -1,0 +1,27 @@
+"use client";
+import React from "react";
+import Skeleton from "@/components/ui/Skeleton";
+
+export default function LeaderboardsLoading() {
+  return (
+    <div className="min-h-screen bg-gradient-to-b from-gray-950 via-gray-900 to-gray-950 p-6 space-y-6">
+      <div className="flex items-center justify-between">
+        <Skeleton className="h-8 w-48 bg-slate-800/80" />
+        <Skeleton className="h-10 w-32 bg-slate-800/60 rounded-xl" />
+      </div>
+      <div className="grid gap-4">
+        {Array.from({ length: 8 }).map((_, i) => (
+          <div key={i} className="flex items-center gap-4 bg-black/40 backdrop-blur-xl border border-white/10 rounded-2xl p-4">
+            <Skeleton className="w-8 h-8 rounded-full bg-slate-800/60 shrink-0" />
+            <Skeleton className="w-12 h-12 rounded-full bg-slate-800/80 shrink-0" />
+            <div className="flex-1 space-y-2">
+              <Skeleton className="h-5 w-40 bg-slate-800/80" />
+              <Skeleton className="h-3 w-24 bg-slate-800/50" />
+            </div>
+            <Skeleton className="h-8 w-16 bg-slate-800/60 rounded-lg" />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/app/notices/loading.jsx
+++ b/app/notices/loading.jsx
@@ -1,0 +1,27 @@
+"use client";
+import React from "react";
+import Skeleton from "@/components/ui/Skeleton";
+
+export default function NoticesLoading() {
+  return (
+    <div className="min-h-screen bg-gradient-to-b from-gray-950 via-gray-900 to-gray-950 p-6 space-y-6">
+      <div className="flex items-center justify-between">
+        <Skeleton className="h-8 w-48 bg-slate-800/80" />
+        <Skeleton className="h-10 w-32 bg-slate-800/60 rounded-xl" />
+      </div>
+      <div className="grid gap-4">
+        {Array.from({ length: 5 }).map((_, i) => (
+          <div key={i} className="bg-black/40 backdrop-blur-xl border border-white/10 rounded-2xl p-6 space-y-3">
+            <Skeleton className="h-6 w-3/4 bg-slate-800/80" />
+            <Skeleton className="h-4 w-full bg-slate-800/50" />
+            <Skeleton className="h-4 w-2/3 bg-slate-800/50" />
+            <div className="flex gap-2 pt-2">
+              <Skeleton className="h-6 w-16 bg-slate-800/60 rounded-full" />
+              <Skeleton className="h-6 w-20 bg-slate-800/60 rounded-full" />
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/app/profile/loading.jsx
+++ b/app/profile/loading.jsx
@@ -1,0 +1,26 @@
+"use client";
+import React from "react";
+import Skeleton from "@/components/ui/Skeleton";
+
+export default function ProfileLoading() {
+  return (
+    <div className="min-h-screen bg-gradient-to-b from-gray-950 via-gray-900 to-gray-950 p-6 space-y-6">
+      <div className="flex items-center gap-6">
+        <Skeleton className="w-20 h-20 rounded-full bg-slate-800/80" />
+        <div className="space-y-2">
+          <Skeleton className="h-7 w-48 bg-slate-800/80" />
+          <Skeleton className="h-4 w-32 bg-slate-800/50" />
+        </div>
+      </div>
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <div key={i} className="bg-black/40 backdrop-blur-xl border border-white/10 rounded-2xl p-6 space-y-3">
+            <Skeleton className="h-5 w-32 bg-slate-800/80" />
+            <Skeleton className="h-4 w-full bg-slate-800/50" />
+            <Skeleton className="h-4 w-3/4 bg-slate-800/50" />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Description

Added loading.jsx files for 5 routes (StudyAI, activity, leaderboards, notices, profile) to show shimmer-animated skeleton placeholders while data is being fetched. This prevents users from seeing a blank white screen during page loads.

## Related Issue

Fixes #3787

## Changes

Added 5 new files:
- \pp/StudyAI/loading.jsx\ - Skeleton layout matching the StudyAI sidebar + content panel
- \pp/activity/loading.jsx\ - Skeleton card list for activity feed
- \pp/leaderboards/loading.jsx\ - Skeleton leaderboard rows with avatars
- \pp/notices/loading.jsx\ - Skeleton notice cards with tags
- \pp/profile/loading.jsx\ - Skeleton profile header + info cards

Each loading.jsx uses the existing \Skeleton\ component from \components/ui/Skeleton.jsx\ with the built-in shimmer animation.