### PR TITLE
docs: fix invalid git clone command and broken local file path

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ learnova/
 ### 1. Clone the repository
 
 ```bash
-git clone [https://github.com/Premshaw23/Learnova.git](https://github.com/Premshaw23/Learnova.git)
+git clone https://github.com/Premshaw23/Learnova.git
 cd Learnova
 ```
 
@@ -442,7 +442,7 @@ Found a security vulnerability? Please report it responsibly to **security@learn
 
 ## 🏗️ System Architecture Blueprint
 
-Want to learn more about how Learnova's underlying technology behaves under the hood? Read our detailed, Mermaid-enhanced [System Architecture Guide](file:///e:/Learnova/Learnova/docs/ARCHITECTURE.md) to understand routing middleware verification, neural network face detection thresholds, and offline PWA queues.
+Want to learn more about how Learnova's underlying technology behaves under the hood? Read our detailed, Mermaid-enhanced [System Architecture Guide](docs/ARCHITECTURE.md) to understand routing middleware verification, neural network face detection thresholds, and offline PWA queues.
 
 ### 🛠️ Documentation Improvements
 - Add badges (optional): build, license, contributors


### PR DESCRIPTION
## Description
This PR resolves two documentation bugs that cause friction for new contributors:
1. **Invalid Git Clone Command:** The URL in the `git clone` bash block was wrapped in Markdown hyperlink syntax. Copy-pasting this caused a terminal error. I removed the markdown formatting to make the command strictly copy-pasteable.
2. **Broken Local File Path:** The link to the System Architecture Guide at the bottom of the README pointed to a local user directory (`file:///e:/...`), which resulted in a broken link on GitHub. I updated this to use a proper relative repository path (`docs/ARCHITECTURE.md`).

## Related Issue(s)
Fixes #None (just a documentation fix)

## Type of Change
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Refactoring (code improvement without functional change)
- [x] 📝 Documentation update
- [ ] 🚨 Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Architecture Impact
- [ ] 🖥️ Frontend (React / Web Dashboard)
- [ ] ☁️ AWS Pipeline / Backend
- [ ] 💻 Electron Desktop App

## Checklist:
- [x] My code follows the Contributing Guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have tested these changes locally and they generate no new warnings or errors.
- [x] I have NOT bypassed the AWS pipeline or hardcoded mock data in production builds.
- [x] I have checked that mobile responsiveness is maintained (if making UI changes).

## Screenshots (if applicable)
None