### PR TITLE
fix(attendance): stop double-normalizing confidenceScore in recordAttendance

### DIFF
--- a/app/api/attendance/record/route.js
+++ b/app/api/attendance/record/route.js
@@ -54,7 +54,7 @@ export const POST = withErrorHandler(
           userId,
           studentName,
           email,
-          confidenceScore: normalizedConfidence,
+          normalizedConfidenceScore: normalizedConfidence,
           normalizedDate,
         },
         token

--- a/lib/services/__tests__/attendanceService.confidence.test.js
+++ b/lib/services/__tests__/attendanceService.confidence.test.js
@@ -1,0 +1,126 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { AttendanceService } from "../attendanceService";
+import { initFirebaseAdmin, getUserProfile } from "@/lib/firebase-admin";
+import { getFirestore, FieldValue } from "firebase-admin/firestore";
+import { connectDb } from "@/lib/mongodb";
+import { awardXp } from "@/lib/gamification-service";
+import { publishEvent } from "@/lib/ssePublisher";
+
+vi.mock("@/lib/firebase-admin", () => ({
+  initFirebaseAdmin: vi.fn(),
+  getUserProfile: vi.fn(),
+}));
+
+vi.mock("firebase-admin/firestore", () => ({
+  getFirestore: vi.fn(),
+  FieldValue: {
+    serverTimestamp: vi.fn(() => "server-timestamp"),
+  },
+}));
+
+vi.mock("@/lib/mongodb", () => ({
+  connectDb: vi.fn(),
+}));
+
+vi.mock("@/lib/gamification-service", () => ({
+  awardXp: vi.fn().mockResolvedValue({}),
+}));
+
+vi.mock("@/lib/ssePublisher", () => ({
+  publishEvent: vi.fn().mockResolvedValue({}),
+}));
+
+describe("AttendanceService.recordAttendance — confidence normalization", () => {
+  let docRef;
+  let collectionRef;
+  let transactionSet;
+  let transactionGet;
+  let mongoUpdateOne;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    getUserProfile.mockResolvedValue({
+      fullName: "Test Student",
+      email: "student@example.com",
+      instituteId: "inst-1",
+      role: "student",
+    });
+
+    docRef = {};
+    collectionRef = { doc: vi.fn(() => docRef) };
+    transactionGet = vi.fn().mockResolvedValue({ exists: false });
+    transactionSet = vi.fn();
+
+    getFirestore.mockReturnValue({
+      runTransaction: vi.fn(async (callback) =>
+        callback({ get: transactionGet, set: transactionSet })
+      ),
+      collection: vi.fn(() => collectionRef),
+    });
+
+    mongoUpdateOne = vi.fn().mockResolvedValue({});
+    connectDb.mockResolvedValue({
+      collection: vi.fn(() => ({ updateOne: mongoUpdateOne })),
+    });
+
+    publishEvent.mockReturnValue({ catch: vi.fn() });
+  });
+
+  it.each([
+    { raw: 85, normalized: 0.85 },
+    { raw: 60, normalized: 0.6 },
+    { raw: 100, normalized: 1 },
+  ])(
+    "persists confidenceScore=$normalized (not double-divided) for raw=$raw, in both Firestore and MongoDB",
+    async ({ raw, normalized }) => {
+      // Mirrors what app/api/attendance/record/route.js now sends:
+      // a single, already-normalized 0-1 value under `normalizedConfidenceScore`.
+      const normalizedConfidenceScore = raw / 100;
+
+      await AttendanceService.recordAttendance(
+        {
+          userId: "user-123",
+          studentName: "Client Name",
+          email: "client@example.com",
+          normalizedConfidenceScore,
+          normalizedDate: "2026-05-25",
+        },
+        { uid: "user-123", role: "student" }
+      );
+
+      expect(transactionSet).toHaveBeenCalledWith(
+        docRef,
+        expect.objectContaining({ confidenceScore: normalized }),
+        { merge: true }
+      );
+
+      expect(mongoUpdateOne).toHaveBeenCalledWith(
+        { userId: "user-123", date: "2026-05-25" },
+        expect.objectContaining({
+          $set: expect.objectContaining({ confidenceScore: normalized }),
+        }),
+        { upsert: true }
+      );
+    }
+  );
+
+  it("does not re-divide an already-normalized confidence score by 100", async () => {
+    // Regression guard for the original bug: raw=85 -> route normalizes to 0.85
+    // -> service must persist 0.85, never 0.0085.
+    await AttendanceService.recordAttendance(
+      {
+        userId: "user-123",
+        studentName: "Client Name",
+        email: "client@example.com",
+        normalizedConfidenceScore: 0.85,
+        normalizedDate: "2026-05-25",
+      },
+      { uid: "user-123", role: "student" }
+    );
+
+    const [, firestorePayload] = transactionSet.mock.calls[0];
+    expect(firestorePayload.confidenceScore).toBe(0.85);
+    expect(firestorePayload.confidenceScore).not.toBeCloseTo(0.0085);
+  });
+});

--- a/lib/services/attendanceService.js
+++ b/lib/services/attendanceService.js
@@ -8,11 +8,10 @@ import { publishEvent } from "@/lib/ssePublisher";
 
 export class AttendanceService {
   static async recordAttendance(data, decodedToken) {
-    const { userId, studentName, email, confidenceScore, normalizedDate } =
-      data;
+    const { userId, studentName, email, normalizedConfidenceScore, 
+      normalizedDate, } = data;
 
-    const parsedConfidence = Number(confidenceScore);
-    const normalizedConfidence = parsedConfidence / 100;
+    const normalizedConfidence = Number(normalizedConfidenceScore);
 
     initFirebaseAdmin();
     const db = getFirestore();


### PR DESCRIPTION
## Problem
`POST /api/attendance/record` normalizes `confidenceScore` to a 0–1 range in the route, then passes that already-normalized value into `AttendanceService.recordAttendance()`, which independently divides by 100 again. A raw score of 85 ends up persisted as `0.0085` instead of `0.85` in both `attendance_records` (Firestore) and `attendance` (MongoDB), breaking any downstream logic comparing against a 0–1 threshold.

The offline sync path (`normalizeConfidenceScore` in `app/api/attendance/sync/route.js`) does not have this bug, creating inconsistent `confidenceScore` semantics between online and offline-synced records in the same collections.

## Fix
Establish a single normalization boundary at the route layer:
- Route continues to normalize once (`parsedConfidence / 100`) and now passes the result as `normalizedConfidenceScore` — an explicit name documenting the expected scale.
- `AttendanceService.recordAttendance()` no longer re-divides; it consumes `normalizedConfidenceScore` directly as the already-correct 0–1 value.

## Tests
Added `lib/services/__tests__/attendanceService.confidence.test.js`:
- Parametrized cases for raw scores 60, 85, 100 → asserts persisted `confidenceScore` in both the Firestore transaction write and the MongoDB `updateOne` write.
- An explicit regression test asserting `0.85` is persisted (not `0.0085`) for an already-normalized input.

Existing `app/api/attendance/record/route.test.js` assertions (`confidenceScore: 0.75`, `0.8`) now pass against the real (unmocked) service.

Closes #3801