### PR TITLE
fix(quiz-sessions): close TOCTOU race in answer/submit completion checks

### DIFF
--- a/app/api/quiz-sessions/answer/__tests__/route.test.js
+++ b/app/api/quiz-sessions/answer/__tests__/route.test.js
@@ -1,0 +1,135 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { POST } from "../route";
+import { connectDb } from "@/lib/mongodb";
+import { requireAuth } from "@/lib/rbac";
+
+vi.mock("@/lib/mongodb", () => ({
+  connectDb: vi.fn(),
+}));
+
+vi.mock("@/lib/rbac", () => ({
+  requireAuth: vi.fn(),
+}));
+
+const FUTURE_DATE = new Date(Date.now() + 60 * 60 * 1000);
+
+function createMockRequest(body) {
+  return {
+    json: vi.fn().mockResolvedValue(body),
+  };
+}
+
+describe("POST /api/quiz-sessions/answer — completion race guard", () => {
+  let findOneSession;
+  let findOneQuiz;
+  let updateOne;
+  let db;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    requireAuth.mockResolvedValue({ uid: "user-123" });
+
+    findOneSession = vi.fn().mockResolvedValue({
+      _id: "session-1",
+      userId: "user-123",
+      quizId: "quiz-1",
+      expiresAt: FUTURE_DATE,
+      completed: false,
+      answers: {},
+    });
+
+    findOneQuiz = vi.fn().mockResolvedValue({
+      _id: "quiz-1",
+      questions: [{ _id: "q1", correctAnswer: "A" }],
+    });
+
+    updateOne = vi.fn().mockResolvedValue({ matchedCount: 1 });
+
+    db = {
+      collection: vi.fn((name) => {
+        if (name === "quiz_sessions") {
+          return { findOne: findOneSession, updateOne };
+        }
+        if (name === "quizzes") {
+          return { findOne: findOneQuiz };
+        }
+        throw new Error(`Unexpected collection: ${name}`);
+      }),
+    };
+
+    connectDb.mockResolvedValue(db);
+  });
+
+  it("includes completed: { $ne: true } in the updateOne filter (atomic guard)", async () => {
+    const req = createMockRequest({
+      sessionId: "session-1",
+      questionId: "q1",
+      answer: "A",
+    });
+
+    await POST(req);
+
+    expect(updateOne).toHaveBeenCalledWith(
+      { _id: "session-1", completed: { $ne: true } },
+      expect.objectContaining({ $set: expect.any(Object) })
+    );
+  });
+
+  it("records the answer successfully when the session is still open", async () => {
+    const req = createMockRequest({
+      sessionId: "session-1",
+      questionId: "q1",
+      answer: "A",
+    });
+
+    const response = await POST(req);
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toEqual({ success: true, message: "Answer recorded" });
+  });
+
+  it("rejects with 'Quiz already submitted' if the session was completed concurrently (matchedCount 0)", async () => {
+    // Simulates the TOCTOU race: the application-level `session.completed`
+    // read-check passed (false), but a concurrent /submit call completed the
+    // session between the read and this write, so the atomic filter no
+    // longer matches.
+    updateOne.mockResolvedValue({ matchedCount: 0 });
+
+    const req = createMockRequest({
+      sessionId: "session-1",
+      questionId: "q1",
+      answer: "A",
+    });
+
+    const response = await POST(req);
+    const body = await response.json();
+
+    expect(response.status).toBe(403);
+    expect(body).toEqual({ error: "Quiz already submitted" });
+  });
+
+  it("still rejects up front via the application-level check when completed is already true", async () => {
+    findOneSession.mockResolvedValue({
+      _id: "session-1",
+      userId: "user-123",
+      quizId: "quiz-1",
+      expiresAt: FUTURE_DATE,
+      completed: true,
+      answers: {},
+    });
+
+    const req = createMockRequest({
+      sessionId: "session-1",
+      questionId: "q1",
+      answer: "A",
+    });
+
+    const response = await POST(req);
+    const body = await response.json();
+
+    expect(response.status).toBe(403);
+    expect(body).toEqual({ error: "Quiz already submitted" });
+    expect(updateOne).not.toHaveBeenCalled();
+  });
+});

--- a/app/api/quiz-sessions/answer/route.js
+++ b/app/api/quiz-sessions/answer/route.js
@@ -57,8 +57,8 @@ export const POST = withErrorHandler(async (req) => {
     );
   }
 
-  await db.collection("quiz_sessions").updateOne(
-    { _id: sessionId },
+  const updateResult = await db.collection("quiz_sessions").updateOne(
+    { _id: sessionId, completed: { $ne: true } },
     {
       $set: {
         [`answers.${questionId}`]: answer,
@@ -66,6 +66,13 @@ export const POST = withErrorHandler(async (req) => {
       },
     }
   );
+
+  if (updateResult.matchedCount === 0) {
+    return new Response(JSON.stringify({ error: "Quiz already submitted" }), {
+      status: 403,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
 
   return new Response(
     JSON.stringify({

--- a/app/api/quiz-sessions/submit/__test__/route.test.js
+++ b/app/api/quiz-sessions/submit/__test__/route.test.js
@@ -1,0 +1,127 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { POST } from "../route";
+import { connectDb } from "@/lib/mongodb";
+import { requireAuth } from "@/lib/rbac";
+
+vi.mock("@/lib/mongodb", () => ({
+  connectDb: vi.fn(),
+}));
+
+vi.mock("@/lib/rbac", () => ({
+  requireAuth: vi.fn(),
+}));
+
+const FUTURE_DATE = new Date(Date.now() + 60 * 60 * 1000);
+
+function createMockRequest(body) {
+  return {
+    json: vi.fn().mockResolvedValue(body),
+  };
+}
+
+describe("POST /api/quiz-sessions/submit — completion race guard", () => {
+  let findOneSession;
+  let findOneQuiz;
+  let updateOne;
+  let db;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    requireAuth.mockResolvedValue({ uid: "user-123" });
+
+    findOneSession = vi.fn().mockResolvedValue({
+      _id: "session-1",
+      userId: "user-123",
+      quizId: "quiz-1",
+      expiresAt: FUTURE_DATE,
+      completed: false,
+      answers: { q1: "A", q2: "B" },
+    });
+
+    findOneQuiz = vi.fn().mockResolvedValue({
+      _id: "quiz-1",
+      passingScore: 70,
+      questions: [
+        { _id: "q1", correctAnswer: "A" },
+        { _id: "q2", correctAnswer: "wrong" },
+      ],
+    });
+
+    updateOne = vi.fn().mockResolvedValue({ matchedCount: 1 });
+
+    db = {
+      collection: vi.fn((name) => {
+        if (name === "quiz_sessions") {
+          return { findOne: findOneSession, updateOne };
+        }
+        if (name === "quizzes") {
+          return { findOne: findOneQuiz };
+        }
+        throw new Error(`Unexpected collection: ${name}`);
+      }),
+    };
+
+    connectDb.mockResolvedValue(db);
+  });
+
+  it("includes completed: { $ne: true } in the updateOne filter (atomic guard)", async () => {
+    const req = createMockRequest({ sessionId: "session-1" });
+
+    await POST(req);
+
+    expect(updateOne).toHaveBeenCalledWith(
+      { _id: "session-1", completed: { $ne: true } },
+      expect.objectContaining({
+        $set: expect.objectContaining({ completed: true }),
+      })
+    );
+  });
+
+  it("returns the computed score when this call wins the race", async () => {
+    const req = createMockRequest({ sessionId: "session-1" });
+
+    const response = await POST(req);
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.score).toBe(1);
+    expect(body.totalQuestions).toBe(2);
+    expect(body.percentage).toBe(50);
+  });
+
+  it("rejects with 'Quiz already submitted' instead of a false 200 if a concurrent submit won the race (matchedCount 0)", async () => {
+    // Simulates two concurrent /submit calls: both pass the application-level
+    // `session.completed` check and compute a score, but only one atomic
+    // updateOne can match `completed: { $ne: true }`. The loser must not
+    // return a 200 with a score that was never persisted.
+    updateOne.mockResolvedValue({ matchedCount: 0 });
+
+    const req = createMockRequest({ sessionId: "session-1" });
+
+    const response = await POST(req);
+    const body = await response.json();
+
+    expect(response.status).toBe(403);
+    expect(body).toEqual({ error: "Quiz already submitted" });
+  });
+
+  it("still rejects up front via the application-level check when completed is already true", async () => {
+    findOneSession.mockResolvedValue({
+      _id: "session-1",
+      userId: "user-123",
+      quizId: "quiz-1",
+      expiresAt: FUTURE_DATE,
+      completed: true,
+      answers: { q1: "A", q2: "B" },
+    });
+
+    const req = createMockRequest({ sessionId: "session-1" });
+
+    const response = await POST(req);
+    const body = await response.json();
+
+    expect(response.status).toBe(403);
+    expect(body).toEqual({ error: "Quiz already submitted" });
+    expect(updateOne).not.toHaveBeenCalled();
+  });
+});

--- a/app/api/quiz-sessions/submit/route.js
+++ b/app/api/quiz-sessions/submit/route.js
@@ -61,8 +61,8 @@ export const POST = withErrorHandler(async (req) => {
   const passed = percentage >= (quiz.passingScore || 70);
 
   const submittedAt = new Date();
-  await db.collection("quiz_sessions").updateOne(
-    { _id: sessionId },
+  const updateResult = await db.collection("quiz_sessions").updateOne(
+    { _id: sessionId, completed: { $ne: true } },
     {
       $set: {
         completed: true,
@@ -73,6 +73,13 @@ export const POST = withErrorHandler(async (req) => {
       },
     }
   );
+
+  if (updateResult.matchedCount === 0) {
+    return new Response(JSON.stringify({ error: "Quiz already submitted" }), {
+      status: 403,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
 
   return new Response(
     JSON.stringify({


### PR DESCRIPTION
## Problem
`app/api/quiz-sessions/answer/route.js` and `app/api/quiz-sessions/submit/route.js` both read the session, check `session.completed` in application code, then call `updateOne({ _id: sessionId }, ...)` without re-including `completed` in the filter. This is a classic TOCTOU race:

- Two concurrent `/answer` calls can both read `completed: false`, then both write — an answer can be recorded after the quiz was already submitted via a concurrent `/submit`.
- Two concurrent `/submit` calls (duplicate retry, multiple tabs) can both pass the check, both compute a score from the same `session.answers` snapshot, and both succeed — the loser gets a normal 200 instead of "already submitted," with no guarantee the score returned to the client matches what's persisted.

Neither `updateOne` included `completed: { $ne: true }` in its filter, so MongoDB provided no atomicity guarantee despite the explicit application-level check.

## Fix
Add `completed: { $ne: true }` to both `updateOne` filters, making the "is this session still open" check atomic with the write itself. After the call, check `updateResult.matchedCount`:
- `1` → this call won the race, proceed as before.
- `0` → a concurrent call already completed the session; return 403 `"Quiz already submitted"` instead of a false success.

The existing up-front `session.completed` check is kept as a cheap fast-path rejection; the atomic filter is what actually closes the race.

## Tests
- `app/api/quiz-sessions/answer/__tests__/route.test.js`
- `app/api/quiz-sessions/submit/__tests__/route.test.js`

Each covers: the atomic filter shape, the normal success path, the lost-race path (`matchedCount: 0` → 403, not a false 200/duplicate write), and the pre-existing up-front rejection when `completed` is already `true` on read.

Closes #3802