### PR TITLE
fix(sessionManager): make createSession's single-session enforcement atomic

### DIFF
--- a/lib/__tests__/sessionManager.test.js
+++ b/lib/__tests__/sessionManager.test.js
@@ -1,0 +1,111 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createSession } from "../sessionManager";
+import { getRedis } from "../redis";
+
+vi.mock("../redis", () => ({
+  getRedis: vi.fn(),
+}));
+
+describe("createSession — atomic single-session-per-user enforcement", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.UPSTASH_REDIS_REST_URL = "https://example.upstash.io";
+    process.env.UPSTASH_REDIS_REST_TOKEN = "test-token";
+  });
+
+  it("performs the read-terminate-create sequence via a single redis.eval call (no separate smembers/multi round trip)", async () => {
+    const evalFn = vi.fn().mockResolvedValue("new-session-id");
+    const smembers = vi.fn();
+    const multi = vi.fn();
+    getRedis.mockReturnValue({ eval: evalFn, smembers, multi });
+
+    await createSession("user-123", { ip: "127.0.0.1" });
+
+    // The old implementation issued a separate smembers() read followed by a
+    // multi()/exec() write, leaving a window for a concurrent request to read
+    // the same stale state. The fix must do everything in one eval call.
+    expect(smembers).not.toHaveBeenCalled();
+    expect(multi).not.toHaveBeenCalled();
+
+    expect(evalFn).toHaveBeenCalledTimes(1);
+    const [script, keys, args] = evalFn.mock.calls[0];
+    expect(typeof script).toBe("string");
+    expect(keys).toEqual(["user:sessions:user-123"]);
+    expect(args[0]).toEqual(expect.any(String)); // new sessionId
+    expect(JSON.parse(args[1])).toEqual(
+      expect.objectContaining({ userId: "user-123", ip: "127.0.0.1" })
+    );
+    expect(args[2]).toBe(String(24 * 60 * 60));
+  });
+
+  it("returns the generated sessionId", async () => {
+    const evalFn = vi.fn().mockResolvedValue("whatever-the-script-returns");
+    getRedis.mockReturnValue({ eval: evalFn });
+
+    const sessionId = await createSession("user-123");
+
+    expect(typeof sessionId).toBe("string");
+    expect(sessionId.length).toBeGreaterThan(0);
+    // The JS-generated UUID is what's returned to the caller and what's
+    // passed into the script as ARGV[1] — not whatever the script itself
+    // returns.
+    const [, , args] = evalFn.mock.calls[0];
+    expect(sessionId).toBe(args[0]);
+  });
+
+  it("simulates two concurrent createSession calls against an in-memory fake Redis and ends with exactly one valid session", async () => {
+    // A minimal fake Redis that runs the Lua-equivalent logic atomically per
+    // call (mirroring what a real Redis server guarantees for EVAL: each
+    // invocation runs to completion without interleaving with another).
+    const store = new Map(); // key -> Set<string> for sets, or string for plain values
+    const ttls = new Map();
+
+    const fakeEval = vi.fn(async (script, keys, args) => {
+      const userSessionsKey = keys[0];
+      const [newSessionId, sessionData, ttlSeconds] = args;
+
+      const existing = store.get(userSessionsKey) || new Set();
+      for (const sid of existing) {
+        store.delete(`session:${sid}`);
+      }
+      store.delete(userSessionsKey);
+
+      store.set(`session:${newSessionId}`, sessionData);
+      ttls.set(`session:${newSessionId}`, Number(ttlSeconds));
+      store.set(userSessionsKey, new Set([newSessionId]));
+      ttls.set(userSessionsKey, Number(ttlSeconds));
+
+      return newSessionId;
+    });
+
+    getRedis.mockReturnValue({ eval: fakeEval });
+
+    const [sessionId1, sessionId2] = await Promise.all([
+      createSession("user-123", { device: "tab-1" }),
+      createSession("user-123", { device: "tab-2" }),
+    ]);
+
+    const liveSessionIds = store.get("user:sessions:user-123");
+    expect(liveSessionIds.size).toBe(1);
+
+    // Exactly one of the two created sessions should remain live; the other
+    // must have been deleted by whichever call ran second.
+    const survivor = [...liveSessionIds][0];
+    expect([sessionId1, sessionId2]).toContain(survivor);
+    const loser = survivor === sessionId1 ? sessionId2 : sessionId1;
+    expect(store.has(`session:${loser}`)).toBe(false);
+    expect(store.has(`session:${survivor}`)).toBe(true);
+  });
+
+  it("returns the bypass session id without touching redis when env vars are missing", async () => {
+    delete process.env.UPSTASH_REDIS_REST_URL;
+    delete process.env.UPSTASH_REDIS_REST_TOKEN;
+    const evalFn = vi.fn();
+    getRedis.mockReturnValue({ eval: evalFn });
+
+    const sessionId = await createSession("user-123");
+
+    expect(sessionId).toBe("local-bypass-session");
+    expect(evalFn).not.toHaveBeenCalled();
+  });
+});

--- a/lib/sessionManager.js
+++ b/lib/sessionManager.js
@@ -8,18 +8,28 @@ function shouldBypass() {
   );
 }
 
+const CREATE_SESSION_SCRIPT = `
+  local userSessionsKey = KEYS[1]
+  local newSessionId = ARGV[1]
+  local sessionData = ARGV[2]
+  local ttlSeconds = tonumber(ARGV[3])
+
+  local existingSessions = redis.call("SMEMBERS", userSessionsKey)
+  for _, sid in ipairs(existingSessions) do
+    redis.call("DEL", "session:" .. sid)
+  end
+  redis.call("DEL", userSessionsKey)
+
+  redis.call("SET", "session:" .. newSessionId, sessionData, "EX", ttlSeconds)
+  redis.call("SADD", userSessionsKey, newSessionId)
+  redis.call("EXPIRE", userSessionsKey, ttlSeconds)
+
+  return newSessionId
+`;
+
 export async function createSession(userId, metadata = {}) {
   const redis = getRedis();
   if (shouldBypass()) return "local-bypass-session";
-
-  // Terminate concurrent sessions (prevent concurrent login)
-  const existingSessions = await redis.smembers(`user:sessions:${userId}`);
-  if (existingSessions && existingSessions.length > 0) {
-    const pipeline = redis.multi();
-    existingSessions.forEach((sid) => pipeline.del(`session:${sid}`));
-    pipeline.del(`user:sessions:${userId}`);
-    await pipeline.exec();
-  }
 
   const sessionId = randomUUID();
   const sessionData = {
@@ -27,12 +37,10 @@ export async function createSession(userId, metadata = {}) {
     createdAt: Date.now(),
     ...metadata,
   };
+  const ttlSeconds = 24 * 60 * 60;
 
-  const multi = redis.multi();
-  multi.set(`session:${sessionId}`, sessionData, { ex: 24 * 60 * 60 });
-  multi.sadd(`user:sessions:${userId}`, sessionId);
-  multi.expire(`user:sessions:${userId}`, 24 * 60 * 60);
-  await multi.exec();
+  await redis.eval(CREATE_SESSION_SCRIPT, [`user:sessions:${userId}`],
+    [sessionId, JSON.stringify(sessionData), String(ttlSeconds)]);
 
   return sessionId;
 }


### PR DESCRIPTION
## Problem
`createSession(userId, metadata)` in `lib/sessionManager.js` enforces single-session-per-user by reading existing session ids, then —in a separate round trip— deleting them and creating the new session, with no locking or optimistic concurrency control around the read:

```js
const existingSessions = await redis.smembers(`user:sessions:${userId}`);
if (existingSessions && existingSessions.length > 0) {
  const pipeline = redis.multi();
  existingSessions.forEach((sid) => pipeline.del(`session:${sid}`));
  pipeline.del(`user:sessions:${userId}`);
  await pipeline.exec();
}
// ...create and store new session
```

Two concurrent login requests for the same user (double-click, two tabs/devices) can both read the same (possibly empty) `existingSessions` set before either has written, then both proceed to create their own session — resulting in two simultaneously valid sessions, defeating the single-session invariant. Depending on ordering, a concurrent call can also delete a session the other request just created mid-flight, silently invalidating a session the client believes is active.

## Fix
Replace the read-then-write sequence with a single Lua script executed via `redis.eval()`. Redis guarantees a script runs to completion without interleaving with any other command, so the read of existing sessions, deleting them, and creating + registering the new one now happen as one atomic, indivisible step — there is no longer a window between "read" and "write" for a second request to land in.

The `@upstash/redis` REST client supports `eval(script, keys, args)` directly, so this didn't require switching transports. Session data is JSON-stringified client-side and passed as a script argument, then stored raw via `SET` inside the script — consistent with the existing `automaticDeserialization` round-trip already used elsewhere in this file (`terminateSession`'s `redis.get`).

`terminateAllUserSessions` has a similar shape but is out of scope for this issue, which is specifically about `createSession`'s "prevent concurrent login" logic.

## Tests
Added `lib/__tests__/sessionManager.test.js`:
- Asserts `createSession` makes exactly one `eval` call and never calls `smembers`/`multi` (the old two-round-trip shape).
- Asserts the returned session id is the one passed into the script.
- Simulates two concurrent `createSession` calls for the same user against an in-memory fake Redis and asserts exactly one session survives, with the loser's session key deleted.
- Asserts the env-var bypass path is unaffected.

Closes #3804